### PR TITLE
Add tenant contact fields and detail retrieval

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -30,9 +30,17 @@ class TenantController extends Controller
             'name' => 'required|string',
             'quota_storage_mb' => 'integer',
             'features' => 'array',
+            'phone' => 'nullable|string',
+            'address' => 'nullable|string',
         ]);
         $tenant = Tenant::create($data);
         return response()->json($tenant, 201);
+    }
+
+    public function show(Request $request, Tenant $tenant)
+    {
+        $this->ensureSuperAdmin($request);
+        return $tenant;
     }
 
     public function update(Request $request, Tenant $tenant)
@@ -42,6 +50,8 @@ class TenantController extends Controller
             'name' => 'sometimes|string',
             'quota_storage_mb' => 'integer',
             'features' => 'array',
+            'phone' => 'sometimes|nullable|string',
+            'address' => 'sometimes|nullable|string',
         ]);
         $tenant->update($data);
         return $tenant;

--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -10,6 +10,8 @@ class Tenant extends Model
         'name',
         'quota_storage_mb',
         'features',
+        'phone',
+        'address',
     ];
 
     protected $casts = [

--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -582,7 +582,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"Example Tenant\"\n}",
+                                                        "raw": "{\n  \"name\": \"Example Tenant\",\n  \"phone\": \"123-456-7890\",\n  \"address\": \"123 Main St\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -628,7 +628,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"Updated Tenant\"\n}"
+                                                        "raw": "{\n  \"name\": \"Updated Tenant\",\n  \"phone\": \"987-654-3210\",\n  \"address\": \"456 Elm St\"\n}"
 						},
 						"url": {
 							"raw": "{{base_url}}/api/tenants/{tenant}",

--- a/backend/database/migrations/2025_01_01_100200_add_contact_fields_to_tenants_table.php
+++ b/backend/database/migrations/2025_01_01_100200_add_contact_fields_to_tenants_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->string('phone')->nullable();
+            $table->string('address')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn(['phone', 'address']);
+        });
+    }
+};

--- a/backend/database/seeders/TenantSeeder.php
+++ b/backend/database/seeders/TenantSeeder.php
@@ -14,6 +14,8 @@ class TenantSeeder extends Seeder
             'name' => 'Default Tenant',
             'quota_storage_mb' => 0,
             'features' => json_encode([]),
+            'phone' => '123-456-7890',
+            'address' => '123 Main St',
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/TenantTest.php
+++ b/backend/tests/TenantTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Models\Tenant;
+use App\Http\Controllers\Api\TenantController;
+
+class TenantTest extends TestCase
+{
+    public function test_tenant_has_contact_fields(): void
+    {
+        $tenant = new Tenant();
+        $this->assertContains('phone', $tenant->getFillable());
+        $this->assertContains('address', $tenant->getFillable());
+    }
+
+    public function test_tenant_controller_has_show_method(): void
+    {
+        $this->assertTrue(method_exists(TenantController::class, 'show'));
+    }
+}

--- a/frontend/src/components/tenants/TenantForm.vue
+++ b/frontend/src/components/tenants/TenantForm.vue
@@ -9,6 +9,14 @@
       <input v-model.number="form.quota_storage_mb" type="number" class="border p-2 w-full" />
     </div>
     <div class="mb-2">
+      <label class="block">Phone</label>
+      <input v-model="form.phone" class="border p-2 w-full" />
+    </div>
+    <div class="mb-2">
+      <label class="block">Address</label>
+      <input v-model="form.address" class="border p-2 w-full" />
+    </div>
+    <div class="mb-2">
       <label class="block">Features (JSON)</label>
       <textarea v-model="form.features" class="border p-2 w-full"></textarea>
     </div>
@@ -22,7 +30,7 @@ import api from '@/services/api';
 
 const emit = defineEmits(['saved']);
 
-const form = ref({ name: '', quota_storage_mb: 0, features: '{}' });
+const form = ref({ name: '', quota_storage_mb: 0, phone: '', address: '', features: '{}' });
 
 async function submit() {
   let payload = { ...form.value };
@@ -33,6 +41,6 @@ async function submit() {
   }
   await api.post('/tenants', payload);
   emit('saved');
-  form.value = { name: '', quota_storage_mb: 0, features: '{}' };
+  form.value = { name: '', quota_storage_mb: 0, phone: '', address: '', features: '{}' };
 }
 </script>

--- a/frontend/src/views/TenantList.vue
+++ b/frontend/src/views/TenantList.vue
@@ -7,7 +7,8 @@
     <TenantForm v-if="showForm" @saved="load" />
     <ul class="mt-4">
       <li v-for="t in tenants" :key="t.id" class="mb-2 flex gap-2 items-center">
-        <span>{{ t.name }} - {{ t.quota_storage_mb }} MB</span>
+        <span>{{ t.name }} - {{ t.phone }} - {{ t.address }} - {{ t.quota_storage_mb }} MB</span>
+        <button class="text-green-600" @click="view(t.id)">View</button>
         <button class="text-blue-600" @click="impersonate(t.id)">Impersonate</button>
         <button class="text-red-600 ml-auto" @click="remove(t.id)">Delete</button>
       </li>
@@ -40,6 +41,11 @@ async function remove(id: number) {
 
 async function impersonate(id: number) {
   await auth.impersonate(id);
+}
+
+async function view(id: number) {
+  const { data } = await api.get(`/tenants/${id}`);
+  alert(`${data.name} - ${data.phone} - ${data.address}`);
 }
 
 onMounted(load);


### PR DESCRIPTION
## Summary
- extend tenants with phone and address fields and expose show endpoint
- support phone/address in Vue tenant pages and Postman collection
- add migration and tests for tenant contact fields

## Testing
- `composer test`
- `npm test` *(fails: browserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ac37dd14148323804347152ff0fd09