### PR TITLE
Redirect to login after unauthorized responses

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -67,7 +67,7 @@ api.interceptors.response.use(
     // When the API responds with 401, clear auth state and redirect to login.
     if (status === 401) {
       const auth = useAuthStore();
-      await auth.logout();
+      await auth.logout(true);
       window.location.href = '/auth/login';
     }
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -44,10 +44,12 @@ export const useAuthStore = defineStore('auth', {
       const { data } = await api.get('/me');
       this.user = data;
     },
-    async logout() {
-      try {
-        await api.post('/auth/logout');
-      } catch (e) {}
+    async logout(skipServer = false) {
+      if (!skipServer) {
+        try {
+          await api.post('/auth/logout');
+        } catch (e) {}
+      }
       this.accessToken = '';
       this.refreshToken = '';
       this.user = null;


### PR DESCRIPTION
## Summary
- Clear auth state locally without server call when encountering 401 responses
- Redirect any unauthorized user to `/auth/login`

## Testing
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9a4980fc8323a81dfca0d753a4d5