### PR TITLE
Add JSON schema appointment form

### DIFF
--- a/frontend/src/components/forms/JsonSchemaForm.vue
+++ b/frontend/src/components/forms/JsonSchemaForm.vue
@@ -1,0 +1,130 @@
+<template>
+  <div v-if="schema && schema.properties">
+    <div v-for="(prop, name) in schema.properties" :key="name" class="mb-4">
+      <label :for="name" class="block font-medium mb-1">
+        {{ name }}<span v-if="isRequired(name)" class="text-red-600">*</span>
+      </label>
+      <template v-if="prop.enum">
+        <select
+          :id="name"
+          v-model="form[name]"
+          class="border rounded p-2 w-full"
+          :disabled="readonly"
+          @change="validateField(name)"
+        >
+          <option value="" disabled>Select...</option>
+          <option v-for="opt in prop.enum" :key="opt" :value="opt">{{ opt }}</option>
+        </select>
+      </template>
+      <template v-else>
+        <input
+          v-if="fieldType(prop) === 'text'"
+          :id="name"
+          type="text"
+          v-model="form[name]"
+          class="border rounded p-2 w-full"
+          :readonly="readonly"
+          @input="validateField(name)"
+        />
+        <input
+          v-else-if="fieldType(prop) === 'number'"
+          :id="name"
+          type="number"
+          v-model.number="form[name]"
+          class="border rounded p-2 w-full"
+          :readonly="readonly"
+          @input="validateField(name)"
+        />
+        <input
+          v-else-if="fieldType(prop) === 'date'"
+          :id="name"
+          type="date"
+          v-model="form[name]"
+          class="border rounded p-2 w-full"
+          :readonly="readonly"
+          @input="validateField(name)"
+        />
+        <input
+          v-else-if="fieldType(prop) === 'time'"
+          :id="name"
+          type="time"
+          v-model="form[name]"
+          class="border rounded p-2 w-full"
+          :readonly="readonly"
+          @input="validateField(name)"
+        />
+        <input
+          v-else-if="fieldType(prop) === 'boolean'"
+          :id="name"
+          type="checkbox"
+          v-model="form[name]"
+          :disabled="readonly"
+          @change="validateField(name)"
+        />
+      </template>
+      <div v-if="errors[name]" class="text-red-600 text-sm mt-1">{{ errors[name] }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch, onMounted } from 'vue';
+
+interface Schema {
+  properties: Record<string, any>;
+  required?: string[];
+}
+
+const props = defineProps<{ schema: Schema; modelValue: any; readonly?: boolean }>();
+const emit = defineEmits<{ (e: 'update:modelValue', value: any): void }>();
+
+const form = reactive<any>({ ...props.modelValue });
+const errors = reactive<Record<string, string>>({});
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    Object.assign(form, val || {});
+    if (props.schema?.required) {
+      props.schema.required.forEach((f) => validateField(f));
+    }
+  },
+  { deep: true },
+);
+
+watch(
+  form,
+  (val) => {
+    emit('update:modelValue', { ...val });
+  },
+  { deep: true },
+);
+
+function isRequired(name: string) {
+  return props.schema?.required?.includes(name);
+}
+
+function fieldType(prop: any) {
+  if (prop.enum) return 'enum';
+  if (prop.type === 'number' || prop.type === 'integer') return 'number';
+  if (prop.type === 'boolean') return 'boolean';
+  if (prop.type === 'string' && prop.format === 'date') return 'date';
+  if (prop.type === 'string' && prop.format === 'time') return 'time';
+  return 'text';
+}
+
+function validateField(name: string) {
+  const val = form[name];
+  if (isRequired(name) && (val === undefined || val === null || val === '')) {
+    errors[name] = 'Required';
+  } else {
+    delete errors[name];
+  }
+}
+
+onMounted(() => {
+  if (props.schema?.required) {
+    props.schema.required.forEach((f) => validateField(f));
+  }
+});
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -41,6 +41,30 @@ export const routes = [
     },
   },
   {
+    path: '/appointments/create',
+    name: 'appointments.create',
+    component: () => import('@/views/appointments/AppointmentForm.vue'),
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.appointmentCreate',
+      title: 'Create Appointment',
+      layout: 'app',
+      groupParent: 'appointments.list',
+    },
+  },
+  {
+    path: '/appointments/:id/edit',
+    name: 'appointments.edit',
+    component: () => import('@/views/appointments/AppointmentForm.vue'),
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.appointmentEdit',
+      title: 'Edit Appointment',
+      layout: 'app',
+      groupParent: 'appointments.list',
+    },
+  },
+  {
     path: '/manuals',
     name: 'manuals',
     component: () => import('@/views/ManualList.vue'),

--- a/frontend/src/views/appointments/AppointmentForm.vue
+++ b/frontend/src/views/appointments/AppointmentForm.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <h2 class="text-xl font-bold mb-4">{{ isEdit ? 'Edit' : 'Create' }} Appointment</h2>
+    <form @submit.prevent="onSubmit" class="max-w-lg">
+      <div class="mb-4">
+        <label class="block font-medium mb-1" for="type">Type<span class="text-red-600">*</span></label>
+        <select id="type" v-model="typeId" class="border rounded p-2 w-full" @change="onTypeChange">
+          <option value="">Select type</option>
+          <option v-for="t in types" :key="t.id" :value="t.id">{{ t.name }}</option>
+        </select>
+      </div>
+      <div class="mb-4">
+        <label class="block font-medium mb-1" for="scheduled">Scheduled At</label>
+        <input id="scheduled" type="datetime-local" v-model="scheduledAt" class="border rounded p-2 w-full" />
+      </div>
+      <div class="mb-4">
+        <label class="block font-medium mb-1" for="sla_start">SLA Start</label>
+        <input id="sla_start" type="datetime-local" v-model="slaStartAt" class="border rounded p-2 w-full" />
+      </div>
+      <div class="mb-4">
+        <label class="block font-medium mb-1" for="sla_end">SLA End</label>
+        <input id="sla_end" type="datetime-local" v-model="slaEndAt" class="border rounded p-2 w-full" />
+      </div>
+      <div class="mb-4" v-if="isEdit">
+        <label class="block font-medium mb-1" for="status">Status</label>
+        <select id="status" v-model="status" class="border rounded p-2 w-full">
+          <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
+        </select>
+      </div>
+      <JsonSchemaForm
+        v-if="currentSchema"
+        :key="typeId"
+        v-model="formData"
+        :schema="currentSchema"
+      />
+      <div v-if="serverError" class="text-red-600 text-sm mt-2">{{ serverError }}</div>
+      <div class="mt-4">
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded" :disabled="!canSubmit">Submit</button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import api from '@/services/api';
+import JsonSchemaForm from '@/components/forms/JsonSchemaForm.vue';
+
+const router = useRouter();
+const route = useRoute();
+
+const types = ref<any[]>([]);
+const typeId = ref<string | number>('');
+const formData = ref<any>({});
+const scheduledAt = ref('');
+const slaStartAt = ref('');
+const slaEndAt = ref('');
+const status = ref('');
+const serverError = ref('');
+const originalStatus = ref('');
+
+const statusOptions = ['draft', 'assigned', 'in_progress', 'completed', 'rejected', 'redo'];
+
+const isEdit = computed(() => route.name === 'appointments.edit');
+
+onMounted(async () => {
+  const { data } = await api.get('/appointment-types');
+  types.value = data;
+  if (isEdit.value) {
+    const res = await api.get(`/appointments/${route.params.id}`);
+    const appt = res.data;
+    typeId.value = appt.type?.id || appt.appointment_type_id;
+    formData.value = appt.form_data || {};
+    scheduledAt.value = toInput(appt.scheduled_at);
+    slaStartAt.value = toInput(appt.sla_start_at);
+    slaEndAt.value = toInput(appt.sla_end_at);
+    status.value = appt.status;
+    originalStatus.value = appt.status;
+  }
+});
+
+function onTypeChange() {
+  formData.value = {};
+}
+
+const currentSchema = computed(() => {
+  const t = types.value.find((t) => t.id === typeId.value);
+  return t ? t.form_schema : null;
+});
+
+const requiredFields = computed(() => currentSchema.value?.required || []);
+
+const canSubmit = computed(() => {
+  if (!typeId.value) return false;
+  return requiredFields.value.every((f: string) => {
+    const val = formData.value[f];
+    return !(val === undefined || val === null || val === '');
+  });
+});
+
+function toInput(v?: string) {
+  return v ? v.substring(0, 16) : '';
+}
+
+function toIso(v: string) {
+  return v ? new Date(v).toISOString() : undefined;
+}
+
+async function onSubmit() {
+  serverError.value = '';
+  const payload: any = {
+    appointment_type_id: typeId.value,
+    form_data: formData.value,
+  };
+  if (scheduledAt.value) payload.scheduled_at = toIso(scheduledAt.value);
+  if (slaStartAt.value) payload.sla_start_at = toIso(slaStartAt.value);
+  if (slaEndAt.value) payload.sla_end_at = toIso(slaEndAt.value);
+  try {
+    if (isEdit.value) {
+      if (status.value && status.value !== originalStatus.value) {
+        payload.status = status.value;
+      }
+      await api.patch(`/appointments/${route.params.id}`, payload);
+      router.push({ name: 'appointments.details', params: { id: route.params.id } });
+    } else {
+      const res = await api.post('/appointments', payload);
+      router.push({ name: 'appointments.details', params: { id: res.data.id } });
+    }
+  } catch (e: any) {
+    serverError.value = e.message || 'Failed to save';
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add minimal JsonSchemaForm component for dynamic forms
- create appointment creation/edit view with schema-driven fields
- add routes for appointment create/edit

## Testing
- `npm run lint`
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad851df0608323974023ae6914dc73