### PR TITLE
feat: integrate Dashcode server table component across lists

### DIFF
--- a/frontend/src/components/datatable/DashcodeServerTable.vue
+++ b/frontend/src/components/datatable/DashcodeServerTable.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="bg-white dark:bg-slate-800 rounded-md shadow-base w-full">
+    <div
+      v-if="$slots.search || $slots.filters"
+      class="flex flex-col md:flex-row md:items-center md:justify-between p-4 gap-4"
+    >
+      <div class="flex-1">
+        <slot name="search" :search="search" />
+      </div>
+      <div class="flex-1 md:text-right">
+        <slot name="filters" />
+      </div>
+    </div>
+    <div v-if="loading || !rows.length" class="p-4">
+      <SkeletonTable :count="perPage" />
+    </div>
+    <div v-else>
+      <div class="overflow-x-auto">
+        <table
+          class="min-w-full divide-y divide-slate-100 table-fixed dark:divide-slate-700"
+        >
+          <thead
+            class="bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300"
+          >
+            <tr>
+              <th
+                v-for="col in tableColumns"
+                :key="col.field"
+                class="table-th cursor-pointer select-none"
+                @click="col.sortable !== false ? toggleSort(col.field) : null"
+              >
+                <div class="flex items-center">
+                  <span>{{ col.label }}</span>
+                  <span v-if="col.sortable !== false" class="ml-1">
+                    <Icon
+                      v-if="sort && sort.field === col.field && sort.type === 'asc'"
+                      icon="heroicons-outline:chevron-up"
+                      class="w-4 h-4"
+                    />
+                    <Icon
+                      v-else-if="sort && sort.field === col.field && sort.type === 'desc'"
+                      icon="heroicons-outline:chevron-down"
+                      class="w-4 h-4"
+                    />
+                    <Icon
+                      v-else
+                      icon="heroicons-outline:chevron-up-down"
+                      class="w-4 h-4 opacity-50"
+                    />
+                  </span>
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="bg-white divide-y divide-slate-100 dark:bg-slate-800 dark:divide-slate-700"
+          >
+            <tr
+              v-for="row in rows"
+              :key="row[rowKey]"
+              class="hover:bg-slate-50 dark:hover:bg-slate-700"
+            >
+              <td
+                v-for="col in columns"
+                :key="col.field"
+                class="table-td"
+              >
+                <span v-if="col.html" v-html="row[col.field]" />
+                <span v-else>{{ row[col.field] }}</span>
+              </td>
+              <td v-if="hasActions" class="table-td">
+                <slot name="actions" :row="row" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="p-4">
+        <Pagination
+          :total="total"
+          :current="page"
+          :perPage="perPage"
+          :pageChanged="(p) => (page.value = p)"
+          :perPageChanged="(pp) => (perPage.value = pp)"
+          :options="perPageOptions"
+          enableSelect
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, useSlots } from 'vue';
+import Icon from '@/components/ui/Icon';
+import Pagination from '@/components/ui/Pagination';
+import SkeletonTable from '@/components/ui/Skeleton/Table.vue';
+import useServerTable from '@/composables/useServerTable';
+
+interface Column {
+  label: string;
+  field: string;
+  sortable?: boolean;
+  html?: boolean;
+}
+
+const props = defineProps({
+  columns: { type: Array as () => Column[], required: true },
+  fetcher: { type: Function as unknown as () => any, required: true },
+  rowKey: { type: String, default: 'id' },
+  perPageOptions: {
+    type: Array as () => { value: number; label: string }[],
+    default: () => [
+      { value: 10, label: '10' },
+      { value: 25, label: '25' },
+      { value: 50, label: '50' },
+    ],
+  },
+});
+
+const slots = useSlots();
+
+const { rows, total, page, perPage, sort, search, loading } = useServerTable(
+  props.fetcher,
+);
+
+const tableColumns = computed(() => {
+  if (slots.actions) {
+    return [...props.columns, { label: 'Actions', field: '__actions' }];
+  }
+  return props.columns;
+});
+
+const hasActions = computed(() => Boolean(slots.actions));
+
+function toggleSort(field: string) {
+  if (!field) return;
+  if (!sort.value || sort.value.field !== field) {
+    sort.value = { field, type: 'asc' } as any;
+  } else if (sort.value.type === 'asc') {
+    sort.value = { field, type: 'desc' } as any;
+  } else {
+    sort.value = null;
+  }
+}
+</script>
+
+<style scoped>
+.table-th {
+  @apply md:px-5 px-3 py-3 text-left text-sm font-medium text-slate-700 dark:text-slate-300;
+}
+.table-td {
+  @apply md:px-5 px-3 py-3 text-sm text-slate-600 dark:text-slate-300;
+}
+</style>
+

--- a/frontend/src/views/appointments/AppointmentsList.vue
+++ b/frontend/src/views/appointments/AppointmentsList.vue
@@ -9,7 +9,11 @@
       <input type="date" v-model="startDate" class="border rounded p-2" />
       <input type="date" v-model="endDate" class="border rounded p-2" />
     </div>
-    <ServerDataTable :key="tableKey" :columns="columns" :fetcher="fetchAppointments">
+    <DashcodeServerTable
+      :key="tableKey"
+      :columns="columns"
+      :fetcher="fetchAppointments"
+    >
       <template #actions="{ row }">
         <div class="flex gap-2">
           <button class="text-blue-600" @click="view(row.id)">View</button>
@@ -23,14 +27,14 @@
           </button>
         </div>
       </template>
-    </ServerDataTable>
+    </DashcodeServerTable>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import ServerDataTable from '@/components/datatable/ServerDataTable.vue';
+import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
 import api from '@/services/api';
 import { useToast } from '@/plugins/toast';
 

--- a/frontend/src/views/manuals/ManualsList.vue
+++ b/frontend/src/views/manuals/ManualsList.vue
@@ -1,56 +1,88 @@
 <template>
   <div>
     <h2 class="text-xl font-bold mb-4">Manuals</h2>
-    <div class="flex gap-2 mb-4">
-      <input
-        v-model="q"
-        placeholder="Search"
-        class="border p-2 flex-1"
-        @input="load"
-      />
-      <button
-        class="bg-blue-600 text-white px-4 py-2 rounded"
-        @click="create"
-      >
-        Upload Manual
-      </button>
-    </div>
-    <table class="w-full border">
-      <thead>
-        <tr class="bg-gray-100 text-left">
-          <th class="p-2 border">File</th>
-          <th class="p-2 border">Category</th>
-          <th class="p-2 border">Tags</th>
-          <th class="p-2 border">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="m in manuals" :key="m.id">
-          <td class="border p-2">{{ m.file?.filename }}</td>
-          <td class="border p-2">{{ m.category }}</td>
-          <td class="border p-2">{{ (m.tags || []).join(', ') }}</td>
-          <td class="border p-2 space-x-2">
-            <button class="text-blue-600" @click="download(m)">Download</button>
-            <button class="text-green-600" @click="edit(m)">Edit</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <DashcodeServerTable
+      :key="tableKey"
+      :columns="columns"
+      :fetcher="fetchManuals"
+    >
+      <template #search="{ search }">
+        <div class="flex gap-2">
+          <input
+            v-model="search.value"
+            placeholder="Search"
+            class="border p-2 flex-1"
+          />
+          <button
+            class="bg-blue-600 text-white px-4 py-2 rounded"
+            @click="create"
+          >
+            Upload Manual
+          </button>
+        </div>
+      </template>
+      <template #actions="{ row }">
+        <div class="space-x-2">
+          <button class="text-blue-600" @click="download(row)">Download</button>
+          <button class="text-green-600" @click="edit(row)">Edit</button>
+        </div>
+      </template>
+    </DashcodeServerTable>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref } from 'vue';
 import { useRouter } from 'vue-router';
+import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
 import api from '@/services/api';
 
-const manuals = ref<any[]>([]);
-const q = ref('');
 const router = useRouter();
+const all = ref<any[]>([]);
+const tableKey = ref(0);
 
-async function load() {
-  const { data } = await api.get('/manuals', q.value ? { params: { q: q.value } } : undefined);
-  manuals.value = data;
+const columns = [
+  { label: 'File', field: 'file', sortable: true },
+  { label: 'Category', field: 'category', sortable: true },
+  { label: 'Tags', field: 'tags', sortable: false },
+];
+
+async function fetchManuals({ page, perPage, sort, search }: any) {
+  if (!all.value.length) {
+    const { data } = await api.get('/manuals');
+    all.value = data;
+  }
+  let rows = all.value.slice();
+  if (search) {
+    const q = String(search).toLowerCase();
+    rows = rows.filter((r) =>
+      [r.file?.filename, r.category, ...(r.tags || [])].some((v) =>
+        String(v ?? '').toLowerCase().includes(q),
+      ),
+    );
+  }
+  if (sort && sort.field) {
+    rows.sort((a: any, b: any) => {
+      const fa = a[sort.field] ?? '';
+      const fb = b[sort.field] ?? '';
+      if (fa < fb) return sort.type === 'asc' ? -1 : 1;
+      if (fa > fb) return sort.type === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }
+  const total = rows.length;
+  const start = (page - 1) * perPage;
+  const paged = rows.slice(start, start + perPage).map((r: any) => ({
+    id: r.id,
+    file: r.file?.filename,
+    category: r.category,
+    tags: (r.tags || []).join(', '),
+  }));
+  return { rows: paged, total };
+}
+
+function reload() {
+  tableKey.value++;
 }
 
 function create() {
@@ -70,7 +102,5 @@ async function download(m: any) {
   a.click();
   window.URL.revokeObjectURL(url);
 }
-
-onMounted(load);
 </script>
 

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -1,48 +1,68 @@
 <template>
   <div>
     <h2 class="text-xl font-bold mb-4">Tenants</h2>
-    <table class="min-w-full border">
-      <thead>
-        <tr class="bg-gray-100 text-left">
-          <th class="p-2 border">ID</th>
-          <th class="p-2 border">Name</th>
-          <th class="p-2 border">Phone</th>
-          <th class="p-2 border">Address</th>
-          <th class="p-2 border w-32">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="t in tenants" :key="t.id" class="border-t">
-          <td class="p-2 border">{{ t.id }}</td>
-          <td class="p-2 border">{{ t.name }}</td>
-          <td class="p-2 border">{{ t.phone }}</td>
-          <td class="p-2 border">{{ t.address }}</td>
-          <td class="p-2 border">
-            <button class="text-blue-600" @click="impersonate(t)">Impersonate</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <DashcodeServerTable
+      :key="tableKey"
+      :columns="columns"
+      :fetcher="fetchTenants"
+    >
+      <template #actions="{ row }">
+        <button class="text-blue-600" @click="impersonate(row)">Impersonate</button>
+      </template>
+    </DashcodeServerTable>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref } from 'vue';
+import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
 import api from '@/services/api';
 import { useAuthStore } from '@/stores/auth';
 
-const tenants = ref<any[]>([]);
 const auth = useAuthStore();
+const tableKey = ref(0);
+const all = ref<any[]>([]);
 
-async function load() {
-  const { data } = await api.get('/tenants');
-  tenants.value = data;
+const columns = [
+  { label: 'ID', field: 'id', sortable: true },
+  { label: 'Name', field: 'name', sortable: true },
+  { label: 'Phone', field: 'phone', sortable: true },
+  { label: 'Address', field: 'address', sortable: false },
+];
+
+async function fetchTenants({ page, perPage, sort, search }: any) {
+  if (!all.value.length) {
+    const { data } = await api.get('/tenants');
+    all.value = data;
+  }
+  let rows = all.value.slice();
+  if (search) {
+    const q = String(search).toLowerCase();
+    rows = rows.filter((r) =>
+      Object.values(r).some((v) => String(v ?? '').toLowerCase().includes(q)),
+    );
+  }
+  if (sort && sort.field) {
+    rows.sort((a: any, b: any) => {
+      const fa = a[sort.field] ?? '';
+      const fb = b[sort.field] ?? '';
+      if (fa < fb) return sort.type === 'asc' ? -1 : 1;
+      if (fa > fb) return sort.type === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }
+  const total = rows.length;
+  const start = (page - 1) * perPage;
+  const paged = rows.slice(start, start + perPage);
+  return { rows: paged, total };
+}
+
+function reload() {
+  tableKey.value++;
 }
 
 async function impersonate(t: any) {
   await auth.impersonate(t.id, t.name);
 }
-
-onMounted(load);
 </script>
 


### PR DESCRIPTION
## Summary
- add DashcodeServerTable component with Dashcode styling, slots, and server data handling
- migrate appointments, employees, types, tenants, and manuals lists to the new table

## Testing
- `npm run lint` *(fails: Name "Header" is reserved in HTML...)*
- `npm test` *(fails: matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68adb7593ff48323877c4c695164cd84