### PR TITLE
feat: add constant-driven navigation

### DIFF
--- a/frontend/src/Layout/Header.vue
+++ b/frontend/src/Layout/Header.vue
@@ -1,5 +1,29 @@
 <template>
   <header class="bg-white dark:bg-slate-800 shadow px-4 h-16 flex items-center">
     <img src="@/assets/images/logo/logo.svg" alt="logo" class="h-8" />
+    <button class="ml-auto md:hidden" @click="show = !show">Menu</button>
+    <nav :class="['ml-auto', show ? 'block' : 'hidden', 'md:block']">
+      <ul class="flex space-x-4">
+        <li v-for="item in topMenu" :key="item.title">
+          <router-link
+            :to="item.link"
+            class="text-gray-700 dark:text-gray-100"
+            :class="{ 'font-semibold text-primary-500': isActive(item.link) }"
+          >
+            {{ item.title }}
+          </router-link>
+        </li>
+      </ul>
+    </nav>
   </header>
 </template>
+<script setup>
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { topMenu } from '@/constant/data'
+
+const show = ref(false)
+const route = useRoute()
+const isActive = (link) => route.path === link
+</script>
+

--- a/frontend/src/Layout/Sidebar.vue
+++ b/frontend/src/Layout/Sidebar.vue
@@ -5,11 +5,38 @@
     </div>
     <nav class="px-4">
       <ul>
-        <li v-for="item in menuItems" :key="item.title" class="mb-4">
-          <div class="font-semibold text-gray-700 dark:text-gray-100">{{ item.title }}</div>
-          <ul v-if="item.child" class="mt-2 pl-4 text-sm text-gray-600 dark:text-gray-300">
+        <li v-for="item in menuItems" :key="item.title" class="mb-2">
+          <div>
+            <button
+              v-if="item.child"
+              class="w-full flex justify-between items-center text-left font-semibold text-gray-700 dark:text-gray-100"
+              @click="toggle(item.title)"
+              :class="{ 'text-primary-500': isChildActive(item) }"
+            >
+              {{ item.title }}
+              <span class="text-xs">{{ open[item.title] ? '-' : '+' }}</span>
+            </button>
+            <router-link
+              v-else
+              :to="item.link"
+              class="block font-semibold text-gray-700 dark:text-gray-100"
+              :class="{ 'text-primary-500': isActive(item.link) }"
+            >
+              {{ item.title }}
+            </router-link>
+          </div>
+          <ul
+            v-if="item.child && open[item.title]"
+            class="mt-2 pl-4 text-sm text-gray-600 dark:text-gray-300"
+          >
             <li v-for="child in item.child" :key="child.childlink" class="py-1">
-              {{ child.childtitle }}
+              <router-link
+                :to="child.childlink"
+                class="block"
+                :class="{ 'text-primary-500 font-semibold': isActive(child.childlink) }"
+              >
+                {{ child.childtitle }}
+              </router-link>
             </li>
           </ul>
         </li>
@@ -18,5 +45,26 @@
   </aside>
 </template>
 <script setup>
+import { reactive, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { menuItems } from '@/constant/data'
+
+const route = useRoute()
+const open = reactive({})
+
+const isActive = (link) => route.path === link
+const isChildActive = (item) =>
+  item.child && item.child.some((c) => c.childlink === route.path)
+
+const toggle = (title) => {
+  open[title] = !open[title]
+}
+
+onMounted(() => {
+  menuItems.forEach((item) => {
+    if (isChildActive(item)) {
+      open[item.title] = true
+    }
+  })
+})
 </script>

--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -1,24 +1,49 @@
 export const menuItems = [
   {
-    isHeadr: true,
-    title: "menu",
-  },
-  {
     title: "Dashboard",
     icon: "heroicons-outline:home",
-    isOpen: true,
+    link: "/",
+  },
+  {
+    title: "Appointments",
+    icon: "heroicons-outline:calendar",
     child: [
-      { childtitle: "Analytics Dashboard", childlink: "home" },
-      { childtitle: "Ecommerce Dashboard", childlink: "ecommerce" },
-      { childtitle: "Project Dashboard", childlink: "project" },
-      { childtitle: "CRM Dashboard", childlink: "crm" },
-      { childtitle: "Banking Dashboard", childlink: "banking" },
+      { childtitle: "Appointments", childlink: "/appointments" },
+      { childtitle: "Appointment Types", childlink: "/appointment-types" },
     ],
   },
   {
-    title: "changelog",
-    icon: "heroicons-outline:document-text",
-    link: "/docs/changelog",
-    badge: "1.0.0",
+    title: "Employees",
+    icon: "heroicons-outline:users",
+    link: "/employees",
   },
+  {
+    title: "Reports",
+    icon: "heroicons-outline:chart-bar",
+    link: "/reports",
+  },
+  {
+    title: "Notifications",
+    icon: "heroicons-outline:bell",
+    link: "/notifications",
+  },
+  {
+    title: "Settings",
+    icon: "heroicons-outline:cog",
+    child: [
+      { childtitle: "Settings", childlink: "/settings" },
+      { childtitle: "GDPR", childlink: "/settings/gdpr" },
+    ],
+  },
+];
+
+export const topMenu = [
+  { title: "Dashboard", icon: "heroicons-outline:home", link: "/" },
+  { title: "Appointments", icon: "heroicons-outline:calendar", link: "/appointments" },
+  { title: "Appointment Types", icon: "heroicons-outline:template", link: "/appointment-types" },
+  { title: "Employees", icon: "heroicons-outline:users", link: "/employees" },
+  { title: "Reports", icon: "heroicons-outline:chart-bar", link: "/reports" },
+  { title: "Notifications", icon: "heroicons-outline:bell", link: "/notifications" },
+  { title: "Settings", icon: "heroicons-outline:cog", link: "/settings" },
+  { title: "GDPR", icon: "heroicons-outline:shield-check", link: "/settings/gdpr" },
 ];


### PR DESCRIPTION
## Summary
- define menu and top-menu constants for Dashboard, Appointments, Appointment Types, Employees, Reports, Notifications, Settings, and GDPR
- render sidebar with collapsible submenus and active route highlighting
- expose top menu in header with toggle support

## Testing
- `npm test` *(fails: matchMedia is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad71cf2c548323aefb3b7e7e94e1f3