### PR TITLE
fix: initialize pinia before store use

### DIFF
--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -1,3 +1,8 @@
-import { createPinia } from 'pinia';
+import { createPinia, setActivePinia } from 'pinia';
 
-export default createPinia();
+export const pinia = createPinia();
+
+// Ensure Pinia is active for usages outside of Vue components
+setActivePinia(pinia);
+
+export default pinia;


### PR DESCRIPTION
## Summary
- activate Pinia instance on creation to allow store usage outside Vue components

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7708c8108323bc771cbde093c1c7