### PR TITLE
Fix employee update and role assignment

### DIFF
--- a/backend/app/Http/Controllers/Api/EmployeeController.php
+++ b/backend/app/Http/Controllers/Api/EmployeeController.php
@@ -51,7 +51,7 @@ class EmployeeController extends Controller
             'email' => 'required|email',
             'phone' => 'nullable|string',
             'address' => 'nullable|string',
-            'roles' => 'array',
+            'roles' => 'array|nullable',
             'roles.*' => 'string',
         ]);
 
@@ -74,7 +74,8 @@ class EmployeeController extends Controller
         ]);
 
         if (! empty($data['roles'])) {
-            $roles = Role::whereIn('name', $data['roles'])->pluck('id');
+            $roles = collect($data['roles'])
+                ->map(fn ($name) => Role::firstOrCreate(['name' => $name, 'tenant_id' => $tenantId])->id);
             $roleData = $roles->mapWithKeys(fn ($id) => [$id => ['tenant_id' => $tenantId]]);
             $user->roles()->sync($roleData);
         }
@@ -115,7 +116,7 @@ class EmployeeController extends Controller
             'name' => 'sometimes|string',
             'phone' => 'sometimes|string',
             'address' => 'sometimes|string',
-            'roles' => 'array',
+            'roles' => 'sometimes|array',
             'roles.*' => 'string',
         ]);
 
@@ -134,7 +135,8 @@ class EmployeeController extends Controller
             if (in_array('SuperAdmin', $data['roles'], true)) {
                 abort(403, 'SuperAdmin role cannot be assigned');
             }
-            $roles = Role::whereIn('name', $data['roles'])->pluck('id');
+            $roles = collect($data['roles'])
+                ->map(fn ($name) => Role::firstOrCreate(['name' => $name, 'tenant_id' => $tenantId])->id);
             $roleData = $roles->mapWithKeys(fn ($id) => [$id => ['tenant_id' => $tenantId]]);
             $employee->roles()->sync($roleData);
         }

--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -442,7 +442,7 @@
         {
           "name": "update",
           "request": {
-            "method": "PUT",
+            "method": "POST",
             "header": [
               {
                 "key": "X-Tenant-ID",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -58,6 +58,7 @@ Route::middleware(['auth:sanctum', 'tenant'])->group(function () {
     Route::put('notification-preferences', [NotificationController::class, 'updatePreferences']);
 
     Route::apiResource('employees', EmployeeController::class);
+    Route::post('employees/{employee}', [EmployeeController::class, 'update']);
 
     Route::get('settings/branding', [SettingsController::class, 'getBranding']);
     Route::put('settings/branding', [SettingsController::class, 'updateBranding']);


### PR DESCRIPTION
## Summary
- accept POST requests for updating employees
- automatically create and sync roles when saving employees
- switch Postman employee update call to POST

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac47f4f5fc832398a3a8f15489f45f