### PR TITLE
feat: refactor reports charts with dashcode patterns

### DIFF
--- a/frontend/src/components/reports/KpiCards.vue
+++ b/frontend/src/components/reports/KpiCards.vue
@@ -3,10 +3,15 @@
     <Card
       v-for="k in kpis"
       :key="k.label"
-      class="flex flex-col gap-1 bg-gradient-to-br from-primary/20 via-primary/10 to-transparent"
+      bodyClass="p-6 flex flex-col gap-1"
     >
-      <span class="text-sm font-medium text-foreground/70">{{ k.label }}</span>
-      <span class="text-3xl font-bold tracking-tight">{{ k.value }}</span>
+      <span class="text-sm font-medium text-slate-600 dark:text-slate-300"
+        >{{ k.label }}</span
+      >
+      <span
+        class="text-3xl font-bold tracking-tight text-slate-900 dark:text-white"
+        >{{ k.value }}</span
+      >
     </Card>
   </div>
 </template>

--- a/frontend/tests/unit/ChartCard.render.test.ts
+++ b/frontend/tests/unit/ChartCard.render.test.ts
@@ -5,9 +5,8 @@ import ChartCard from '@/components/reports/ChartCard.vue';
 import { createI18n } from 'vue-i18n';
 import en from '@/i18n/en.json';
 
-vi.mock('vue-chartjs', () => ({
-  Bar: { name: 'Bar', template: '<div />' },
-  Line: { name: 'Line', template: '<div />' },
+vi.mock('vue3-apexcharts', () => ({
+  default: { name: 'apexchart', template: '<div />' },
 }));
 
 const i18n = createI18n({ locale: 'en', messages: { en } });
@@ -20,6 +19,9 @@ describe('ChartCard', () => {
       series: [],
     });
     app.use(i18n);
+    app.config.globalProperties.$store = {
+      themeSettingsStore: { skin: '', isDark: false },
+    } as any;
     const div = document.createElement('div');
     app.mount(div);
     expect(div.querySelector('.animate-pulse')).toBeTruthy();
@@ -28,8 +30,11 @@ describe('ChartCard', () => {
     const series = [{ label: 'A', data: [{ x: '1', y: 1 }] }];
     const app = createApp(ChartCard, { title: 'Test', type: 'bar', series });
     app.use(i18n);
+    app.config.globalProperties.$store = {
+      themeSettingsStore: { skin: '', isDark: false },
+    } as any;
     const div = document.createElement('div');
     app.mount(div);
-    expect(div.querySelector('div')).toBeTruthy();
+    expect(div.querySelector('.animate-pulse')).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
- restyle KPI cards with Dashcode Card
- replace Chart.js charts with ApexCharts and add date range controls in Reports view
- adjust ChartCard test for ApexCharts

## Testing
- `npm test` *(fails: FormRenderer tests - p-dropdown not rendered, p-message-error missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adbe4df7cc8323b90c595320c20121