### PR TITLE
feat: render primevue widgets from schema

### DIFF
--- a/frontend/src/components/appointments/FormRenderer.vue
+++ b/frontend/src/components/appointments/FormRenderer.vue
@@ -5,35 +5,167 @@
       :key="key"
       class="mb-4"
     >
-      <label :for="key" class="block mb-1">{{ key }}</label>
-      <InputText
-        v-model="model[key]"
-        :id="key"
-        class="w-full"
-        :required="schema.required && schema.required.includes(key)"
-      />
+      <FloatLabel v-if="!isRadio(config) && !isCheckbox(config)">
+        <component
+          :is="widgetFor(config)"
+          v-model="model[key]"
+          :id="key"
+          class="w-full"
+          v-bind="resolveProps(config)"
+          :aria-required="isRequired(key)"
+          :aria-invalid="!!errors[key]"
+          :class="{ 'p-invalid': !!errors[key] }"
+        />
+        <label :for="key">
+          {{ t(config.title || key) }}
+          <span v-if="isRequired(key)" class="text-red-500">*</span>
+        </label>
+      </FloatLabel>
+
+      <div v-else-if="isCheckbox(config)" class="flex items-center gap-2">
+        <Checkbox
+          v-model="model[key]"
+          :inputId="key"
+          :binary="true"
+          :aria-required="isRequired(key)"
+          :aria-invalid="!!errors[key]"
+          :class="{ 'p-invalid': !!errors[key] }"
+        />
+        <label :for="key">
+          {{ t(config.title || key) }}
+          <span v-if="isRequired(key)" class="text-red-500">*</span>
+        </label>
+      </div>
+
+      <div v-else-if="isRadio(config)">
+        <label class="block mb-1">
+          {{ t(config.title || key) }}
+          <span v-if="isRequired(key)" class="text-red-500">*</span>
+        </label>
+        <div class="flex flex-col gap-1">
+          <div
+            v-for="option in config.enum"
+            :key="option"
+            class="flex items-center gap-2"
+          >
+            <RadioButton
+              v-model="model[key]"
+              :inputId="`${key}-${option}`"
+              :name="key"
+              :value="option"
+              :aria-required="isRequired(key)"
+              :aria-invalid="!!errors[key]"
+              :class="{ 'p-invalid': !!errors[key] }"
+            />
+            <label :for="`${key}-${option}`">{{ t(option) }}</label>
+          </div>
+        </div>
+      </div>
+
+      <Message v-if="errors[key]" severity="error" :closable="false">
+        {{ errors[key] }}
+      </Message>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { reactive, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import InputText from 'primevue/inputtext';
+import Textarea from 'primevue/textarea';
+import InputNumber from 'primevue/inputnumber';
+import Dropdown from 'primevue/dropdown';
+import MultiSelect from 'primevue/multiselect';
+import Checkbox from 'primevue/checkbox';
+import RadioButton from 'primevue/radiobutton';
+import Chips from 'primevue/chips';
+import Calendar from 'primevue/calendar';
+import Slider from 'primevue/slider';
+import FloatLabel from 'primevue/floatlabel';
+import Message from 'primevue/message';
+
+interface Property {
+  type: string;
+  format?: string;
+  enum?: any[];
+  items?: { enum?: any[]; type?: string };
+  title?: string;
+  minimum?: number;
+  maximum?: number;
+}
 
 interface Schema {
-  properties: Record<string, any>;
+  properties: Record<string, Property>;
   required?: string[];
 }
 
 const props = defineProps<{ schema: Schema; modelValue: Record<string, any> }>();
 const emit = defineEmits(['update:modelValue']);
+const { t } = useI18n();
 
 const model = reactive({ ...props.modelValue });
+const errors = reactive<Record<string, string>>({});
+
+function isRequired(key: string) {
+  return props.schema.required?.includes(key) ?? false;
+}
+
+function validate(key: string) {
+  if (!isRequired(key)) {
+    delete errors[key];
+    return;
+  }
+  const val = model[key];
+  const empty =
+    val === undefined ||
+    val === null ||
+    val === '' ||
+    (Array.isArray(val) && val.length === 0);
+  if (empty) {
+    errors[key] = t('forms.required', 'Required');
+  } else {
+    delete errors[key];
+  }
+}
+
+function widgetFor(config: Property) {
+  if (config.enum) {
+    if (config.type === 'array') return MultiSelect;
+    if (config.format === 'radio') return RadioButton;
+    return Dropdown;
+  }
+  if (config.format === 'textarea') return Textarea;
+  if (config.format === 'chips') return Chips;
+  if (config.format === 'slider') return Slider;
+  if (config.format === 'date' || config.format === 'date-time') return Calendar;
+  if (config.type === 'number' || config.type === 'integer') return InputNumber;
+  return InputText;
+}
+
+function resolveProps(config: Property) {
+  const p: any = {};
+  if (config.enum) p.options = config.enum;
+  if (config.format === 'slider') {
+    p.min = config.minimum;
+    p.max = config.maximum;
+  }
+  return p;
+}
+
+function isRadio(config: Property) {
+  return !!config.enum && config.format === 'radio';
+}
+
+function isCheckbox(config: Property) {
+  return config.type === 'boolean' && !config.enum;
+}
 
 watch(
   () => props.modelValue,
   (val) => {
     Object.assign(model, val);
+    Object.keys(props.schema.properties).forEach(validate);
   },
   { deep: true }
 );
@@ -41,6 +173,7 @@ watch(
 watch(
   model,
   (val) => {
+    Object.keys(props.schema.properties).forEach(validate);
     emit('update:modelValue', { ...val });
   },
   { deep: true }

--- a/frontend/tests/unit/FormRenderer.test.ts
+++ b/frontend/tests/unit/FormRenderer.test.ts
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, nextTick } from 'vitest';
+import { createApp } from 'vue';
+import { createI18n } from 'vue-i18n';
+import PrimeVue from 'primevue/config';
+import en from '@/i18n/en.json';
+import FormRenderer from '@/components/appointments/FormRenderer.vue';
+
+describe('FormRenderer', () => {
+  it('renders widgets based on schema', () => {
+    const schema = {
+      properties: {
+        name: { type: 'string' },
+        status: { type: 'string', enum: ['a', 'b'] },
+        agree: { type: 'boolean' },
+      },
+    };
+    const app = createApp(FormRenderer, {
+      schema,
+      modelValue: { name: '', status: '', agree: false },
+    });
+    app.use(createI18n({ legacy: false, locale: 'en', messages: { en } }));
+    app.use(PrimeVue);
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    app.mount(el);
+    expect(el.querySelector('input.p-inputtext')).not.toBeNull();
+    expect(el.querySelector('.p-dropdown')).not.toBeNull();
+    expect(el.querySelector('.p-checkbox')).not.toBeNull();
+  });
+
+  it('validates required fields', async () => {
+    const schema = {
+      properties: { title: { type: 'string', title: 'appointments.form.title' } },
+      required: ['title'],
+    };
+    const app = createApp(FormRenderer, { schema, modelValue: { title: '' } });
+    app.use(createI18n({ legacy: false, locale: 'en', messages: { en } }));
+    app.use(PrimeVue);
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    app.mount(el);
+    const input = el.querySelector('input') as HTMLInputElement;
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    await nextTick();
+    expect(el.querySelector('.p-message-error')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- render JSON schema fields with matching PrimeVue widgets
- add unit tests for widget mapping and required validation

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading '0'))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca1a9146c8323b281bceb40cd0a98