### PR TITLE
feat: redesign app shell with primevue layout

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -3,7 +3,8 @@
   "actions": {
     "toggleTheme": "Αλλαγή θέματος",
     "toggleDensity": "Αλλαγή πυκνότητας",
-    "toast": "Ειδοποίηση"
+    "toast": "Ειδοποίηση",
+    "logout": "Αποσύνδεση"
   },
   "messages": {
     "helloToast": "Γεια από το τοστ"
@@ -16,5 +17,20 @@
     "title": "Παλέτα εντολών",
     "placeholder": "Πληκτρολογήστε για αναζήτηση...",
     "empty": "Καμία ενέργεια"
+  },
+  "profile": {
+    "settings": "Ρυθμίσεις"
+  },
+  "routes": {
+    "appointments": "Ραντεβού",
+    "appointmentDetail": "Λεπτομέρειες Ραντεβού",
+    "manuals": "Εγχειρίδια",
+    "manualDetail": "Λεπτομέρειες Εγχειριδίου",
+    "reports": "Αναφορές",
+    "settings": "Ρυθμίσεις",
+    "gdpr": "GDPR",
+    "notifications": "Ειδοποιήσεις",
+    "employees": "Υπάλληλοι",
+    "tenants": "Μισθωτές"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -3,7 +3,8 @@
   "actions": {
     "toggleTheme": "Toggle Theme",
     "toggleDensity": "Toggle Density",
-    "toast": "Toast"
+    "toast": "Toast",
+    "logout": "Logout"
   },
   "messages": {
     "helloToast": "Hello from toast"
@@ -16,5 +17,20 @@
     "title": "Command palette",
     "placeholder": "Type to search...",
     "empty": "No actions"
+  },
+  "profile": {
+    "settings": "Settings"
+  },
+  "routes": {
+    "appointments": "Appointments",
+    "appointmentDetail": "Appointment Detail",
+    "manuals": "Manuals",
+    "manualDetail": "Manual Detail",
+    "reports": "Reports",
+    "settings": "Settings",
+    "gdpr": "GDPR",
+    "notifications": "Notifications",
+    "employees": "Employees",
+    "tenants": "Tenants"
   }
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,57 +3,57 @@ import { useAuthStore } from '@/stores/auth';
 import api from '@/services/api';
 import { setTokens } from '@/services/authStorage';
 
-const routes = [
+export const routes = [
   { path: '/', redirect: '/appointments', meta: { requiresAuth: true } },
   {
     path: '/appointments',
     component: () => import('@/views/AppointmentList.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.appointments' },
   },
   {
     path: '/appointments/:id',
     component: () => import('@/views/AppointmentDetail.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.appointmentDetail' },
   },
   {
     path: '/manuals',
     component: () => import('@/views/ManualList.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.manuals' },
   },
   {
     path: '/manuals/:id',
     component: () => import('@/views/ManualDetail.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.manualDetail' },
   },
   {
     path: '/notifications',
     component: () => import('@/views/NotificationCenter.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.notifications' },
   },
   {
     path: '/settings',
     component: () => import('@/views/SettingsView.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.settings' },
   },
   {
     path: '/settings/gdpr',
     component: () => import('@/views/Settings/GdprView.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.gdpr' },
   },
   {
     path: '/reports',
     component: () => import('@/views/ReportsDashboard.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.reports' },
   },
   {
     path: '/employees',
     component: () => import('@/views/EmployeeList.vue'),
-    meta: { requiresAuth: true, admin: true },
+    meta: { requiresAuth: true, admin: true, breadcrumb: 'routes.employees' },
   },
   {
     path: '/tenants',
     component: () => import('@/views/TenantList.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, breadcrumb: 'routes.tenants' },
   },
   { path: '/login', component: () => import('@/views/Auth/LoginView.vue') },
   {

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from '@playwright/test';
 
-test.skip('navigation via sidebar and command palette', async ({ page }) => {
-  // placeholder due to environment
+// Environment does not provide a running server; this test documents
+// the expected keyboard navigation behaviour.
+test.skip('sidebar keyboard navigation', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Menu' }).click();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('menuitem', { name: 'Appointments' })).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('menuitem', { name: 'Manuals' })).toBeFocused();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('menuitem', { name: 'Appointments' })).not.toBeVisible();
 });

--- a/frontend/tests/unit/AppShell.accessibility.test.ts
+++ b/frontend/tests/unit/AppShell.accessibility.test.ts
@@ -9,6 +9,7 @@ import PrimeVue from 'primevue/config';
 import ToastService from 'primevue/toastservice';
 import ConfirmationService from 'primevue/confirmationservice';
 import ConfirmDialog from 'primevue/confirmdialog';
+import { createRouter, createWebHistory } from 'vue-router';
 
 vi.mock('@/stores/branding', () => ({
   useBrandingStore: () => ({ branding: {}, load: vi.fn() }),
@@ -41,22 +42,26 @@ Object.defineProperty(window, 'matchMedia', {
 describe('AppShell', () => {
   it('renders and toggles', async () => {
     const app = createApp(AppShell);
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    });
+    app.use(router);
     app.use(createPinia());
     app.use(i18n);
     app.use(PrimeVue);
     app.use(ToastService);
     app.use(ConfirmationService);
     app.component('ConfirmDialog', ConfirmDialog);
-    app.component('router-link', { template: '<a><slot /></a>' });
-    app.component('router-view', { template: '<div />' });
     const div = document.createElement('div');
     document.body.appendChild(div);
     app.mount(div);
+    await router.isReady();
     const skip = div.querySelector('a[href="#main"]') as HTMLAnchorElement;
     expect(skip).not.toBeNull();
-    const buttons = div.querySelectorAll('button');
-    (buttons[1] as HTMLButtonElement).click();
-    (buttons[2] as HTMLButtonElement).click();
+    const buttons = Array.from(div.querySelectorAll('button')) as HTMLButtonElement[];
+    buttons.find((b) => b.textContent?.includes('Toggle Theme'))?.click();
+    buttons.find((b) => b.textContent?.includes('Toggle Density'))?.click();
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
     await nextTick();
     const palette = div.querySelector('[role="dialog"]');

--- a/frontend/tests/unit/AppShell.notifications.test.ts
+++ b/frontend/tests/unit/AppShell.notifications.test.ts
@@ -9,6 +9,7 @@ import PrimeVue from 'primevue/config';
 import ToastService from 'primevue/toastservice';
 import ConfirmationService from 'primevue/confirmationservice';
 import ConfirmDialog from 'primevue/confirmdialog';
+import { createRouter, createWebHistory } from 'vue-router';
 
 vi.mock('@/stores/branding', () => ({
   useBrandingStore: () => ({ branding: {}, load: vi.fn() }),
@@ -41,17 +42,21 @@ Object.defineProperty(window, 'matchMedia', {
 describe('AppShell notifications', () => {
   it('triggers toast and confirm dialog', async () => {
     const app = createApp(AppShell);
+    const router = createRouter({
+      history: createWebHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    });
+    app.use(router);
     app.use(createPinia());
     app.use(i18n);
     app.use(PrimeVue);
     app.use(ToastService);
     app.use(ConfirmationService);
     app.component('ConfirmDialog', ConfirmDialog);
-    app.component('router-link', { template: '<a><slot /></a>' });
-    app.component('router-view', { template: '<div />' });
     const div = document.createElement('div');
     document.body.appendChild(div);
     app.mount(div);
+    await router.isReady();
 
     app.config.globalProperties.$toast.add({ severity: 'info', summary: 'test', detail: 'hello' });
     await nextTick();


### PR DESCRIPTION
## Summary
- replace sidebar Menu with icon-based PanelMenu and add top Menubar with profile TieredMenu, language selector, notification badge
- show route-aware breadcrumbs using new router meta and translations
- document keyboard navigation expectations in Playwright test

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9aa1d33c832388c04245f0e29f70