### PR TITLE
Fix CORS origin handling for credentialed requests

### DIFF
--- a/backend/app/Http/Middleware/SecurityHeaders.php
+++ b/backend/app/Http/Middleware/SecurityHeaders.php
@@ -20,8 +20,11 @@ class SecurityHeaders
 
         $allowedOrigins = $cors['allowed_origins'] ?? ['*'];
         $origin = $request->headers->get('Origin');
+
         if (in_array('*', $allowedOrigins)) {
-            $response->headers->set('Access-Control-Allow-Origin', $origin ?? '*');
+            if ($origin) {
+                $response->headers->set('Access-Control-Allow-Origin', $origin);
+            }
         } elseif ($origin && in_array($origin, $allowedOrigins)) {
             $response->headers->set('Access-Control-Allow-Origin', $origin);
         } elseif (!empty($allowedOrigins)) {

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -14,7 +14,7 @@ return Application::configure(
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->append([
+        $middleware->prepend([
             \App\Http\Middleware\SecurityHeaders::class,
             \App\Http\Middleware\RequestId::class,
             \App\Http\Middleware\ETag::class,

--- a/backend/config/security.php
+++ b/backend/config/security.php
@@ -3,10 +3,11 @@
 return [
     'cors' => [
         // In production only allow requests from the configured frontend URL.
-        // During local development allow requests from any origin.
+        // During local development explicitly allow the local frontend to
+        // ensure credentialed requests work in browsers.
         'allowed_origins' => env('APP_ENV') === 'production'
             ? [env('FRONTEND_URL', '')]
-            : ['*'],
+            : [env('FRONTEND_URL', 'http://localhost:5173')],
         'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
         'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With'],
     ],

--- a/backend/tests/SecurityHeadersTest.php
+++ b/backend/tests/SecurityHeadersTest.php
@@ -9,7 +9,7 @@ class SecurityHeadersTest extends TestCase
         $response = $this->options('/api/health');
 
         $response->assertStatus(204);
-        $response->assertHeader('Access-Control-Allow-Origin', '*');
+        $response->assertHeader('Access-Control-Allow-Origin', config('security.cors.allowed_origins')[0]);
         $response->assertHeader('Access-Control-Allow-Credentials', 'true');
     }
 }


### PR DESCRIPTION
## Summary
- ensure local frontend origin is explicitly allowed for credentialed CORS requests
- run security middleware before framework CORS handler and avoid wildcard origins
- update CORS header test to expect configured origin

## Testing
- `composer test --no-interaction`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6acdeb0c8323b4b319c1cd26ce81