### PR TITLE
feat: tabbed appointment detail with navigation guard

### DIFF
--- a/frontend/src/components/appointments/PhotoCapture.vue
+++ b/frontend/src/components/appointments/PhotoCapture.vue
@@ -1,34 +1,22 @@
 <template>
   <div>
     <Button label="Add Photos" @click="onSelect" />
-    <div v-if="previews.length" class="flex gap-2 mt-2">
-      <img
-        v-for="(src, idx) in previews"
-        :key="idx"
-        :src="src"
-        class="w-20 h-20 object-cover border"
-      />
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
 import { pickFiles } from '@/services/native';
 import Button from 'primevue/button';
 
 const emit = defineEmits(['update']);
-const previews = ref<string[]>([]);
 
 async function onSelect() {
   const files = await pickFiles({ multiple: true, accept: 'image/*', capture: 'environment' });
   if (!files.length) return;
   const result: File[] = [];
-  previews.value = [];
   for (const file of files) {
     const compressed = await compress(file);
     result.push(compressed);
-    previews.value.push(URL.createObjectURL(compressed));
   }
   emit('update', result);
 }

--- a/frontend/src/components/appointments/UploadQueue.vue
+++ b/frontend/src/components/appointments/UploadQueue.vue
@@ -1,19 +1,21 @@
 <template>
-  <div
-    v-if="queue.length"
-    class="fixed bottom-4 right-4 w-64 bg-white shadow-lg p-3 border rounded"
-  >
-    <h3 class="font-bold mb-2">Upload Queue</h3>
-    <div v-for="item in queue" :key="item.id" class="flex justify-between mb-1">
-      <span>{{ item.id }}</span>
-      <button class="text-blue-600" @click="retry(item.id)">Retry</button>
+  <Panel v-if="queue.length" header="Upload Queue" class="fixed bottom-4 right-4 w-80">
+    <div v-for="item in queue" :key="item.id" class="flex items-center gap-2 mb-2">
+      <div class="flex-1">
+        <div class="font-medium">{{ item.id }}</div>
+        <ProgressBar mode="indeterminate" class="h-2 mt-1" />
+      </div>
+      <Button label="Retry" text @click="retry(item.id)" />
     </div>
-  </div>
+  </Panel>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { useDraftsStore } from '@/stores/drafts';
+import Panel from 'primevue/panel';
+import ProgressBar from 'primevue/progressbar';
+import Button from 'primevue/button';
 
 const drafts = useDraftsStore();
 const { queue } = storeToRefs(drafts);

--- a/frontend/src/views/AppointmentDetail.vue
+++ b/frontend/src/views/AppointmentDetail.vue
@@ -3,31 +3,52 @@
     <template #title>{{ appointment.title }}</template>
     <template #content>
       <ProgressBar :value="progress" class="mb-4" />
-      <FormRenderer
-        v-if="appointment.form_schema"
-        v-model="formData"
-        :schema="appointment.form_schema"
-        class="mb-4"
-      />
-      <KauInput v-model="kau" class="mb-4" />
-      <PhotoCapture @update="onPhotos" class="mb-4" />
-      <div class="flex gap-2 mb-4">
+      <Steps :model="stepItems" :activeStep="activeIndex" class="mb-4" />
+      <TabView v-model:activeIndex="activeIndex">
+        <TabPanel header="Form">
+          <FormRenderer
+            v-if="appointment.form_schema"
+            v-model="formData"
+            :schema="appointment.form_schema"
+            class="mb-4"
+          />
+          <KauInput v-model="kau" class="mb-4" />
+          <Message v-if="errorMessage" severity="error" class="mb-4">
+            {{ errorMessage }}
+          </Message>
+          <Button label="Complete Step" @click="completeStep" />
+        </TabPanel>
+        <TabPanel header="Photos">
+          <PhotoCapture @update="onPhotos" class="mb-4" />
+          <Galleria v-if="photoUrls.length" :value="photoUrls" :numVisible="5">
+            <template #item="slotProps">
+              <img :src="slotProps.item" class="w-full" />
+            </template>
+            <template #thumbnail="slotProps">
+              <img :src="slotProps.item" class="w-20 h-20 object-cover" />
+            </template>
+          </Galleria>
+        </TabPanel>
+        <TabPanel header="Comments">
+          <AppointmentComments
+            v-if="appointment"
+            :appointment-id="appointment.id"
+            class="mt-2"
+          />
+        </TabPanel>
+      </TabView>
+      <div class="flex gap-2 mt-4">
         <Button label="Map" text @click="openMap" />
         <Button label="Call" text @click="call" />
       </div>
-      <Button label="Complete Step" @click="completeStep" />
-      <AppointmentComments
-        v-if="appointment"
-        :appointment-id="appointment.id"
-        class="mt-6"
-      />
     </template>
   </Card>
+  <ConfirmDialog />
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue';
-import { useRoute } from 'vue-router';
+import { ref, onMounted, computed, watch } from 'vue';
+import { useRoute, onBeforeRouteLeave } from 'vue-router';
 import { useAppointmentsStore } from '@/stores/appointments';
 import { useDraftsStore } from '@/stores/drafts';
 import PhotoCapture from '@/components/appointments/PhotoCapture.vue';
@@ -37,15 +58,30 @@ import AppointmentComments from '@/components/appointments/AppointmentComments.v
 import Button from 'primevue/button';
 import Card from 'primevue/card';
 import ProgressBar from 'primevue/progressbar';
+import TabView from 'primevue/tabview';
+import TabPanel from 'primevue/tabpanel';
+import Steps from 'primevue/steps';
+import Message from 'primevue/message';
+import Galleria from 'primevue/galleria';
+import ConfirmDialog from 'primevue/confirmdialog';
+import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'primevue/usetoast';
 
 const route = useRoute();
 const appointments = useAppointmentsStore();
 const drafts = useDraftsStore();
+const confirm = useConfirm();
+const toast = useToast();
 
 const appointment = ref<any>(null);
 const kau = ref('');
 const photos = ref<File[]>([]);
 const formData = ref<Record<string, any>>({});
+const activeIndex = ref(0);
+const errorMessage = ref('');
+const dirty = ref(false);
+const stepItems = [{ label: 'Form' }, { label: 'Photos' }, { label: 'Comments' }];
+const photoUrls = computed(() => photos.value.map((p) => URL.createObjectURL(p)));
 const progress = computed(() =>
   appointment.value
     ? (appointment.value.completedSteps / appointment.value.totalSteps) * 100
@@ -63,8 +99,16 @@ onMounted(async () => {
   }
 });
 
+watch([kau, formData], () => {
+  dirty.value = true;
+  errorMessage.value = '';
+  saveDraft();
+}, { deep: true });
+
 function onPhotos(files: File[]) {
   photos.value = files;
+  dirty.value = true;
+  errorMessage.value = '';
   saveDraft();
 }
 
@@ -80,9 +124,27 @@ function saveDraft() {
 
 function completeStep() {
   if (!appointment.value) return;
+  if (!Object.keys(formData.value).length) {
+    errorMessage.value = 'Please complete the form before proceeding.';
+    return;
+  }
   appointment.value.completedSteps++;
+  dirty.value = false;
   saveDraft();
+  toast.add({ severity: 'success', summary: 'Step completed', life: 3000 });
 }
+
+onBeforeRouteLeave((to, from, next) => {
+  if (dirty.value) {
+    confirm.require({
+      message: 'You have unsaved changes. Leave anyway?',
+      accept: () => next(),
+      reject: () => next(false),
+    });
+  } else {
+    next();
+  }
+});
 
 function openMap() {
   if (appointment.value?.location) {

--- a/frontend/tests/e2e/appointment.detail.tabs.spec.ts
+++ b/frontend/tests/e2e/appointment.detail.tabs.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test';
+
+// No running server in the environment; this test documents the expected flow.
+test.skip('tab switching and unsaved changes guard', async ({ page }) => {
+  await page.goto('/appointments/1');
+  await page.getByRole('tab', { name: 'Photos' }).click();
+  await page.getByRole('tab', { name: 'Comments' }).click();
+  await page.getByRole('textbox').first().fill('some value');
+  await page.getByRole('link', { name: 'Appointments' }).click();
+  await page.getByRole('button', { name: 'Leave' }).click();
+});

--- a/frontend/tests/unit/drafts.save.test.ts
+++ b/frontend/tests/unit/drafts.save.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+vi.mock('idb', () => {
+  const store: Record<string, any> = {};
+  return {
+    openDB: vi.fn(async () => ({
+      put: async (_s: string, data: any, id: string) => {
+        store[id] = data;
+      },
+      get: async (_s: string, id: string) => store[id],
+      delete: async (_s: string, id: string) => {
+        delete store[id];
+      },
+    })),
+  };
+});
+
+vi.mock('@/services/uploader', () => ({
+  uploadFile: vi.fn(async () => {}),
+}));
+
+describe('drafts store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('saves draft and adds to queue', async () => {
+    const { useDraftsStore } = await import('@/stores/drafts');
+    const store = useDraftsStore();
+    await store.save('1', { kau: 'abc' });
+    const loaded = await store.load('1');
+    expect(loaded).toEqual({ kau: 'abc' });
+    expect(store.queue).toHaveLength(1);
+    expect(store.queue[0].id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- structure appointment detail with TabView and Steps, add photo Galleria and leave guard
- restyle upload queue with Panel and progress bar
- cover draft persistence with unit test and document tab/guard flow in e2e spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9ff992088323b073d9b4d9e66870