### PR TITLE
fix: add default toast export

### DIFF
--- a/frontend/src/plugins/toast.ts
+++ b/frontend/src/plugins/toast.ts
@@ -3,3 +3,24 @@ import { useToast as usePrimeToast } from 'primevue/usetoast';
 
 export const toastPlugin = ToastService;
 export const useToast = usePrimeToast;
+
+/**
+ * Basic wrapper around PrimeVue's toast service so modules outside of Vue
+ * components can trigger notifications. The exported `toast` object exposes a
+ * single `show` method that displays an error toast. If the toast service isn't
+ * available (for example during tests), the call is silently ignored.
+ */
+const toast = {
+  show(message: string) {
+    try {
+      const t = usePrimeToast();
+      t.add({ severity: 'error', summary: message, detail: '' });
+    } catch {
+      // When called outside of a Vue component before the plugin is
+      // initialised, `usePrimeToast` will throw. In that case we simply ignore
+      // the request to avoid crashing.
+    }
+  },
+};
+
+export default toast;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
-import { toast } from '@/plugins/toast';
+import toast from '@/plugins/toast';
 
 export interface ApiError {
   message: string;


### PR DESCRIPTION
## Summary
- expose default toast object wrapping PrimeVue's toast service
- update API service to import default toast helper

## Testing
- `npm test` *(fails: Failed to resolve import "primevue/config" and missing primevue dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e2fa96c8323af715c875b9c03fb