### PR TITLE
feat: appointment details with photos and comments

### DIFF
--- a/frontend/src/components/comments/CommentEditor.vue
+++ b/frontend/src/components/comments/CommentEditor.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <Textarea v-model="body" rows="3" placeholder="Add a comment" />
+    <MultiSelect
+      v-model="selectedMentions"
+      :options="employees"
+      option-label="name"
+      option-value="id"
+      placeholder="Mention users"
+      display="chip"
+      filter
+      class="w-full"
+    />
+    <InputText
+      v-if="allowFiles"
+      v-model="fileIds"
+      placeholder="File IDs comma separated"
+    />
+    <Button label="Comment" @click="submit" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import api from '@/services/api';
+import Textarea from 'primevue/textarea';
+import MultiSelect from 'primevue/multiselect';
+import InputText from 'primevue/inputtext';
+import Button from 'primevue/button';
+
+const props = defineProps<{ appointmentId: number | string; allowFiles?: boolean }>();
+const emit = defineEmits<{ (e: 'added', comment: any): void }>();
+
+const body = ref('');
+const selectedMentions = ref<any[]>([]);
+const fileIds = ref('');
+const employees = ref<any[]>([]);
+const allowFiles = props.allowFiles ?? false;
+
+onMounted(async () => {
+  const { data } = await api.get('/employees');
+  employees.value = data;
+});
+
+async function submit() {
+  const mentions = selectedMentions.value.map((m: any) => m.id ?? m);
+  const files = allowFiles
+    ? fileIds.value
+        .split(',')
+        .map((s) => parseInt(s.trim()))
+        .filter((n) => !isNaN(n))
+    : [];
+  const { data } = await api.post(`/appointments/${props.appointmentId}/comments`, {
+    body: body.value,
+    mentions,
+    files,
+  });
+  emit('added', data);
+  body.value = '';
+  selectedMentions.value = [];
+  fileIds.value = '';
+}
+</script>

--- a/frontend/src/components/comments/CommentsThread.vue
+++ b/frontend/src/components/comments/CommentsThread.vue
@@ -1,0 +1,49 @@
+<template>
+  <div>
+    <div
+      v-for="c in comments"
+      :key="c.id"
+      class="mb-4 border-b pb-2 last:border-b-0"
+    >
+      <div class="text-sm text-gray-600 mb-1">
+        {{ c.user?.name || 'Unknown' }} ·
+        <span>{{ formatDate(c.created_at) }}</span>
+      </div>
+      <div class="whitespace-pre-line">{{ c.body }}</div>
+      <div
+        v-if="c.files?.length"
+        class="mt-2 flex flex-wrap gap-2"
+      >
+        <template v-for="file in c.files" :key="file.id">
+          <img
+            v-if="hasThumb(file)"
+            :src="file.variants.thumb"
+            class="w-16 h-16 object-cover rounded"
+          />
+          <div
+            v-else
+            class="flex items-center gap-2 px-2 py-1 border rounded text-xs text-gray-600"
+          >
+            <span>{{ file.filename }}</span>
+            <button disabled class="text-gray-400 cursor-not-allowed">Open</button>
+          </div>
+          <!-- TODO: needs signed URL endpoint -->
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ comments: any[] }>();
+
+function formatDate(d?: string) {
+  return d ? new Date(d).toLocaleString() : '';
+}
+
+function hasThumb(file: any) {
+  if (file?.variants?.thumb) return true;
+  console.warn('TODO: needs signed URL endpoint');
+  return false;
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -31,7 +31,7 @@ export const routes = [
   {
     path: '/appointments/:id',
     name: 'appointments.details',
-    component: () => import('@/views/AppointmentDetail.vue'),
+    component: () => import('@/views/appointments/AppointmentDetails.vue'),
     meta: {
       requiresAuth: true,
       breadcrumb: 'routes.appointmentDetail',

--- a/frontend/src/views/appointments/AppointmentDetails.vue
+++ b/frontend/src/views/appointments/AppointmentDetails.vue
@@ -1,0 +1,145 @@
+<template>
+  <div v-if="appointment">
+    <Card class="mb-4">
+      <template #title>
+        Appointment {{ appointment.id }}
+      </template>
+      <template #content>
+        <div class="mb-2 flex items-center gap-2">
+          <span class="font-semibold">{{ appointment.type?.name || '—' }}</span>
+          <span
+            class="px-2 py-1 rounded-full text-xs font-semibold"
+            :class="statusClasses[appointment.status]"
+          >
+            {{ appointment.status.replace(/_/g, ' ') }}
+          </span>
+        </div>
+        <ul class="text-sm mb-2">
+          <li>Scheduled: {{ format(appointment.scheduled_at) || '—' }}</li>
+          <li>Started: {{ format(appointment.started_at) || '—' }}</li>
+          <li>Completed: {{ format(appointment.completed_at) || '—' }}</li>
+          <li>SLA End: {{ format(appointment.sla_end_at) || '—' }}</li>
+          <li>SLA: {{ slaStatus }}</li>
+        </ul>
+        <div class="flex gap-2 mt-2">
+          <button
+            v-for="a in changeActions"
+            :key="a.value"
+            class="text-blue-600"
+            @click="updateStatus(a.value)"
+          >
+            Mark {{ a.label }}
+          </button>
+        </div>
+      </template>
+    </Card>
+
+    <TabView>
+      <TabPanel header="Details">
+        <div class="text-sm">
+          <div>Kau Notes: {{ appointment.kau_notes || '—' }}</div>
+        </div>
+      </TabPanel>
+      <TabPanel header="Photos">
+        <div class="flex flex-wrap gap-4">
+          <template v-for="photo in appointment.photos" :key="photo.id">
+            <img
+              v-if="hasThumb(photo.file)"
+              :src="photo.file.variants.thumb"
+              class="w-24 h-24 object-cover rounded"
+            />
+            <div
+              v-else
+              class="flex items-center gap-2 px-2 py-1 border rounded text-sm text-gray-600"
+            >
+              <span>{{ photo.file?.filename }}</span>
+              <button disabled class="text-gray-400 cursor-not-allowed">Open</button>
+            </div>
+            <!-- TODO: needs signed URL endpoint -->
+          </template>
+        </div>
+      </TabPanel>
+      <TabPanel header="Comments">
+        <CommentsThread :comments="appointment.comments" class="mb-4" />
+        <CommentEditor :appointment-id="appointment.id" @added="onCommentAdded" />
+      </TabPanel>
+    </TabView>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import api from '@/services/api';
+import Card from 'primevue/card';
+import TabView from 'primevue/tabview';
+import TabPanel from 'primevue/tabpanel';
+import { useToast } from '@/plugins/toast';
+import CommentsThread from '@/components/comments/CommentsThread.vue';
+import CommentEditor from '@/components/comments/CommentEditor.vue';
+
+const route = useRoute();
+const toast = useToast();
+
+const appointment = ref<any>(null);
+
+const statusClasses: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-800',
+  assigned: 'bg-blue-100 text-blue-800',
+  in_progress: 'bg-yellow-100 text-yellow-800',
+  completed: 'bg-green-100 text-green-800',
+  rejected: 'bg-red-100 text-red-800',
+  redo: 'bg-purple-100 text-purple-800',
+};
+
+function format(date?: string) {
+  return date ? new Date(date).toLocaleString() : '';
+}
+
+const slaStatus = computed(() => {
+  const appt = appointment.value;
+  if (!appt) return 'none';
+  if (appt.sla_status) return appt.sla_status;
+  if (!appt.sla_end_at) return 'none';
+  const reference = appt.completed_at || new Date().toISOString();
+  return new Date(reference) <= new Date(appt.sla_end_at)
+    ? 'within'
+    : 'breached';
+});
+
+function hasThumb(file: any) {
+  if (file?.variants?.thumb) return true;
+  console.warn('TODO: needs signed URL endpoint');
+  return false;
+}
+
+async function load() {
+  const { data } = await api.get(`/appointments/${route.params.id}`);
+  appointment.value = data;
+}
+
+onMounted(load);
+
+function onCommentAdded(c: any) {
+  appointment.value.comments.push(c);
+}
+
+async function updateStatus(status: string) {
+  if (!appointment.value) return;
+  try {
+    await api.patch(`/appointments/${appointment.value.id}`, { status });
+    appointment.value.status = status;
+  } catch (e: any) {
+    if (e.status === 422) {
+      toast.add({ severity: 'error', summary: 'Invalid status transition', detail: '' });
+    }
+  }
+}
+
+const changeActions = [
+  { label: 'In Progress', value: 'in_progress' },
+  { label: 'Completed', value: 'completed' },
+  { label: 'Rejected', value: 'rejected' },
+  { label: 'Redo', value: 'redo' },
+];
+</script>


### PR DESCRIPTION
## Summary
- add appointment detail view with summary card, photo gallery and comments tab
- support comment mentions and optional attachments through new comment components
- route appointments.details to the new view

## Testing
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad83a2284c8323af66c3340bb7c9b6