### PR TITLE
style: modernize reports dashboard

### DIFF
--- a/frontend/src/components/reports/ChartCard.vue
+++ b/frontend/src/components/reports/ChartCard.vue
@@ -1,7 +1,7 @@
 <template>
-  <Card class="p-4">
-    <h3 class="mb-2 font-bold">{{ title }}</h3>
-    <div v-if="!hasData" class="flex h-40 items-center justify-center">
+  <Card class="flex flex-col gap-4 p-6">
+    <h3 class="text-lg font-semibold tracking-tight">{{ title }}</h3>
+    <div v-if="!hasData" class="flex h-56 items-center justify-center">
       <Skeleton class="h-full w-full" />
     </div>
     <component
@@ -9,6 +9,7 @@
       :is="chartComponent"
       :data="chartData"
       :options="chartOptions"
+      class="h-64"
     />
   </Card>
 </template>
@@ -72,6 +73,7 @@ const chartData = computed(() => ({
 
 const chartOptions = computed(() => ({
   responsive: true,
+  maintainAspectRatio: false,
   plugins: { legend: { display: true } },
   scales: {
     x: { type: inferTime(props.series) ? 'time' : 'category' },

--- a/frontend/src/components/reports/KpiCards.vue
+++ b/frontend/src/components/reports/KpiCards.vue
@@ -1,8 +1,12 @@
 <template>
-  <div class="grid gap-4 md:grid-cols-4">
-    <Card v-for="k in kpis" :key="k.label">
-      <div class="text-sm text-gray-500">{{ k.label }}</div>
-      <div class="text-2xl font-bold">{{ k.value }}</div>
+  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+    <Card
+      v-for="k in kpis"
+      :key="k.label"
+      class="flex flex-col gap-1 bg-gradient-to-br from-primary/20 via-primary/10 to-transparent"
+    >
+      <span class="text-sm font-medium text-foreground/70">{{ k.label }}</span>
+      <span class="text-3xl font-bold tracking-tight">{{ k.value }}</span>
     </Card>
   </div>
 </template>

--- a/frontend/src/components/ui/Button.vue
+++ b/frontend/src/components/ui/Button.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :class="[
-      'inline-flex items-center justify-center rounded-2xl font-medium focus-ring',
+      'inline-flex items-center justify-center rounded-2xl font-medium focus-ring transition-colors shadow-sm',
       sizeClasses,
       variantClasses,
       full ? 'w-full' : '',

--- a/frontend/src/components/ui/Card.vue
+++ b/frontend/src/components/ui/Card.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="rounded-2xl bg-background p-4 text-foreground shadow-lg">
+  <div
+    class="rounded-2xl border border-foreground/10 bg-background/80 p-4 text-foreground shadow-lg backdrop-blur-sm"
+  >
     <slot />
   </div>
 </template>

--- a/frontend/src/components/ui/Input.vue
+++ b/frontend/src/components/ui/Input.vue
@@ -1,6 +1,6 @@
 <template>
   <input
-    class="w-full rounded-2xl border border-foreground/20 bg-background px-3 py-2 text-foreground placeholder-foreground/50 focus-ring"
+    class="w-full rounded-2xl border border-foreground/20 bg-background/80 px-3 py-2 text-foreground placeholder-foreground/50 shadow-sm backdrop-blur-sm transition-colors focus-ring"
     v-bind="$attrs"
   />
 </template>

--- a/frontend/src/components/ui/Select.vue
+++ b/frontend/src/components/ui/Select.vue
@@ -1,6 +1,6 @@
 <template>
   <select
-    class="w-full rounded-2xl border border-foreground/20 bg-background px-3 py-2 text-foreground focus-ring"
+    class="w-full rounded-2xl border border-foreground/20 bg-background/80 px-3 py-2 text-foreground shadow-sm backdrop-blur-sm transition-colors focus-ring"
     v-bind="$attrs"
   >
     <slot />

--- a/frontend/src/views/ReportsDashboard.vue
+++ b/frontend/src/views/ReportsDashboard.vue
@@ -1,36 +1,37 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">Reports</h2>
-    <div class="mb-4 flex flex-wrap items-end gap-2">
-      <select v-model="range" class="border rounded p-1">
-        <option value="today">Today</option>
-        <option value="7">Last 7 days</option>
-        <option value="30">Last 30 days</option>
-        <option value="custom">Custom</option>
-      </select>
-      <input
-        v-if="range === 'custom'"
-        type="date"
-        v-model="from"
-        class="border rounded p-1"
-      />
-      <input
-        v-if="range === 'custom'"
-        type="date"
-        v-model="to"
-        class="border rounded p-1"
-      />
-      <Button @click="fetchData">Apply</Button>
-      <Button @click="exportCsv">Export CSV</Button>
+  <div class="mx-auto max-w-7xl space-y-8 p-6">
+    <div
+      class="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center"
+    >
+      <h2 class="text-3xl font-bold tracking-tight">Reports</h2>
+      <div class="flex flex-wrap items-end gap-2">
+        <Select v-model="range" class="w-40">
+          <option value="today">Today</option>
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="custom">Custom</option>
+        </Select>
+        <Input
+          v-if="range === 'custom'"
+          type="date"
+          v-model="from"
+          class="w-40"
+        />
+        <Input
+          v-if="range === 'custom'"
+          type="date"
+          v-model="to"
+          class="w-40"
+        />
+        <Button @click="fetchData">Apply</Button>
+        <Button variant="secondary" @click="exportCsv">Export CSV</Button>
+      </div>
     </div>
-    <KpiCards :kpis="kpis" class="mb-6" />
-    <ChartCard title="Materials" type="bar" :series="materialSeries" />
-    <ChartCard
-      title="Materials Trend"
-      type="line"
-      :series="materialSeries"
-      class="mt-6"
-    />
+    <KpiCards :kpis="kpis" />
+    <div class="grid gap-6 md:grid-cols-2">
+      <ChartCard title="Materials" type="bar" :series="materialSeries" />
+      <ChartCard title="Materials Trend" type="line" :series="materialSeries" />
+    </div>
   </div>
 </template>
 
@@ -38,6 +39,8 @@
 import { ref, onMounted, computed } from 'vue';
 import api from '@/services/api';
 import Button from '@/components/ui/Button.vue';
+import Input from '@/components/ui/Input.vue';
+import Select from '@/components/ui/Select.vue';
 import KpiCards from '@/components/reports/KpiCards.vue';
 import ChartCard from '@/components/reports/ChartCard.vue';
 


### PR DESCRIPTION
## Summary
- refresh Card, Button, Input and Select UI components with glass-like styling
- revamp KPI and chart cards with gradients and responsive layout
- redesign Reports dashboard with modern controls and grid-based charts

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac7f4e94348323b0796195b838c68f