### PR TITLE
fix: resolve vue component imports

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src'),
     },
+    extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },
   build: {
     outDir: '../public',


### PR DESCRIPTION
## Summary
- ensure Vite resolves `.vue` files so `@/components/ui/Icon` imports work

## Testing
- `npm test` *(fails: matchMedia is not a function)*
- `npm run build` *(fails: Preprocessor dependency "sass" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ada8ace2ac8323a159081b0de4252c