### PR TITLE
feat: restrict CORS based on environment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@ APP_ENV=production
 APP_KEY=
 APP_DEBUG=false
 APP_URL=https://example.com
+FRONTEND_URL=http://localhost:5173
 
 LOG_CHANNEL=stack
 LOG_LEVEL=info

--- a/backend/app/Http/Middleware/SecurityHeaders.php
+++ b/backend/app/Http/Middleware/SecurityHeaders.php
@@ -18,7 +18,16 @@ class SecurityHeaders
             $response = $next($request);
         }
 
-        $response->headers->set('Access-Control-Allow-Origin', implode(',', $cors['allowed_origins'] ?? ['*']));
+        $allowedOrigins = $cors['allowed_origins'] ?? ['*'];
+        $origin = $request->headers->get('Origin');
+        if (in_array('*', $allowedOrigins)) {
+            $response->headers->set('Access-Control-Allow-Origin', $origin ?? '*');
+        } elseif ($origin && in_array($origin, $allowedOrigins)) {
+            $response->headers->set('Access-Control-Allow-Origin', $origin);
+        } elseif (!empty($allowedOrigins)) {
+            $response->headers->set('Access-Control-Allow-Origin', $allowedOrigins[0]);
+        }
+        $response->headers->set('Access-Control-Allow-Credentials', 'true');
         $response->headers->set('Access-Control-Allow-Methods', implode(',', $cors['allowed_methods'] ?? ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']));
         $response->headers->set('Access-Control-Allow-Headers', implode(',', $cors['allowed_headers'] ?? ['Content-Type', 'Authorization', 'X-Requested-With']));
 

--- a/backend/config/security.php
+++ b/backend/config/security.php
@@ -2,7 +2,11 @@
 
 return [
     'cors' => [
-        'allowed_origins' => ['*'],
+        // In production only allow requests from the configured frontend URL.
+        // During local development allow requests from any origin.
+        'allowed_origins' => env('APP_ENV') === 'production'
+            ? [env('FRONTEND_URL', '')]
+            : ['*'],
         'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
         'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With'],
     ],

--- a/backend/tests/SecurityHeadersTest.php
+++ b/backend/tests/SecurityHeadersTest.php
@@ -10,5 +10,6 @@ class SecurityHeadersTest extends TestCase
 
         $response->assertStatus(204);
         $response->assertHeader('Access-Control-Allow-Origin', '*');
+        $response->assertHeader('Access-Control-Allow-Credentials', 'true');
     }
 }


### PR DESCRIPTION
## Summary
- limit allowed origins to the configured frontend URL in production while keeping open access in development
- return the request origin and credentials in CORS headers
- document `FRONTEND_URL` environment variable

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac63f3cae08323bc1b97f85817ac3b