### PR TITLE
feat: add reusable server-side data table wrapper

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,8 @@
     "vue": "^3.5.20",
     "vue-chartjs": "5.3.1",
     "vue-i18n": "9.14.0",
-    "vue-router": "4.3.0"
+    "vue-router": "4.3.0",
+    "vue-good-table-next": "^0.4.11"
   },
   "devDependencies": {
     "@playwright/test": "1.55.0",

--- a/frontend/src/components/datatable/ServerDataTable.vue
+++ b/frontend/src/components/datatable/ServerDataTable.vue
@@ -1,0 +1,60 @@
+<template>
+  <VueGoodTable
+    :columns="tableColumns"
+    :rows="rows"
+    :pagination-options="{ enabled: true, perPage: perPage, total: total }"
+    :search-options="{ enabled: true, externalQuery: search }"
+    :sort-options="{ enabled: true }"
+    :keyField="rowKey"
+    :styleClass="'table w-full'"
+    @on-page-change="onPageChange"
+    @on-sort-change="onSortChange"
+    @on-search="onSearch"
+  >
+    <template v-if="slots.actions" #table-row="props">
+      <span v-if="props.column.field === '__actions'">
+        <slot name="actions" v-bind="props" />
+      </span>
+      <span v-else>
+        {{ props.formattedRow[props.column.field] }}
+      </span>
+    </template>
+  </VueGoodTable>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+import { VueGoodTable } from 'vue-good-table-next';
+import useServerTable from '@/composables/useServerTable';
+
+const props = defineProps({
+  columns: { type: Array, required: true },
+  fetcher: { type: Function, required: true },
+  rowKey: { type: String, default: 'id' }
+});
+
+const slots = useSlots();
+
+const { rows, total, page, perPage, sort, search } = useServerTable(props.fetcher);
+
+const tableColumns = computed(() => {
+  if (slots.actions) {
+    return [...props.columns, { label: 'Actions', field: '__actions' }];
+  }
+  return props.columns;
+});
+
+function onPageChange({ currentPage, currentPerPage }) {
+  page.value = currentPage;
+  perPage.value = currentPerPage;
+}
+
+function onSortChange(params) {
+  const first = params[0];
+  sort.value = first ? { field: first.field, type: first.type } : null;
+}
+
+function onSearch(value) {
+  search.value = value;
+}
+</script>

--- a/frontend/src/composables/useServerTable.js
+++ b/frontend/src/composables/useServerTable.js
@@ -1,0 +1,31 @@
+import { ref, watch } from 'vue';
+
+export default function useServerTable(fetcher) {
+  const page = ref(1);
+  const perPage = ref(10);
+  const sort = ref(null);
+  const search = ref('');
+  const rows = ref([]);
+  const total = ref(0);
+  const loading = ref(false);
+
+  const load = async () => {
+    loading.value = true;
+    try {
+      const { rows: r, total: t } = await fetcher({
+        page: page.value,
+        perPage: perPage.value,
+        sort: sort.value,
+        search: search.value,
+      });
+      rows.value = r;
+      total.value = t;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  watch([page, perPage, sort, search], load, { immediate: true });
+
+  return { page, perPage, sort, search, rows, total, loading, load };
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,6 +8,8 @@ import Aura from '@primevue/themes/aura';
 import ToastService from 'primevue/toastservice';
 import ConfirmationService from 'primevue/confirmationservice';
 import ConfirmDialog from 'primevue/confirmdialog';
+import { VueGoodTablePlugin } from 'vue-good-table-next';
+import 'vue-good-table-next/dist/style.css';
 import 'primeicons/primeicons.css';
 import './styles/tokens.css';
 import './assets/main.css';
@@ -19,6 +21,7 @@ createApp(App)
   .use(PrimeVue, { theme: { preset: Aura } })
   .use(ToastService)
   .use(ConfirmationService)
+  .use(VueGoodTablePlugin)
   .component('ConfirmDialog', ConfirmDialog)
   .mount('#app');
 


### PR DESCRIPTION
## Summary
- install vue-good-table-next and register plugin
- add ServerDataTable wrapper component with server-side paging/sort/search
- provide useServerTable composable for remote data fetching

## Testing
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad75fab15483238fe3016b841012ee