### PR TITLE
feat: add axios client with auth and tenant interceptors

### DIFF
--- a/frontend/src/config/app.js
+++ b/frontend/src/config/app.js
@@ -1,0 +1,7 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+export const ACCESS_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY || 'access_token';
+export const REFRESH_TOKEN_KEY = import.meta.env.VITE_REFRESH_TOKEN_KEY || 'refresh_token';
+export const TENANT_ID_KEY = import.meta.env.VITE_TENANT_ID_KEY || 'tenant_id';
+export const USER_KEY = import.meta.env.VITE_USER_KEY || 'user';
+export const AUTH_HEADER = 'Authorization';
+export const TENANT_HEADER = 'X-Tenant-ID';

--- a/frontend/src/lib/http.js
+++ b/frontend/src/lib/http.js
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import {
+  API_BASE_URL,
+  AUTH_HEADER,
+  TENANT_HEADER,
+} from '../config/app';
+import { useAuthStore } from '../store/auth';
+import { useTenantStore } from '../store/tenant';
+
+const http = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+http.interceptors.request.use((config) => {
+  const auth = useAuthStore();
+  const tenant = useTenantStore();
+  if (auth.token) {
+    config.headers[AUTH_HEADER] = `Bearer ${auth.token}`;
+  }
+  if (tenant.tenantId) {
+    config.headers[TENANT_HEADER] = tenant.tenantId;
+  }
+  return config;
+});
+
+http.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { response, config } = error;
+    const auth = useAuthStore();
+    if (response && response.status === 401 && !config._retry) {
+      config._retry = true;
+      try {
+        await auth.refresh();
+        return http(config);
+      } catch (err) {
+        await auth.logout();
+      }
+    }
+    const normalized = {
+      status: response?.status,
+      message: response?.data?.message || error.message,
+    };
+    return Promise.reject(normalized);
+  }
+);
+
+export default http;

--- a/frontend/src/store/auth.js
+++ b/frontend/src/store/auth.js
@@ -1,0 +1,67 @@
+import { defineStore } from 'pinia';
+import axios from 'axios';
+import http from '../lib/http';
+import {
+  API_BASE_URL,
+  ACCESS_TOKEN_KEY,
+  REFRESH_TOKEN_KEY,
+  USER_KEY,
+} from '../config/app';
+
+function readStorage() {
+  const token = localStorage.getItem(ACCESS_TOKEN_KEY) || '';
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY) || '';
+  let user = null;
+  try {
+    user = JSON.parse(localStorage.getItem(USER_KEY));
+  } catch {}
+  return { token, refreshToken, user };
+}
+
+const initial = readStorage();
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    token: initial.token,
+    refreshToken: initial.refreshToken,
+    user: initial.user,
+  }),
+  actions: {
+    loadFromStorage() {
+      const data = readStorage();
+      this.token = data.token;
+      this.refreshToken = data.refreshToken;
+      this.user = data.user;
+    },
+    async login(payload) {
+      const { data } = await http.post('/auth/login', payload);
+      this.token = data.accessToken;
+      this.refreshToken = data.refreshToken;
+      this.user = data.user;
+      localStorage.setItem(ACCESS_TOKEN_KEY, this.token);
+      localStorage.setItem(REFRESH_TOKEN_KEY, this.refreshToken);
+      localStorage.setItem(USER_KEY, JSON.stringify(this.user));
+    },
+    async logout() {
+      try {
+        await http.post('/auth/logout');
+      } catch (e) {}
+      this.token = '';
+      this.refreshToken = '';
+      this.user = null;
+      localStorage.removeItem(ACCESS_TOKEN_KEY);
+      localStorage.removeItem(REFRESH_TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
+    },
+    async refresh() {
+      if (!this.refreshToken) throw new Error('Missing refresh token');
+      const { data } = await axios.post(`${API_BASE_URL}/auth/refresh`, {
+        refreshToken: this.refreshToken,
+      });
+      this.token = data.accessToken;
+      this.refreshToken = data.refreshToken || this.refreshToken;
+      localStorage.setItem(ACCESS_TOKEN_KEY, this.token);
+      localStorage.setItem(REFRESH_TOKEN_KEY, this.refreshToken);
+    },
+  },
+});

--- a/frontend/src/store/tenant.js
+++ b/frontend/src/store/tenant.js
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia';
+import { TENANT_ID_KEY } from '../config/app';
+
+const initialTenant = localStorage.getItem(TENANT_ID_KEY) || '';
+
+export const useTenantStore = defineStore('tenant', {
+  state: () => ({
+    tenantId: initialTenant,
+  }),
+  actions: {
+    setTenant(id) {
+      this.tenantId = id;
+      if (id) {
+        localStorage.setItem(TENANT_ID_KEY, id);
+      } else {
+        localStorage.removeItem(TENANT_ID_KEY);
+      }
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add config constants for API base and storage keys
- create axios http client injecting auth and tenant headers, refresh-on-401
- add Pinia auth and tenant stores for token and tenant management

## Testing
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad734661e48323a939893f18d6e789