### PR TITLE
fix: prevent login redirect loop

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -77,7 +77,9 @@ api.interceptors.response.use(
         } catch (e) {}
       }
       await auth.logout(true);
-      window.location.href = '/auth/login';
+      if (window.location.pathname !== '/auth/login') {
+        window.location.href = '/auth/login';
+      }
     }
 
     if (status && status >= 500) {


### PR DESCRIPTION
## Summary
- avoid reloading login page when API responses return 401

## Testing
- `npm test` *(fails: matchMedia is not a function, nextTick is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ada07484e083238793aa55718fe83e