### PR TITLE
Fix service worker registration in development

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -24,15 +24,15 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
   event.respondWith(
-    caches.match(event.request).then((cached) => {
-      const fetchPromise = fetch(event.request)
-        .then((response) => {
-          const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
-          return response;
-        })
-        .catch(() => cached);
-      return cached || fetchPromise;
-    })
+    fetch(event.request)
+      .then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      })
+      .catch(async () => {
+        const cached = await caches.match(event.request);
+        return cached || (await caches.match('/index.html'));
+      })
   );
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -28,7 +28,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   document.head.appendChild(script);
 }
 
-if ('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/service-worker.js');
   });


### PR DESCRIPTION
## Summary
- Only register service worker in production builds
- Ensure service worker fetch handler returns cached fallback when offline

## Testing
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find config)*
- `npm --prefix frontend test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d09a26c8323a8a759ed5d70c691