### PR TITLE
Auto-capture auth tokens in Postman collection

### DIFF
--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -3,6 +3,16 @@
     "name": "ASBuild API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{access_token}}",
+        "type": "string"
+      }
+    ]
+  },
   "item": [
     {
       "name": "appointment-types.index",
@@ -256,9 +266,22 @@
         },
         "body": {
           "mode": "raw",
-          "raw": "{\n  \"email\": \"jane@example.com\",\n  \"password\": \"password\"\n}"
+          "raw": "{\n  \"email\": \"{{email}}\",\n  \"password\": \"{{password}}\"\n}"
         }
-      }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const json = pm.response.json();",
+              "pm.environment.set('access_token', json.access_token);",
+              "pm.environment.set('refresh_token', json.refresh_token);"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ]
     },
     {
       "name": "api/auth/logout",


### PR DESCRIPTION
## Summary
- add collection-level bearer auth placeholder
- parse login response to populate access/refresh token variables
- parameterize login credentials for easier reuse

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3171296883239fe2d548732e713e