### PR TITLE
Add employee contact fields

### DIFF
--- a/backend/app/Http/Controllers/Api/EmployeeController.php
+++ b/backend/app/Http/Controllers/Api/EmployeeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\Role;
+use App\Models\Tenant;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -48,18 +49,23 @@ class EmployeeController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'email' => 'required|email',
+            'phone' => 'nullable|string',
+            'address' => 'nullable|string',
             'roles' => 'array',
         ]);
 
         $password = Str::random(config('security.password.min_length'));
 
         $tenantId = $this->getTenantId($request);
+        Tenant::findOrFail($tenantId);
 
         $user = User::create([
             'name' => $data['name'],
             'email' => $data['email'],
             'tenant_id' => $tenantId,
             'password' => Hash::make($password),
+            'phone' => $data['phone'] ?? null,
+            'address' => $data['address'] ?? null,
         ]);
 
         if (! empty($data['roles'])) {
@@ -98,11 +104,19 @@ class EmployeeController extends Controller
 
         $data = $request->validate([
             'name' => 'sometimes|string',
+            'phone' => 'sometimes|string',
+            'address' => 'sometimes|string',
             'roles' => 'array',
         ]);
 
         if (isset($data['name'])) {
             $employee->name = $data['name'];
+        }
+        if (isset($data['phone'])) {
+            $employee->phone = $data['phone'];
+        }
+        if (isset($data['address'])) {
+            $employee->address = $data['address'];
         }
         $employee->save();
 

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -16,6 +16,8 @@ class User extends Authenticatable
         'email',
         'password',
         'tenant_id',
+        'phone',
+        'address',
     ];
 
     protected $hidden = [

--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -334,9 +334,9 @@
                                                         }
                                                 ],
                                                 "body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\"\n}"
-						},
+                                                        "mode": "raw",
+                                                        "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\",\n  \"phone\": \"123-456-7890\",\n  \"address\": \"123 Main St\"\n}"
+                                                },
 						"url": {
 							"raw": "{{base_url}}/api/employees",
 							"host": [
@@ -385,9 +385,9 @@
                                                         }
                                                 ],
                                                 "body": {
-							"mode": "raw",
-							"raw": "{\n  \"name\": \"Updated Employee\"\n}"
-						},
+                                                        "mode": "raw",
+                                                        "raw": "{\n  \"name\": \"Updated Employee\",\n  \"phone\": \"987-654-3210\",\n  \"address\": \"456 Elm St\"\n}"
+                                                },
 						"url": {
 							"raw": "{{base_url}}/api/employees/{employee}",
 							"host": [

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -29,6 +29,9 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'tenant_id' => 1,
+            'phone' => fake()->phoneNumber(),
+            'address' => fake()->address(),
         ];
     }
 

--- a/backend/database/migrations/2025_01_01_101100_add_contact_fields_to_users_table.php
+++ b/backend/database/migrations/2025_01_01_101100_add_contact_fields_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('phone')->nullable()->after('tenant_id');
+            $table->string('address')->nullable()->after('phone');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['phone', 'address']);
+        });
+    }
+};

--- a/backend/database/seeders/SuperAdminSeeder.php
+++ b/backend/database/seeders/SuperAdminSeeder.php
@@ -16,6 +16,8 @@ class SuperAdminSeeder extends Seeder
             'email' => 'anastasiou.ks@gmail.com',
             'password' => Hash::make('Swordfish01!@#'),
             'tenant_id' => 1,
+            'phone' => '123-456-7890',
+            'address' => '456 Admin St',
             'created_at' => now(),
             'updated_at' => now(),
         ]);


### PR DESCRIPTION
## Summary
- store employee phone and address on users table
- capture phone and address in employee APIs and Postman collection
- validate tenant existence to avoid foreign key errors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac412e7e1c832389cb23b30e557fc3