### PR TITLE
Enable POST auth login route

### DIFF
--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,5 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\AuthController;
 
 // Web routes are handled by the SPA; see RouteServiceProvider fallback.
+
+Route::prefix('auth')->middleware('api')->group(function () {
+    Route::post('login', [AuthController::class, 'login'])
+        ->middleware('throttle:auth')
+        ->name('login');
+});


### PR DESCRIPTION
## Summary
- allow POST requests to /auth/login

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68ac65eeb99483239ddb0f444ed1c9d6