### PR TITLE
feat: configure API host via env variable

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { toast } from '@/plugins/toast';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: import.meta.env.API_URL || '/api',
   withCredentials: true,
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import path from 'path';
 export default defineConfig({
   plugins: [vue()],
   base: '',
+  envPrefix: ['VITE_', 'API_'],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- use `API_URL` env variable for frontend axios base URL
- expose `API_*` vars to Vite via `envPrefix`

## Testing
- `npm install`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run ‘npx playwright install’)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5f96aec08323974187145cfd2c34