### PR TITLE
Fix missing super admin menus after refresh

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -342,6 +342,12 @@ router.beforeEach(async (to, from, next) => {
     } catch (e) {}
   }
 
+  if (auth.isAuthenticated && !auth.user) {
+    try {
+      await auth.fetchUser();
+    } catch (e) {}
+  }
+
   if (to.meta.requiresAuth && !auth.isAuthenticated) {
     return next('/auth/login');
   }


### PR DESCRIPTION
## Summary
- fetch current user on navigation when token exists but user not loaded to retain role-based menus

## Testing
- `npm test` *(fails: matchMedia is not a function; nextTick is not a function)*
- `npm run lint` *(fails: Attribute order warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ada9e591d48323b9597954f4c67c7f