### PR TITLE
feat: add global toast and loading overlay

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,4 +1,5 @@
 <template>
+  <Toast />
   <component :is="layoutComponent" />
 </template>
 
@@ -6,6 +7,7 @@
 import { computed, defineComponent, h } from 'vue';
 import { useRoute, RouterView } from 'vue-router';
 import AppLayout from './Layout/AppLayout.vue';
+import Toast from '@/components/ui/Toast.vue';
 
 const route = useRoute();
 

--- a/frontend/src/components/ui/LoadingOverlay.vue
+++ b/frontend/src/components/ui/LoadingOverlay.vue
@@ -1,0 +1,12 @@
+<template>
+  <div
+    v-if="active"
+    class="fixed inset-0 z-40 flex items-center justify-center bg-black/50"
+  >
+    <div class="w-8 h-8 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ active: boolean }>();
+</script>

--- a/frontend/src/components/ui/Toast.vue
+++ b/frontend/src/components/ui/Toast.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="fixed top-4 right-4 z-50 space-y-2">
+    <div
+      v-for="t in toasts"
+      :key="t.id"
+      class="px-4 py-2 rounded shadow text-white"
+      :class="t.type === 'error' ? 'bg-red-600' : 'bg-gray-800'"
+    >
+      {{ t.message }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { useToastStore } from '@/store/toast';
+
+const toastStore = useToastStore();
+const { toasts } = storeToRefs(toastStore);
+</script>

--- a/frontend/src/lib/http.js
+++ b/frontend/src/lib/http.js
@@ -6,6 +6,7 @@ import {
 } from '../config/app';
 import { useAuthStore } from '../store/auth';
 import { useTenantStore } from '../store/tenant';
+import { useToastStore } from '../store/toast';
 
 const http = axios.create({
   baseURL: API_BASE_URL,
@@ -37,10 +38,16 @@ http.interceptors.response.use(
         await auth.logout();
       }
     }
+    const toast = useToastStore();
     const normalized = {
-      status: response?.status,
-      message: response?.data?.message || error.message,
+      status: response?.status ?? 0,
+      code: response?.data?.code,
+      message: response
+        ? response.data?.message || error.message
+        : 'Network error. Please try again.',
+      details: response?.data?.details,
     };
+    toast.add(normalized.message);
     return Promise.reject(normalized);
   }
 );

--- a/frontend/src/store/toast.js
+++ b/frontend/src/store/toast.js
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia';
+
+let nextId = 1;
+
+export const useToastStore = defineStore('toast', {
+  state: () => ({
+    toasts: []
+  }),
+  actions: {
+    add(message, type = 'error') {
+      const id = nextId++;
+      this.toasts.push({ id, message, type });
+      // auto-remove after 5s
+      setTimeout(() => {
+        this.remove(id);
+      }, 5000);
+    },
+    remove(id) {
+      this.toasts = this.toasts.filter(t => t.id !== id);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add Pinia toast store and global `<Toast/>` component
- normalize HTTP errors and send toasts for failures
- introduce `<LoadingOverlay/>` for blocking UI during long ops

## Testing
- `npm test` (fails: matchMedia is not a function)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad95605640832386cdae4130662513