### PR TITLE
fix: define default primary ring color

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -27,6 +27,7 @@ module.exports = {
         "vtd-primary": colors.sky,
         "vtd-secondary": colors.gray,
         primary: {
+          DEFAULT: "#4669fa",
           50: "#F6F8FF",
           100: "#EDF0FF",
           200: "#D1DAFE",


### PR DESCRIPTION
## Summary
- add DEFAULT shade for Tailwind `primary` color so focus ring utilities are generated

## Testing
- `npm run lint`
- `npm test` *(fails: matchMedia is not a function; nextTick is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad982fcbec8323ad51a0fb00214aa9