### PR TITLE
refactor: use route names for menu and breadcrumbs

### DIFF
--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -2,48 +2,44 @@ export const menuItems = [
   {
     title: "Dashboard",
     icon: "heroicons-outline:home",
-    link: "/",
+    link: "dashboard",
   },
   {
     title: "Appointments",
     icon: "heroicons-outline:calendar",
-    child: [
-      { childtitle: "Appointments", childlink: "/appointments" },
-      { childtitle: "Appointment Types", childlink: "/appointment-types" },
-    ],
+    link: "appointments",
   },
   {
     title: "Employees",
     icon: "heroicons-outline:users",
-    link: "/employees",
+    link: "employees",
   },
   {
     title: "Reports",
     icon: "heroicons-outline:chart-bar",
-    link: "/reports",
+    link: "reports",
   },
   {
     title: "Notifications",
     icon: "heroicons-outline:bell",
-    link: "/notifications",
+    link: "notifications",
   },
   {
     title: "Settings",
     icon: "heroicons-outline:cog",
     child: [
-      { childtitle: "Settings", childlink: "/settings" },
-      { childtitle: "GDPR", childlink: "/settings/gdpr" },
+      { childtitle: "Settings", childlink: "settings" },
+      { childtitle: "GDPR", childlink: "settings-gdpr" },
     ],
   },
 ];
 
 export const topMenu = [
-  { title: "Dashboard", icon: "heroicons-outline:home", link: "/" },
-  { title: "Appointments", icon: "heroicons-outline:calendar", link: "/appointments" },
-  { title: "Appointment Types", icon: "heroicons-outline:template", link: "/appointment-types" },
-  { title: "Employees", icon: "heroicons-outline:users", link: "/employees" },
-  { title: "Reports", icon: "heroicons-outline:chart-bar", link: "/reports" },
-  { title: "Notifications", icon: "heroicons-outline:bell", link: "/notifications" },
-  { title: "Settings", icon: "heroicons-outline:cog", link: "/settings" },
-  { title: "GDPR", icon: "heroicons-outline:shield-check", link: "/settings/gdpr" },
+  { title: "Dashboard", icon: "heroicons-outline:home", link: "dashboard" },
+  { title: "Appointments", icon: "heroicons-outline:calendar", link: "appointments" },
+  { title: "Employees", icon: "heroicons-outline:users", link: "employees" },
+  { title: "Reports", icon: "heroicons-outline:chart-bar", link: "reports" },
+  { title: "Notifications", icon: "heroicons-outline:bell", link: "notifications" },
+  { title: "Settings", icon: "heroicons-outline:cog", link: "settings" },
+  { title: "GDPR", icon: "heroicons-outline:shield-check", link: "settings-gdpr" },
 ];

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,7 @@ const APP_NAME = import.meta.env.VITE_APP_NAME || 'AsBuild';
 export const routes = [
   {
     path: '/',
+    name: 'dashboard',
     component: () => import('@/views/home/Dashboard.vue'),
     meta: {
       requiresAuth: true,
@@ -18,50 +19,53 @@ export const routes = [
   },
   {
     path: '/appointments',
+    name: 'appointments',
     component: () => import('@/views/AppointmentList.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.appointments',
       title: 'Appointments',
       layout: 'app',
-      groupParent: 'appointments',
     },
   },
   {
     path: '/appointments/:id',
+    name: 'appointment-detail',
     component: () => import('@/views/AppointmentDetail.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.appointmentDetail',
       title: 'Appointment Detail',
       layout: 'app',
-      groupParent: '/appointments',
+      groupParent: 'appointments',
     },
   },
   {
     path: '/manuals',
+    name: 'manuals',
     component: () => import('@/views/ManualList.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.manuals',
       title: 'Manuals',
       layout: 'app',
-      groupParent: 'manuals',
     },
   },
   {
     path: '/manuals/:id',
+    name: 'manual-detail',
     component: () => import('@/views/ManualDetail.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.manualDetail',
       title: 'Manual Detail',
       layout: 'app',
-      groupParent: '/manuals',
+      groupParent: 'manuals',
     },
   },
   {
     path: '/notifications',
+    name: 'notifications',
     component: () => import('@/views/NotificationCenter.vue'),
     meta: {
       requiresAuth: true,
@@ -72,28 +76,30 @@ export const routes = [
   },
   {
     path: '/settings',
+    name: 'settings',
     component: () => import('@/views/SettingsView.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.settings',
       title: 'Settings',
       layout: 'app',
-      groupParent: 'settings',
     },
   },
   {
     path: '/settings/gdpr',
+    name: 'settings-gdpr',
     component: () => import('@/views/Settings/GdprView.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.gdpr',
       title: 'GDPR',
       layout: 'app',
-      groupParent: '/settings',
+      groupParent: 'settings',
     },
   },
   {
     path: '/reports',
+    name: 'reports',
     component: () => import('@/views/ReportsDashboard.vue'),
     meta: {
       requiresAuth: true,
@@ -104,6 +110,7 @@ export const routes = [
   },
   {
     path: '/employees',
+    name: 'employees',
     component: () => import('@/views/EmployeeList.vue'),
     meta: {
       requiresAuth: true,
@@ -115,6 +122,7 @@ export const routes = [
   },
   {
     path: '/tenants',
+    name: 'tenants',
     component: () => import('@/views/TenantList.vue'),
     meta: {
       requiresAuth: true,
@@ -127,11 +135,13 @@ export const routes = [
   },
   {
     path: '/auth/login',
+    name: 'login',
     component: () => import('@/views/auth/Login.vue'),
     meta: { layout: 'default', title: 'Sign in', hide: true },
   },
   {
     path: '/:pathMatch(.*)*',
+    name: 'not-found',
     component: () => import('@/views/_errors/NotFound.vue'),
     meta: { title: 'Not Found', layout: 'default', hide: true },
   },


### PR DESCRIPTION
## Summary
- use route names instead of paths in menu data and remove dead links
- name all routes and align breadcrumb groupParent values

## Testing
- `npm run lint`
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7d73a5688323880ffec4ced2c07c