### PR TITLE
Name login route for API auth

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -20,7 +20,9 @@ Route::middleware(['api','tenant'])->get('/health', function () {
 });
 
 Route::prefix('auth')->group(function () {
-    Route::post('login', [AuthController::class, 'login'])->middleware('throttle:auth');
+    Route::post('login', [AuthController::class, 'login'])
+        ->middleware('throttle:auth')
+        ->name('login');
     Route::post('logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
     Route::post('refresh', [AuthController::class, 'refresh']);
     Route::post('password/email', [AuthController::class, 'sendResetLinkEmail']);


### PR DESCRIPTION
## Summary
- name the `auth/login` route so middleware can redirect unauthenticated requests

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ac293ffe8c8323becb28b69b6dca92