### PR TITLE
Add appointments calendar view with FullCalendar

### DIFF
--- a/frontend/src/assets/scss/app/_calander.scss
+++ b/frontend/src/assets/scss/app/_calander.scss
@@ -1,0 +1,175 @@
+.fc-toolbar-chunk button {
+  height: 50px;
+  //min-width: 70px;
+  &.fc-prev-button {
+    &:after {
+      // content: url("https://api.iconify.design/akar-icons/chevron-left.svg?color=white&width=24");
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+  &.fc-next-button {
+    &:after {
+      //content: url("https://api.iconify.design/akar-icons/chevron-right.svg?color=white&width=24");
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+}
+.fc-button {
+  font-size: 14px !important;
+  line-height: 14px !important;
+  height: auto !important;
+  text-transform: capitalize !important;
+  font-family: Inter !important;
+  padding: 12px 20px 12px 20px !important;
+}
+.fc .fc-button-primary {
+  color: #000 !important;
+  &:hover {
+    color: #fff !important;
+  }
+}
+.fc .fc-button-primary.fc-button-active {
+  color: #fff !important;
+}
+.dark {
+  .fc .fc-button-primary {
+    color: #fff !important;
+  }
+}
+.fc .fc-button-primary {
+  background: transparent !important;
+  @apply dark:text-white border-slate-100 dark:border-slate-700;
+}
+.fc .fc-button-primary:not(:disabled):active,
+.fc .fc-button-primary:not(:disabled).fc-button-active,
+.fc .fc-button-primary:hover {
+  background: #111112 !important;
+}
+.dark {
+  .fc .fc-button-primary:not(:disabled):active,
+  .fc .fc-button-primary:not(:disabled).fc-button-active,
+  .fc .fc-button-primary:hover {
+    background: #0f172a !important;
+  }
+}
+.fc .fc-button-primary:disabled {
+  background: #a0aec0 !important;
+  border-color: #a0aec0 !important;
+  @apply cursor-not-allowed;
+}
+.dark {
+  .fc .fc-button-primary:disabled {
+    background: #334155 !important;
+    border-color: #334155 !important;
+  }
+}
+.fc .fc-daygrid-day.fc-day-today {
+  background: rgba(95, 99, 242, 0.04) !important;
+}
+.dark {
+  .fc .fc-daygrid-day.fc-day-today {
+    background: #334155 !important;
+  }
+}
+.fc .fc-button-primary:focus {
+  box-shadow: none !important;
+}
+.fc-theme-standard .fc-scrollgrid {
+  border-color: #eef1f9 !important;
+}
+.dark {
+  .fc-theme-standard .fc-scrollgrid {
+    border-color: #334155 !important;
+  }
+}
+.fc-theme-standard td,
+.fc-theme-standard th {
+  @apply border-slate-100 dark:border-slate-700;
+}
+.fc-col-header-cell .fc-scrollgrid-sync-inner {
+  @apply bg-slate-50 dark:bg-slate-700  text-xs text-slate-500 dark:text-slate-300 font-normal py-3;
+}
+.fc-daygrid-day-top {
+  @apply text-sm px-3 py-2  text-slate-900 dark:text-white font-normal;
+}
+.fc-h-event .fc-event-main-frame {
+  @apply justify-center text-center w-max mx-auto;
+  .fc-event-time {
+    @apply font-normal flex-none;
+  }
+}
+.fc-event-time {
+  @apply text-sm font-normal;
+}
+.fc-event-title {
+  font-size: 14px !important;
+  font-weight: 300 !important;
+}
+.fc .fc-toolbar-title {
+  @apply text-lg font-normal text-slate-600 dark:text-slate-300;
+}
+// event css
+.fc-daygrid-event-dot {
+  @apply hidden;
+}
+.dashcode-calender {
+  .bg-primary-500 {
+    @apply bg-[#4669FA] border-none text-white text-center px-2 font-medium text-sm;
+  }
+  .bg-secondary-500 {
+    @apply bg-[#A0AEC0] border-none text-white text-center px-2 font-medium text-sm;
+  }
+  .bg-danger-500 {
+    @apply bg-[#F1595C] border-none text-white text-center px-2 font-medium text-sm;
+  }
+  .bg-info {
+    @apply bg-[#0CE7FA] border-none text-white text-center px-2 font-medium text-sm;
+  }
+  .bg-warning-500 {
+    @apply bg-[#FA916B] border-none text-white text-center px-2 font-medium text-sm;
+  }
+  .bg-success-500 {
+    @apply bg-[#50C793] border-none text-white text-center px-2 font-medium text-sm;
+  }
+  .bg-slate-800 {
+    @apply bg-[#222] border-none text-white text-center px-2 font-medium text-sm;
+  }
+}
+@media (max-width: 981px) {
+  .fc-button-group,
+  .fc .fc-toolbar {
+    display: block !important;
+  }
+  .fc .fc-toolbar {
+    @apply space-y-4;
+  }
+  .fc-toolbar-chunk {
+    @apply space-y-4;
+  }
+  .fc .fc-button {
+    padding: 0.4em 0.65em !important;
+  }
+}
+.fc .fc-timegrid-axis-cushion,
+.fc .fc-timegrid-slot-label-cushion {
+  @apply dark:text-slate-300;
+}
+.fc .fc-list-event:hover td {
+  @apply bg-inherit;
+}
+.fc .fc-list-event-dot {
+  @apply hidden;
+}
+.fc-direction-ltr .fc-list-day-text,
+.fc-direction-rtl .fc-list-day-side-text,
+.fc-direction-ltr .fc-list-day-side-text,
+.fc-direction-rtl .fc-list-day-text {
+  font-size: 16px;
+  font-weight: 500;
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -29,6 +29,18 @@ export const routes = [
     },
   },
   {
+    path: '/appointments/calendar',
+    name: 'appointments.calendar',
+    component: () => import('@/views/appointments/Calendar.vue'),
+    meta: {
+      requiresAuth: true,
+      breadcrumb: 'routes.appointments',
+      title: 'Appointments Calendar',
+      layout: 'app',
+      groupParent: 'appointments.list',
+    },
+  },
+  {
     path: '/appointments/:id',
     name: 'appointments.details',
     component: () => import('@/views/appointments/AppointmentDetails.vue'),

--- a/frontend/src/views/appointments/Calendar.vue
+++ b/frontend/src/views/appointments/Calendar.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    <div class="card">
+      <div class="dashcode-calender">
+        <FullCalendar :options="calendarOptions" />
+      </div>
+    </div>
+    <Modal :activeModal="showCreate" @close="showCreate = false" title="Create Appointment">
+      <div class="flex justify-end space-x-3">
+        <button class="btn btn-light" @click="showCreate = false">Cancel</button>
+        <button class="btn btn-success" @click="create">Create</button>
+      </div>
+    </Modal>
+    <Modal :activeModal="showEvent" @close="showEvent = false" title="Appointment">
+      <div class="flex justify-end space-x-3">
+        <button class="btn btn-light" @click="view">View</button>
+        <button class="btn btn-success" @click="edit">Edit</button>
+      </div>
+    </Modal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import FullCalendar from '@fullcalendar/vue3';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import '@fullcalendar/core/vdom';
+import Modal from '@/components/ui/Modal';
+import { useAppointmentsStore } from '@/stores/appointments';
+
+const router = useRouter();
+const store = useAppointmentsStore();
+
+const showCreate = ref(false);
+const showEvent = ref(false);
+const selectedDate = ref('');
+const selectedEvent = ref<any>(null);
+
+onMounted(() => {
+  if (!store.appointments.length) {
+    store.fetch();
+  }
+});
+
+const events = computed(() =>
+  store.appointments.map((a: any) => ({
+    id: a.id,
+    title: a.title || a.type?.name || `Appointment ${a.id}`,
+    start: a.scheduled_at,
+    end: a.sla_end_at || a.scheduled_at,
+    extendedProps: { appointment: a },
+  })),
+);
+
+const calendarOptions = computed(() => ({
+  plugins: [dayGridPlugin, interactionPlugin],
+  initialView: 'dayGridMonth',
+  events: events.value,
+  dateClick(info: any) {
+    selectedDate.value = info.dateStr;
+    showCreate.value = true;
+  },
+  eventClick(info: any) {
+    selectedEvent.value = info.event;
+    showEvent.value = true;
+  },
+}));
+
+function create() {
+  showCreate.value = false;
+  router.push({ name: 'appointments.create', query: { date: selectedDate.value } });
+}
+
+function view() {
+  if (!selectedEvent.value) return;
+  showEvent.value = false;
+  router.push({ name: 'appointments.details', params: { id: selectedEvent.value.id } });
+}
+
+function edit() {
+  if (!selectedEvent.value) return;
+  showEvent.value = false;
+  router.push({ name: 'appointments.edit', params: { id: selectedEvent.value.id } });
+}
+</script>
+


### PR DESCRIPTION
## Summary
- add Calendar.vue to display appointments using Dashcode FullCalendar
- add /appointments/calendar route
- include Dashcode calendar SCSS styles

## Testing
- `npm run lint` *(fails: Attribute order warnings and 13 errors)*
- `npm test` *(fails: missing module clsx, matchMedia not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68adb91aa3f0832383a9882cf44df330