### PR TITLE
fix: handle missing API_URL

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,8 +2,20 @@
 import axios from 'axios';
 import { toast } from '@/plugins/toast';
 
+// Resolve API URL from available environment variables.
+// Vite inlines missing variables as the string "undefined", so explicitly
+// guard against that case before falling back to the default `/api` path.
+const envApiUrl =
+  (import.meta.env.API_URL && import.meta.env.API_URL !== 'undefined'
+    ? import.meta.env.API_URL
+    : undefined) ||
+  (import.meta.env.VITE_API_URL && import.meta.env.VITE_API_URL !== 'undefined'
+    ? import.meta.env.VITE_API_URL
+    : undefined) ||
+  '/api';
+
 const api = axios.create({
-  baseURL: import.meta.env.API_URL || '/api',
+  baseURL: envApiUrl,
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- avoid undefined API host by checking multiple environment variables for API URL

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6168d3988323ba03349c33541b91