### PR TITLE
feat: add app layout and breadcrumbs

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,25 @@
+<template>
+  <component :is="layoutComponent" />
+</template>
+
+<script setup lang="ts">
+import { computed, defineComponent, h } from 'vue';
+import { useRoute, RouterView } from 'vue-router';
+import AppLayout from './Layout/AppLayout.vue';
+
+const route = useRoute();
+
+const DefaultLayout = defineComponent({
+  name: 'DefaultLayout',
+  setup() {
+    return () => h(RouterView);
+  },
+});
+
+const layouts: Record<string, any> = {
+  app: AppLayout,
+  default: DefaultLayout,
+};
+
+const layoutComponent = computed(() => layouts[(route.meta.layout as string) || 'app'] || DefaultLayout);
+</script>

--- a/frontend/src/Layout/AppLayout.vue
+++ b/frontend/src/Layout/AppLayout.vue
@@ -1,23 +1,26 @@
 <template>
-  <div class="flex min-h-screen bg-gray-50 dark:bg-slate-900">
-    <Sidebar />
-    <div class="flex-1 flex flex-col">
-      <Header />
-      <main class="flex-1 p-4">
-        <Breadcrumbs v-if="$slots.breadcrumbs">
-          <slot name="breadcrumbs" />
-        </Breadcrumbs>
-        <slot />
-      </main>
-      <Footer />
+    <div class="flex min-h-screen bg-gray-50 dark:bg-slate-900">
+      <Sidebar />
+      <div class="flex flex-1 flex-col">
+        <Header />
+        <main class="flex-1 p-4">
+          <Breadcrumbs />
+          <div class="relative">
+            <Transition name="fade" mode="out-in">
+              <router-view />
+            </Transition>
+          </div>
+        </main>
+        <Footer />
+      </div>
+      <Settings />
     </div>
-    <Settings />
-  </div>
-</template>
-<script setup>
-import Header from './Header.vue'
-import Sidebar from './Sidebar.vue'
-import Breadcrumbs from './Breadcrumbs.vue'
-import Footer from './Footer.vue'
-import Settings from './Settings.vue'
-</script>
+  </template>
+  <script setup>
+  import Header from './Header.vue'
+  import Sidebar from './Sidebar.vue'
+  import Breadcrumbs from './Breadcrumbs.vue'
+  import Footer from './Footer.vue'
+  import Settings from './Settings.vue'
+  import { Transition } from 'vue'
+  </script>

--- a/frontend/src/Layout/Breadcrumbs.vue
+++ b/frontend/src/Layout/Breadcrumbs.vue
@@ -1,5 +1,54 @@
 <template>
-  <nav class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-    <slot />
+  <nav v-if="!hidden" class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+    <ol class="flex items-center gap-2">
+      <li v-for="(item, index) in items" :key="item.to" class="flex items-center">
+        <RouterLink
+          v-if="index < items.length - 1"
+          :to="item.to"
+          class="hover:underline"
+        >
+          {{ t(item.label) }}
+        </RouterLink>
+        <span v-else class="text-gray-700 dark:text-gray-200">{{ t(item.label) }}</span>
+        <span v-if="index < items.length - 1">/</span>
+      </li>
+    </ol>
   </nav>
 </template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute, useRouter, RouterLink } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+
+function resolveParent(key: string) {
+  if (!key) return undefined;
+  const routes = router.getRoutes();
+  return routes.find((r) => r.path === key || r.path === `/${key}`);
+}
+
+const items = computed(() => {
+  const crumbs: { label: string; to: string }[] = [];
+  const groupParent = route.meta.groupParent as string | undefined;
+  if (groupParent) {
+    const parentRoute = resolveParent(groupParent);
+    if (parentRoute && parentRoute.meta && parentRoute.meta.breadcrumb && !parentRoute.meta.hide) {
+      crumbs.push({ label: parentRoute.meta.breadcrumb as string, to: parentRoute.path });
+    }
+  }
+  route.matched.forEach((r) => {
+    if (r.meta && r.meta.breadcrumb && !r.meta.hide) {
+      if (!crumbs.some((c) => c.to === r.path)) {
+        crumbs.push({ label: r.meta.breadcrumb as string, to: r.path });
+      }
+    }
+  });
+  return crumbs;
+});
+
+const hidden = computed(() => route.meta.hide);
+</script>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from 'vue';
 import router from './router';
 import stores from './stores';
-import AppShell from './components/layout/AppShell.vue';
+import App from './App.vue';
 import i18n from './i18n';
 import PrimeVue from 'primevue/config';
 import Aura from '@primevue/themes/aura';
@@ -12,7 +12,7 @@ import 'primeicons/primeicons.css';
 import './styles/tokens.css';
 import './assets/main.css';
 
-createApp(AppShell)
+createApp(App)
   .use(stores)
   .use(i18n)
   .use(router)


### PR DESCRIPTION
## Summary
- render routes through App.vue with dynamic layout selection
- build AppLayout with header, sidebar, footer, settings and transitioned router view
- implement Breadcrumbs component using route meta and group parents

## Testing
- `npm run lint`
- `npm test` *(fails: matchMedia is not a function, nextTick is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad708cf6e48323a9536fb7a8995c12