### PR TITLE
Refactor navigation and appointments UI with PrimeVue

### DIFF
--- a/frontend/src/components/layout/AppShell.vue
+++ b/frontend/src/components/layout/AppShell.vue
@@ -8,14 +8,13 @@
       class="sticky top-0 z-20 flex items-center justify-between bg-background p-4 shadow"
     >
       <div class="flex items-center gap-2">
-        <button
-          class="mr-2 rounded p-2 focus-ring md:hidden"
+        <Button
+          class="mr-2 md:hidden"
+          icon="pi pi-bars"
           aria-label="Menu"
-          :aria-expanded="sidebarOpen"
-          @click="sidebarOpen = !sidebarOpen"
-        >
-          ☰
-        </button>
+          @click="sidebarOpen = true"
+          text
+        />
         <div class="flex items-center gap-2">
           <img
             v-if="branding.logo"
@@ -27,69 +26,30 @@
         </div>
       </div>
       <div class="flex items-center gap-2">
-        <label class="sr-only" for="language">{{ t('a11y.language') }}</label>
-        <select
-          id="language"
+        <Dropdown
           v-model="locale"
-          class="rounded border border-foreground/20 bg-background px-2 py-1 focus-ring"
-        >
-          <option value="el">Ελληνικά</option>
-          <option value="en">English</option>
-        </select>
-        <Button @click="toggleTheme">{{ t('actions.toggleTheme') }}</Button>
-        <Button @click="toggleDensity">{{ t('actions.toggleDensity') }}</Button>
-        <Badge v-if="queue.length" class="bg-blue-600 text-white">{{
-          queue.length
-        }}</Badge>
-        <button
-          class="rounded p-2 focus-ring"
+          :options="languages"
+          optionLabel="label"
+          optionValue="value"
+          class="w-32"
+        />
+        <Button @click="toggleTheme" :label="t('actions.toggleTheme')" text />
+        <Button @click="toggleDensity" :label="t('actions.toggleDensity')" text />
+        <Badge v-if="queue.length" :value="queue.length" />
+        <Button
+          icon="pi pi-search"
           aria-label="Command"
           @click="open(paletteActions)"
-        >
-          ⌘K
-        </button>
+          text
+        />
       </div>
     </header>
-    <div class="flex">
-      <aside
-        class="fixed inset-y-0 left-0 z-10 w-64 -translate-x-full bg-background shadow transition-transform md:static md:translate-x-0"
-        :class="{ 'translate-x-0': sidebarOpen }"
-        aria-label="Sidebar"
-      >
-        <nav class="mt-4 space-y-1 p-4">
-          <router-link
-            class="block rounded px-2 py-1 hover:bg-foreground/10"
-            to="/appointments"
-          >
-            Appointments
-          </router-link>
-          <router-link
-            class="block rounded px-2 py-1 hover:bg-foreground/10"
-            to="/manuals"
-            >Manuals</router-link
-          >
-          <router-link
-            class="block rounded px-2 py-1 hover:bg-foreground/10"
-            to="/reports"
-            >Reports</router-link
-          >
-          <router-link
-            class="block rounded px-2 py-1 hover:bg-foreground/10"
-            to="/settings"
-            >Settings</router-link
-          >
-          <router-link
-            v-if="auth.user?.roles?.some((r: any) => r.name === 'SuperAdmin')"
-            class="block rounded px-2 py-1 hover:bg-foreground/10"
-            to="/tenants"
-            >Tenants</router-link
-          >
-        </nav>
-      </aside>
-      <main id="main" tabindex="-1" class="flex-1 p-4 md:ml-64">
-        <router-view />
-      </main>
-    </div>
+    <Sidebar v-model:visible="sidebarOpen">
+      <Menu :model="menuItems" class="w-full" />
+    </Sidebar>
+    <main id="main" tabindex="-1" class="p-4">
+      <router-view />
+    </main>
     <Toast />
     <UploadQueue />
   </div>
@@ -98,10 +58,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import Button from '../ui/Button.vue';
+import Button from 'primevue/button';
 import Toast from '../ui/Toast.vue';
 import UploadQueue from '../appointments/UploadQueue.vue';
-import Badge from '../ui/Badge.vue';
+import Badge from 'primevue/badge';
+import Sidebar from 'primevue/sidebar';
+import Menu from 'primevue/menu';
+import Dropdown from 'primevue/dropdown';
 import { useBrandingStore } from '@/stores/branding';
 import { useAuthStore } from '@/stores/auth';
 import { useDraftsStore } from '@/stores/drafts';
@@ -114,6 +77,11 @@ const density = ref<'compact' | ''>('');
 const sidebarOpen = ref(false);
 const { t, locale } = useI18n();
 
+const languages = [
+  { label: 'Ελληνικά', value: 'el' },
+  { label: 'English', value: 'en' },
+];
+
 const brandingStore = useBrandingStore();
 const branding = computed(() => brandingStore.branding);
 onMounted(() => brandingStore.load());
@@ -121,6 +89,19 @@ onMounted(() => brandingStore.load());
 const auth = useAuthStore();
 const drafts = useDraftsStore();
 const { queue } = storeToRefs(drafts);
+
+const menuItems = computed(() => {
+  const items = [
+    { label: 'Appointments', to: '/appointments' },
+    { label: 'Manuals', to: '/manuals' },
+    { label: 'Reports', to: '/reports' },
+    { label: 'Settings', to: '/settings' },
+  ];
+  if (auth.user?.roles?.some((r: any) => r.name === 'SuperAdmin')) {
+    items.push({ label: 'Tenants', to: '/tenants' });
+  }
+  return items;
+});
 
 function toggleTheme() {
   theme.value = theme.value === 'dark' ? 'light' : 'dark';

--- a/frontend/src/views/AppointmentDetail.vue
+++ b/frontend/src/views/AppointmentDetail.vue
@@ -1,26 +1,32 @@
 <template>
-  <div v-if="appointment">
-    <h2 class="text-xl font-bold mb-2">{{ appointment.title }}</h2>
-    <div class="mb-4">Step {{ appointment.completedSteps }} / {{ appointment.totalSteps }}</div>
-    <FormRenderer
-      v-if="appointment.form_schema"
-      v-model="formData"
-      :schema="appointment.form_schema"
-      class="mb-4"
-    />
-    <KauInput v-model="kau" class="mb-4" />
-    <PhotoCapture @update="onPhotos" class="mb-4" />
-    <div class="flex gap-2 mb-4">
-      <Button label="Map" text @click="openMap" />
-      <Button label="Call" text @click="call" />
-    </div>
-    <Button label="Complete Step" @click="completeStep" />
-    <AppointmentComments v-if="appointment" :appointment-id="appointment.id" class="mt-6" />
-  </div>
+  <Card v-if="appointment">
+    <template #title>{{ appointment.title }}</template>
+    <template #content>
+      <ProgressBar :value="progress" class="mb-4" />
+      <FormRenderer
+        v-if="appointment.form_schema"
+        v-model="formData"
+        :schema="appointment.form_schema"
+        class="mb-4"
+      />
+      <KauInput v-model="kau" class="mb-4" />
+      <PhotoCapture @update="onPhotos" class="mb-4" />
+      <div class="flex gap-2 mb-4">
+        <Button label="Map" text @click="openMap" />
+        <Button label="Call" text @click="call" />
+      </div>
+      <Button label="Complete Step" @click="completeStep" />
+      <AppointmentComments
+        v-if="appointment"
+        :appointment-id="appointment.id"
+        class="mt-6"
+      />
+    </template>
+  </Card>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useAppointmentsStore } from '@/stores/appointments';
 import { useDraftsStore } from '@/stores/drafts';
@@ -29,6 +35,8 @@ import KauInput from '@/components/appointments/KauInput.vue';
 import FormRenderer from '@/components/appointments/FormRenderer.vue';
 import AppointmentComments from '@/components/appointments/AppointmentComments.vue';
 import Button from 'primevue/button';
+import Card from 'primevue/card';
+import ProgressBar from 'primevue/progressbar';
 
 const route = useRoute();
 const appointments = useAppointmentsStore();
@@ -38,6 +46,11 @@ const appointment = ref<any>(null);
 const kau = ref('');
 const photos = ref<File[]>([]);
 const formData = ref<Record<string, any>>({});
+const progress = computed(() =>
+  appointment.value
+    ? (appointment.value.completedSteps / appointment.value.totalSteps) * 100
+    : 0,
+);
 
 onMounted(async () => {
   const id = route.params.id as string;

--- a/frontend/src/views/AppointmentList.vue
+++ b/frontend/src/views/AppointmentList.vue
@@ -1,14 +1,19 @@
 <template>
   <div>
-    <h2 class="text-xl font-bold mb-4">Appointments</h2>
-    <Button
-      v-if="isAdmin"
-      label="New Appointment"
-      icon="pi pi-plus"
-      class="mb-4"
-      @click="showDialog = true"
-    />
-    <DataTable :value="appointments">
+    <Toolbar class="mb-4">
+      <template #start>
+        <h2 class="text-xl font-bold">Appointments</h2>
+      </template>
+      <template #end>
+        <Button
+          v-if="isAdmin"
+          label="New Appointment"
+          icon="pi pi-plus"
+          @click="showDialog = true"
+        />
+      </template>
+    </Toolbar>
+    <DataTable :value="appointments" paginator :rows="10">
       <Column field="title" header="Title">
         <template #body="slotProps">
           <router-link
@@ -52,6 +57,7 @@ import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import Dialog from 'primevue/dialog';
 import InputText from 'primevue/inputtext';
+import Toolbar from 'primevue/toolbar';
 
 const store = useAppointmentsStore();
 const { appointments } = storeToRefs(store);

--- a/frontend/tests/unit/AppShell.accessibility.test.ts
+++ b/frontend/tests/unit/AppShell.accessibility.test.ts
@@ -5,6 +5,7 @@ import { createI18n } from 'vue-i18n';
 import AppShell from '@/components/layout/AppShell.vue';
 import en from '@/i18n/en.json';
 import { createPinia } from 'pinia';
+import PrimeVue from 'primevue/config';
 
 vi.mock('@/stores/branding', () => ({
   useBrandingStore: () => ({ branding: {}, load: vi.fn() }),
@@ -23,11 +24,26 @@ vi.mock('@/components/appointments/UploadQueue.vue', () => ({
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } });
 
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 describe('AppShell', () => {
   it('renders and toggles', async () => {
     const app = createApp(AppShell);
     app.use(createPinia());
     app.use(i18n);
+    app.use(PrimeVue);
     app.component('router-link', { template: '<a><slot /></a>' });
     app.component('router-view', { template: '<div />' });
     const div = document.createElement('div');
@@ -38,9 +54,9 @@ describe('AppShell', () => {
     const buttons = div.querySelectorAll('button');
     (buttons[1] as HTMLButtonElement).click();
     (buttons[2] as HTMLButtonElement).click();
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
-      await nextTick();
-      const palette = div.querySelector('[role="dialog"]');
-      expect(palette).not.toBeNull();
-    });
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+    await nextTick();
+    const palette = div.querySelector('[role="dialog"]');
+    expect(palette).not.toBeNull();
   });
+});


### PR DESCRIPTION
## Summary
- replace custom sidebar and menu with PrimeVue `Sidebar`, `Menu`, and `Dropdown`
- enhance appointment detail with PrimeVue `Card` and step `ProgressBar`
- streamline appointment list using PrimeVue `Toolbar` and table pagination

## Testing
- `npm test`
- `npm run lint` *(fails: 40 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac903f49548323b297c33608aee222