### PR TITLE
feat(router): add route metadata and 404 page

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,62 +3,132 @@ import { useAuthStore } from '@/stores/auth';
 import api from '@/services/api';
 import { setTokens } from '@/services/authStorage';
 
+const APP_NAME = import.meta.env.VITE_APP_NAME || 'AsBuild';
+
 export const routes = [
-  { path: '/', redirect: '/appointments', meta: { requiresAuth: true } },
+  {
+    path: '/',
+    redirect: '/appointments',
+    meta: { requiresAuth: true, layout: 'app', hide: true },
+  },
   {
     path: '/appointments',
     component: () => import('@/views/AppointmentList.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.appointments' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.appointments',
+      title: 'Appointments',
+      layout: 'app',
+      groupParent: 'appointments',
+    },
   },
   {
     path: '/appointments/:id',
     component: () => import('@/views/AppointmentDetail.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.appointmentDetail' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.appointmentDetail',
+      title: 'Appointment Detail',
+      layout: 'app',
+      groupParent: '/appointments',
+    },
   },
   {
     path: '/manuals',
     component: () => import('@/views/ManualList.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.manuals' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.manuals',
+      title: 'Manuals',
+      layout: 'app',
+      groupParent: 'manuals',
+    },
   },
   {
     path: '/manuals/:id',
     component: () => import('@/views/ManualDetail.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.manualDetail' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.manualDetail',
+      title: 'Manual Detail',
+      layout: 'app',
+      groupParent: '/manuals',
+    },
   },
   {
     path: '/notifications',
     component: () => import('@/views/NotificationCenter.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.notifications' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.notifications',
+      title: 'Notifications',
+      layout: 'app',
+    },
   },
   {
     path: '/settings',
     component: () => import('@/views/SettingsView.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.settings' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.settings',
+      title: 'Settings',
+      layout: 'app',
+      groupParent: 'settings',
+    },
   },
   {
     path: '/settings/gdpr',
     component: () => import('@/views/Settings/GdprView.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.gdpr' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.gdpr',
+      title: 'GDPR',
+      layout: 'app',
+      groupParent: '/settings',
+    },
   },
   {
     path: '/reports',
     component: () => import('@/views/ReportsDashboard.vue'),
-    meta: { requiresAuth: true, breadcrumb: 'routes.reports' },
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.reports',
+      title: 'Reports',
+      layout: 'app',
+    },
   },
   {
     path: '/employees',
     component: () => import('@/views/EmployeeList.vue'),
-    meta: { requiresAuth: true, admin: true, breadcrumb: 'routes.employees' },
+    meta: {
+      requiresAuth: true,
+      admin: true,
+      breadcrumb: 'routes.employees',
+      title: 'Employees',
+      layout: 'app',
+    },
   },
   {
     path: '/tenants',
     component: () => import('@/views/TenantList.vue'),
-    meta: { requiresAuth: true, admin: true, super: true, breadcrumb: 'routes.tenants' },
+    meta: {
+      requiresAuth: true,
+      admin: true,
+      super: true,
+      breadcrumb: 'routes.tenants',
+      title: 'Tenants',
+      layout: 'app',
+    },
   },
-  { path: '/login', component: () => import('@/views/Auth/LoginView.vue') },
+  {
+    path: '/login',
+    component: () => import('@/views/Auth/LoginView.vue'),
+    meta: { title: 'Login', layout: 'default', hide: true },
+  },
   {
     path: '/:pathMatch(.*)*',
-    component: () => import('@/views/ErrorView.vue'),
+    component: () => import('@/views/_errors/NotFound.vue'),
+    meta: { title: 'Not Found', layout: 'default', hide: true },
   },
 ];
 
@@ -69,6 +139,8 @@ const router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
   const auth = useAuthStore();
+
+  document.title = to.meta?.title || APP_NAME;
 
   if (!auth.isAuthenticated) {
     const access = to.query.access_token || to.query.token;
@@ -104,7 +176,7 @@ router.beforeEach(async (to, from, next) => {
   }
 
   if (to.meta.admin) {
-    const roles = auth.user?.roles?.map((r: any) => r.name) || [];
+    const roles = auth.user?.roles?.map((r) => r.name) || [];
     if (to.meta.super) {
       if (!roles.includes('SuperAdmin')) {
         return next('/');

--- a/frontend/src/views/_errors/NotFound.vue
+++ b/frontend/src/views/_errors/NotFound.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="p-8 text-center">
+    <h1 class="text-2xl mb-4">404 Not Found</h1>
+    <p>The page you are looking for doesn't exist.</p>
+  </div>
+</template>
+
+<script setup>
+// no logic needed
+</script>


### PR DESCRIPTION
## Summary
- expand routes with title/breadcrumb meta and layout control
- add global navigation guard for document titles
- introduce NotFound view and catch-all route

## Testing
- `npm run lint`
- `npm test` (fails: matchMedia is not a function; nextTick is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68ad6e5c86108323bfbd5b68b328d8eb