### PR TITLE
feat: enhance header interactions

### DIFF
--- a/frontend/src/Layout/Header.vue
+++ b/frontend/src/Layout/Header.vue
@@ -17,6 +17,19 @@
             </li>
           </ul>
         </nav>
+        <button
+          class="text-gray-700 dark:text-gray-100"
+          @click="ui.toggleTheme"
+        >
+          <i :class="ui.theme === 'dark' ? 'pi pi-sun' : 'pi pi-moon'"></i>
+        </button>
+        <Bell />
+        <input
+          v-if="dev"
+          v-model="tenantId"
+          class="border rounded px-1 py-0.5 text-sm w-24"
+          placeholder="Tenant"
+        />
         <div v-if="auth.user" class="relative">
           <button
             class="flex items-center space-x-2 text-gray-700 dark:text-gray-100"
@@ -28,6 +41,21 @@
             v-if="profileOpen"
             class="absolute right-0 mt-2 w-32 bg-white dark:bg-slate-700 border rounded shadow"
           >
+            <router-link
+              to="/settings/profile"
+              class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-slate-600"
+              @click="profileOpen = false"
+            >
+              Profile
+            </router-link>
+            <router-link
+              v-if="isAdmin"
+              to="/settings/branding"
+              class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-slate-600"
+              @click="profileOpen = false"
+            >
+              Branding
+            </router-link>
             <button
               @click="logout"
               class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-slate-600"
@@ -50,16 +78,27 @@
   </div>
 </template>
 <script setup>
-import { ref } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { topMenu } from '@/constant/data'
 import { useAuthStore } from '@/stores/auth'
+import { useUiStore } from '@/store/ui'
+import { useTenantStore } from '@/store/tenant'
+import Bell from '@/components/notifications/Bell.vue'
 
 const show = ref(false)
 const profileOpen = ref(false)
 const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
+const ui = useUiStore()
+const tenant = useTenantStore()
+const tenantId = ref(tenant.tenantId)
+const dev = import.meta.env.DEV
+const isAdmin = computed(() =>
+  auth.user?.roles?.some((r) => ['ClientAdmin', 'SuperAdmin'].includes(r.name))
+)
+watch(tenantId, (id) => tenant.setTenant(id))
 const isActive = (link) => route.path === link
 
 const logout = async () => {


### PR DESCRIPTION
## Summary
- add theme toggle, notification bell, and dev tenant selector to header
- expand profile menu with profile, branding, and logout options

## Testing
- `npm test` *(fails: matchMedia is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad92bb38208323a1b6d95cac1c0cf4