### PR TITLE
Ensure CSRF cookie is fetched for API requests

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -19,6 +19,20 @@ const api = axios.create({
   withCredentials: true,
 });
 
+let csrfFetched = false;
+
+api.interceptors.request.use(async (config) => {
+  if (
+    !csrfFetched &&
+    config.method &&
+    ['post', 'put', 'patch', 'delete'].includes(config.method.toLowerCase())
+  ) {
+    csrfFetched = true;
+    await api.get('/sanctum/csrf-cookie', { baseURL: '/' });
+  }
+  return config;
+});
+
 api.interceptors.response.use(
   (response) => response,
   (error) => {

--- a/frontend/tests/auth.test.ts
+++ b/frontend/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import MockAdapter from 'axios-mock-adapter';
 import { setActivePinia, createPinia } from 'pinia';
 
@@ -12,6 +12,7 @@ describe('auth store', () => {
   let auth: any;
 
   beforeEach(async () => {
+    vi.resetModules();
     const store: Record<string, string> = {};
     // @ts-ignore
     globalThis.localStorage = {
@@ -26,6 +27,7 @@ describe('auth store', () => {
 
     setActivePinia(createPinia());
     mock = new MockAdapter(api);
+    mock.onGet('/sanctum/csrf-cookie').reply(204);
     memory = { accessToken: '', refreshToken: '' };
     injectStorage({
       getAccessToken: () => memory.accessToken,


### PR DESCRIPTION
## Summary
- Fetch Sanctum CSRF cookie before any state-changing API request to prevent token mismatch
- Mock CSRF cookie endpoint and reset modules in auth store tests

## Testing
- `npm test` *(fails: Playwright missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ac66c5a8a483238ea17c20bbf04737