### PR TITLE
Allow partial appointment type updates and expand Postman examples

### DIFF
--- a/backend/app/Http/Controllers/Api/AppointmentTypeController.php
+++ b/backend/app/Http/Controllers/Api/AppointmentTypeController.php
@@ -37,7 +37,7 @@ class AppointmentTypeController extends Controller
     public function update(Request $request, AppointmentType $appointmentType)
     {
         $this->ensureAdmin($request);
-        $data = $this->validateSchema($request);
+        $data = $this->validateSchema($request, false);
         $appointmentType->update($data);
         return response()->json($appointmentType);
     }
@@ -49,13 +49,14 @@ class AppointmentTypeController extends Controller
         return response()->json(['message' => 'deleted']);
     }
 
-    protected function validateSchema(Request $request): array
+    protected function validateSchema(Request $request, bool $nameRequired = true): array
     {
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
+        $rules = [
+            'name' => ($nameRequired ? 'required' : 'sometimes') . '|string|max:255',
             'form_schema' => 'nullable|json',
             'fields_summary' => 'nullable|json',
-        ]);
+        ];
+        $validated = $request->validate($rules);
 
         foreach (['form_schema', 'fields_summary'] as $field) {
             if (isset($validated[$field])) {

--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -66,6 +66,38 @@
           "response": []
         },
         {
+          "name": "store with form fields",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "X-Tenant-ID",
+                "value": "{{tenant_id}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Detailed Type\",\n  \"form_schema\": \"{\\\"type\\\": \\\"object\\\", \\\"properties\\\": {\\\"title\\\": {\\\"type\\\": \\\"string\\\"}, \\\"priority\\\": {\\\"type\\\": \\\"integer\\\"}, \\\"done\\\": {\\\"type\\\": \\\"boolean\\\"}}, \\\"required\\\": [\\\"title\\\"]}\",\n  \"fields_summary\": \"{\\\"title\\\": \\\"string\\\", \\\"priority\\\": \\\"integer\\\", \\\"done\\\": \\\"boolean\\\"}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/appointment-types",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "appointment-types"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "show",
           "request": {
             "method": "GET",
@@ -326,6 +358,38 @@
                 "appointments",
                 "{appointment}",
                 "comments"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "store with type fields",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "X-Tenant-ID",
+                "value": "{{tenant_id}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\\n  \"scheduled_at\": \"2024-01-03T00:00:00Z\",\\n  \"sla_start_at\": \"2024-01-03T08:00:00Z\",\\n  \"sla_end_at\": \"2024-01-03T17:00:00Z\",\\n  \"kau_notes\": \"Notes\",\\n  \"appointment_type_id\": 2,\\n  \"form_data\": {\\n    \"title\": \"Install\",\\n    \"priority\": 1,\\n    \"done\": false\\n  }\\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{base_url}}/api/appointments",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "appointments"
               ]
             }
           },

--- a/backend/tests/CreatesApplication.php
+++ b/backend/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication(): Application
+    {
+        $app = require __DIR__ . '/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/backend/tests/Feature/AppointmentRoutesTest.php
+++ b/backend/tests/Feature/AppointmentRoutesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AppointmentType;
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AppointmentRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $tenant = Tenant::create(['name' => 'Test Tenant']);
+        $role = Role::create(['name' => 'ClientAdmin', 'tenant_id' => $tenant->id]);
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+        $this->tenant = $tenant;
+    }
+
+    public function test_crud_routes_work(): void
+    {
+        // index
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->getJson('/api/appointments')
+            ->assertStatus(200);
+
+        // create appointment type
+        $type = AppointmentType::create([
+            'name' => 'Type A',
+            'form_schema' => ['type' => 'object', 'properties' => ['note' => ['type' => 'string']], 'required' => ['note']],
+            'fields_summary' => ['note' => 'string'],
+        ]);
+
+        // store
+        $payload = [
+            'scheduled_at' => '2024-01-01T00:00:00Z',
+            'sla_start_at' => '2024-01-01T08:00:00Z',
+            'sla_end_at' => '2024-01-01T17:00:00Z',
+            'kau_notes' => 'Notes',
+            'appointment_type_id' => $type->id,
+            'form_data' => ['note' => 'Sample'],
+        ];
+        $appointmentId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->postJson('/api/appointments', $payload)
+            ->assertStatus(201)
+            ->json('id');
+
+        // show
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->getJson("/api/appointments/{$appointmentId}")
+            ->assertStatus(200);
+
+        // update
+        $update = [
+            'kau_notes' => 'Updated',
+            'form_data' => ['note' => 'Updated'],
+        ];
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->putJson("/api/appointments/{$appointmentId}", $update)
+            ->assertStatus(200)
+            ->assertJsonPath('kau_notes', 'Updated');
+
+        // destroy
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->deleteJson("/api/appointments/{$appointmentId}")
+            ->assertStatus(200);
+    }
+}

--- a/backend/tests/Feature/AppointmentTypeRoutesTest.php
+++ b/backend/tests/Feature/AppointmentTypeRoutesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AppointmentTypeRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $tenant = Tenant::create(['name' => 'Test Tenant']);
+        $role = Role::create(['name' => 'ClientAdmin', 'tenant_id' => $tenant->id]);
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+        $this->tenant = $tenant; // store for headers
+    }
+
+    public function test_crud_routes_work(): void
+    {
+        // index
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->getJson('/api/appointment-types')
+            ->assertStatus(200);
+
+        // store
+        $payload = [
+            'name' => 'Type A',
+            'form_schema' => json_encode(['type' => 'object', 'properties' => ['note' => ['type' => 'string']], 'required' => ['note']]),
+            'fields_summary' => json_encode(['note' => 'string']),
+        ];
+        $typeId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->postJson('/api/appointment-types', $payload)
+            ->assertStatus(201)
+            ->json('id');
+
+        // show
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->getJson("/api/appointment-types/{$typeId}")
+            ->assertStatus(200);
+
+        // update without name
+        $update = [
+            'fields_summary' => json_encode(['note' => 'text']),
+        ];
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->putJson("/api/appointment-types/{$typeId}", $update)
+            ->assertStatus(200)
+            ->assertJsonPath('fields_summary.note', 'text');
+
+        // destroy
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->deleteJson("/api/appointment-types/{$typeId}")
+            ->assertStatus(200);
+    }
+}

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
## Summary
- Permit updating appointment types without resubmitting the name field
- Wire base controller for authorization calls
- Add detailed Postman examples for appointment types and appointments
- Cover appointment and appointment-type routes with feature tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac4cb165a4832380fec3be244ac326