### PR TITLE
Redirect to login on unauthorized and improve login styling

### DIFF
--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -1,17 +1,31 @@
 <template>
-  <div class="max-w-sm mx-auto py-10">
+  <div class="max-w-sm mx-auto py-10 px-4">
     <form @submit.prevent="submit" class="space-y-4">
-      <h1 class="text-xl font-bold">Sign in</h1>
-      <div>
-        <label class="block text-sm">Email</label>
-        <input v-model="email" type="email" class="border p-2 w-full" required />
+      <h1 class="text-xl font-bold text-gray-800">Sign in</h1>
+      <div class="space-y-1">
+        <label class="block text-sm text-gray-700">Email</label>
+        <input
+          v-model="email"
+          type="email"
+          class="border border-gray-300 rounded-md px-3 py-2 w-full focus-ring"
+          required
+        />
       </div>
-      <div>
-        <label class="block text-sm">Password</label>
-        <input v-model="password" type="password" class="border p-2 w-full" required />
+      <div class="space-y-1">
+        <label class="block text-sm text-gray-700">Password</label>
+        <input
+          v-model="password"
+          type="password"
+          class="border border-gray-300 rounded-md px-3 py-2 w-full focus-ring"
+          required
+        />
       </div>
-      <div v-if="error" class="text-red-500 text-sm">{{ error }}</div>
-      <button type="submit" :disabled="loading" class="bg-blue-500 text-white px-4 py-2 w-full">
+      <div v-if="error" class="text-danger-500 text-sm">{{ error }}</div>
+      <button
+        type="submit"
+        :disabled="loading"
+        class="bg-primary-500 hover:bg-primary-600 text-white px-4 py-2 w-full rounded-md disabled:opacity-50"
+      >
         {{ loading ? '...' : 'Sign in' }}
       </button>
     </form>


### PR DESCRIPTION
## Summary
- redirect to login on 401 API responses
- restyle login form with DashCode tokens

## Testing
- `npm run lint`
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9749c6008323b9d8c439e6801470