### PR TITLE
feat: refactor manuals list to Dashcode components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "vue-toastification": "^2.0.0-rc.5",
         "vue3-apexcharts": "1.4.1",
         "vue3-click-away": "^1.2.4",
+        "vue3-dropzone": "^2.2.1",
         "vue3-perfect-scrollbar": "^1.6.1"
       },
       "devDependencies": {
@@ -2548,6 +2549,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.16",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
@@ -3964,6 +3974,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+      "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/fill-range": {
@@ -7463,6 +7485,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8005,6 +8033,19 @@
       "resolved": "https://registry.npmjs.org/vue3-click-away/-/vue3-click-away-1.2.4.tgz",
       "integrity": "sha512-O9Z2KlvIhJT8OxaFy04eiZE9rc1Mk/bp+70dLok68ko3Kr8AW5dU+j8avSk4GDQu94FllSr4m5ul4BpzlKOw1A==",
       "license": "MIT"
+    },
+    "node_modules/vue3-dropzone": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vue3-dropzone/-/vue3-dropzone-2.2.1.tgz",
+      "integrity": "sha512-TWV/BWTMHePoAcHVn+S5a+a69S1Hwkpdn1LlcBkzvesGZTBqL0TDnKuXWMrF+aWlPLVBUfRJO0uIy9+n2jkDxA==",
+      "license": "ISC",
+      "dependencies": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.2.4"
+      },
+      "peerDependencies": {
+        "vue": ">=3"
+      }
     },
     "node_modules/vue3-perfect-scrollbar": {
       "version": "1.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,8 @@
     "vue-toastification": "^2.0.0-rc.5",
     "vue3-apexcharts": "1.4.1",
     "vue3-click-away": "^1.2.4",
-    "vue3-perfect-scrollbar": "^1.6.1"
+    "vue3-perfect-scrollbar": "^1.6.1",
+    "vue3-dropzone": "^2.2.1"
   },
   "devDependencies": {
     "@playwright/test": "1.55.0",

--- a/frontend/src/components/manuals/ManualCard.vue
+++ b/frontend/src/components/manuals/ManualCard.vue
@@ -1,24 +1,46 @@
 <template>
-  <div class="border p-4 rounded shadow">
+  <div
+    class="bg-white dark:bg-slate-800 rounded-md shadow p-4 flex flex-col h-full"
+  >
     <div class="flex justify-between items-start">
       <div>
-        <h3 class="font-bold">{{ manual.file?.filename }}</h3>
-        <div class="text-sm text-gray-500">
+        <h3 class="font-medium text-base">{{ manual.file?.filename }}</h3>
+        <div class="text-xs text-gray-500">
           Updated {{ new Date(manual.updated_at).toLocaleDateString() }}
         </div>
-        <div v-if="manual.category" class="text-sm">{{ manual.category }}</div>
+        <div v-if="manual.category" class="text-xs mt-1">
+          {{ manual.category }}
+        </div>
       </div>
       <button
         class="text-yellow-500 text-xl"
         :aria-pressed="favorite"
         @click.stop="$emit('toggle-favorite', manual.id)"
       >
-        {{ favorite ? '★' : '☆' }}
+        <Icon
+          :icon="favorite ? 'heroicons-solid:star' : 'heroicons-outline:star'"
+        />
       </button>
     </div>
-    <div class="mt-3 flex gap-2">
-      <button class="text-blue-600" @click="$emit('open', manual.id)">Open</button>
-      <button class="text-blue-600" @click="$emit('offline', manual)">
+
+    <div
+      v-if="manual.tags && manual.tags.length"
+      class="mt-3 flex flex-wrap gap-1"
+    >
+      <span
+        v-for="tag in manual.tags"
+        :key="tag"
+        class="text-xs bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-200 px-2 py-0.5 rounded-full"
+      >
+        {{ tag }}
+      </span>
+    </div>
+
+    <div class="mt-auto pt-4 flex gap-2">
+      <button class="btn btn-outline-primary" @click="$emit('open', manual.id)">
+        Open
+      </button>
+      <button class="btn btn-outline-secondary" @click="$emit('offline', manual)">
         {{ offline ? 'Remove Offline' : 'Keep Offline' }}
       </button>
     </div>
@@ -26,6 +48,8 @@
 </template>
 
 <script setup lang="ts">
+import Icon from '@/components/ui/Icon/index.vue';
+
 defineProps<{ manual: any; favorite: boolean; offline: boolean }>();
 defineEmits(['open', 'toggle-favorite', 'offline']);
 </script>


### PR DESCRIPTION
## Summary
- restyle ManualCard with Dashcode styling and tag chips
- replace manuals list with Dashcode grid, filters, and modal form
- add upload modal using vue3-dropzone

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'themeSettingsStore'))*
- `npx eslint src/components/manuals/ManualCard.vue src/views/manuals/ManualForm.vue src/views/manuals/ManualsList.vue`

------
https://chatgpt.com/codex/tasks/task_e_68adbcb9968083238459128fe3fdef9c