### PR TITLE
Allow super admin employee management across tenants

### DIFF
--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -298,14 +298,19 @@
 			]
 		},
 		{
-			"name": "employees",
-			"item": [
-				{
-					"name": "index",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
+                        "name": "employees",
+                        "item": [
+                                {
+                                        "name": "index",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "X-Tenant-ID",
+                                                                "value": "{{tenant_id}}"
+                                                        }
+                                                ],
+                                                "url": {
 							"raw": "{{base_url}}/api/employees",
 							"host": [
 								"{{base_url}}"
@@ -318,12 +323,17 @@
 					},
 					"response": []
 				},
-				{
-					"name": "store",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
+                                {
+                                        "name": "store",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [
+                                                        {
+                                                                "key": "X-Tenant-ID",
+                                                                "value": "{{tenant_id}}"
+                                                        }
+                                                ],
+                                                "body": {
 							"mode": "raw",
 							"raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\"\n}"
 						},
@@ -340,12 +350,17 @@
 					},
 					"response": []
 				},
-				{
-					"name": "show",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
+                                {
+                                        "name": "show",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                        {
+                                                                "key": "X-Tenant-ID",
+                                                                "value": "{{tenant_id}}"
+                                                        }
+                                                ],
+                                                "url": {
 							"raw": "{{base_url}}/api/employees/{employee}",
 							"host": [
 								"{{base_url}}"
@@ -359,12 +374,17 @@
 					},
 					"response": []
 				},
-				{
-					"name": "update",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
+                                {
+                                        "name": "update",
+                                        "request": {
+                                                "method": "PUT",
+                                                "header": [
+                                                        {
+                                                                "key": "X-Tenant-ID",
+                                                                "value": "{{tenant_id}}"
+                                                        }
+                                                ],
+                                                "body": {
 							"mode": "raw",
 							"raw": "{\n  \"name\": \"Updated Employee\"\n}"
 						},
@@ -382,12 +402,17 @@
 					},
 					"response": []
 				},
-				{
-					"name": "destroy",
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
+                                {
+                                        "name": "destroy",
+                                        "request": {
+                                                "method": "DELETE",
+                                                "header": [
+                                                        {
+                                                                "key": "X-Tenant-ID",
+                                                                "value": "{{tenant_id}}"
+                                                        }
+                                                ],
+                                                "url": {
 							"raw": "{{base_url}}/api/employees/{employee}",
 							"host": [
 								"{{base_url}}"

--- a/backend/tests/EmployeeTest.php
+++ b/backend/tests/EmployeeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use App\Http\Controllers\Api\EmployeeController;
+
+class EmployeeTest extends TestCase
+{
+    public function test_employee_controller_has_show_method(): void
+    {
+        $this->assertTrue(method_exists(EmployeeController::class, 'show'));
+    }
+
+    public function test_employee_controller_allows_super_admin(): void
+    {
+        $reflection = new ReflectionClass(EmployeeController::class);
+        $method = $reflection->getMethod('ensureAdmin');
+        $code = implode("", array_slice(file($method->getFileName()), $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+        $this->assertStringContainsString('SuperAdmin', $code);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow super admins to manage employees for any tenant
- Add employee detail retrieval and tenant-aware role syncing
- Document tenant header for employee routes and add regression tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3e1338388323bc72094e84e079cc