### PR TITLE
refactor: dashcode lists and forms for tenants and employees

### DIFF
--- a/frontend/src/components/tenants/TenantForm.vue
+++ b/frontend/src/components/tenants/TenantForm.vue
@@ -1,32 +1,24 @@
 <template>
-  <form @submit.prevent="submit" class="border p-4 mt-4">
-    <div class="mb-2">
-      <label class="block">Name</label>
-      <input v-model="form.name" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">Storage Quota (MB)</label>
-      <input v-model.number="form.quota_storage_mb" type="number" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">Phone</label>
-      <input v-model="form.phone" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">Address</label>
-      <input v-model="form.address" class="border p-2 w-full" />
-    </div>
-    <div class="mb-2">
-      <label class="block">Features (JSON)</label>
-      <textarea v-model="form.features" class="border p-2 w-full"></textarea>
-    </div>
-    <button class="bg-blue-600 text-white px-4 py-2">Save</button>
+  <form @submit.prevent="submit" class="space-y-4">
+    <Textinput label="Name" v-model="form.name" />
+    <Textinput
+      label="Storage Quota (MB)"
+      type="number"
+      v-model.number="form.quota_storage_mb"
+    />
+    <Textinput label="Phone" v-model="form.phone" />
+    <Textinput label="Address" v-model="form.address" />
+    <Textarea label="Features (JSON)" v-model="form.features" />
+    <Button type="submit" text="Save" btnClass="btn-dark" />
   </form>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
 import api from '@/services/api';
+import Textinput from '@/components/ui/Textinput/index.vue';
+import Textarea from '@/components/ui/Textarea/index.vue';
+import Button from '@/components/ui/Button/index.vue';
 
 const emit = defineEmits(['saved']);
 

--- a/frontend/src/views/employees/EmployeeForm.vue
+++ b/frontend/src/views/employees/EmployeeForm.vue
@@ -2,31 +2,18 @@
   <div>
     <h2 class="text-xl font-bold mb-4">{{ isEdit ? 'Edit' : 'Invite' }} Employee</h2>
     <form @submit.prevent="submit" class="grid gap-4 max-w-lg">
-      <div>
-        <label class="block mb-1">Name</label>
-        <input v-model="form.name" class="border p-2 w-full" />
-      </div>
-      <div>
-        <label class="block mb-1">Email</label>
-        <input v-model="form.email" type="email" class="border p-2 w-full" />
-      </div>
-      <div>
-        <label class="block mb-1">Phone</label>
-        <input v-model="form.phone" class="border p-2 w-full" />
-      </div>
-      <div>
-        <label class="block mb-1">Address</label>
-        <input v-model="form.address" class="border p-2 w-full" />
-      </div>
-      <div>
-        <label class="block mb-1">Roles</label>
-        <select v-model="form.roles" multiple class="border p-2 w-full">
-          <option v-for="r in roleOptions" :key="r" :value="r">{{ r }}</option>
-        </select>
-      </div>
-      <button class="bg-blue-600 text-white px-4 py-2 rounded">
-        {{ isEdit ? 'Save' : 'Invite' }}
-      </button>
+      <Textinput label="Name" v-model="form.name" />
+      <Textinput label="Email" type="email" v-model="form.email" />
+      <Textinput label="Phone" v-model="form.phone" />
+      <Textinput label="Address" v-model="form.address" />
+      <VueSelect label="Roles">
+        <vSelect v-model="form.roles" :options="roleOptions" multiple />
+      </VueSelect>
+      <Button
+        type="submit"
+        :text="isEdit ? 'Save' : 'Invite'"
+        btnClass="btn-dark"
+      />
     </form>
   </div>
 </template>
@@ -35,6 +22,10 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '@/services/api';
+import Textinput from '@/components/ui/Textinput/index.vue';
+import VueSelect from '@/components/ui/Select/VueSelect.vue';
+import Button from '@/components/ui/Button/index.vue';
+import vSelect from 'vue-select';
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -2,10 +2,11 @@
   <div>
     <h2 class="text-xl font-bold mb-4">Employees</h2>
     <div class="mb-4">
-      <RouterLink
-        class="bg-blue-600 text-white px-4 py-2 rounded"
-        :to="{ name: 'employees.create' }"
-      >Invite Employee</RouterLink>
+      <Button
+        btnClass="btn-primary"
+        text="Invite Employee"
+        link="/employees/create"
+      />
     </div>
     <DashcodeServerTable
       :key="tableKey"
@@ -14,11 +15,16 @@
     >
       <template #actions="{ row }">
         <div class="flex gap-2">
-          <RouterLink
-            class="text-blue-600"
-            :to="{ name: 'employees.edit', params: { id: row.id } }"
-          >Edit</RouterLink>
-          <button class="text-red-600" @click="remove(row.id)">Delete</button>
+          <Button
+            :link="`/employees/${row.id}/edit`"
+            btnClass="btn-outline-primary btn-sm"
+            text="Edit"
+          />
+          <Button
+            btnClass="btn-outline-danger btn-sm"
+            text="Delete"
+            @click="remove(row.id)"
+          />
         </div>
       </template>
     </DashcodeServerTable>
@@ -26,9 +32,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import { RouterLink } from 'vue-router';
+import { ref, inject } from 'vue';
 import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
+import Button from '@/components/ui/Button/index.vue';
 import api from '@/services/api';
 import { useToast } from '@/plugins/toast';
 
@@ -89,8 +95,16 @@ function reload() {
   tableKey.value++;
 }
 
+const swal = inject('$swal');
+
 async function remove(id: number) {
-  if (!confirm('Delete employee?')) return;
+  const result = await swal?.fire({
+    title: 'Delete employee?',
+    icon: 'warning',
+    showCancelButton: true,
+    confirmButtonText: 'Yes, delete',
+  });
+  if (!result?.isConfirmed) return;
   try {
     await api.delete(`/employees/${id}`);
     all.value = [];

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -7,19 +7,39 @@
       :fetcher="fetchTenants"
     >
       <template #actions="{ row }">
-        <button class="text-blue-600" @click="impersonate(row)">Impersonate</button>
+        <div class="flex gap-2">
+          <Button
+            btnClass="btn-outline-primary btn-sm"
+            text="View"
+            @click="view(row.id)"
+          />
+          <Button
+            btnClass="btn-outline-secondary btn-sm"
+            text="Impersonate"
+            @click="impersonate(row)"
+          />
+          <Button
+            btnClass="btn-outline-danger btn-sm"
+            text="Delete"
+            @click="remove(row.id)"
+          />
+        </div>
       </template>
     </DashcodeServerTable>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, inject } from 'vue';
+import { useRouter } from 'vue-router';
 import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
+import Button from '@/components/ui/Button/index.vue';
 import api from '@/services/api';
 import { useAuthStore } from '@/stores/auth';
 
 const auth = useAuthStore();
+const router = useRouter();
+const swal = inject('$swal');
 const tableKey = ref(0);
 const all = ref<any[]>([]);
 
@@ -63,6 +83,23 @@ function reload() {
 
 async function impersonate(t: any) {
   await auth.impersonate(t.id, t.name);
+}
+
+function view(id: number) {
+  router.push(`/tenants/${id}`);
+}
+
+async function remove(id: number) {
+  const result = await swal?.fire({
+    title: 'Delete tenant?',
+    icon: 'warning',
+    showCancelButton: true,
+    confirmButtonText: 'Yes, delete',
+  });
+  if (!result?.isConfirmed) return;
+  await api.delete(`/tenants/${id}`);
+  all.value = [];
+  reload();
 }
 </script>
 


### PR DESCRIPTION
## Summary
- refactor tenant list to use Dashcode buttons with view, impersonate and delete actions
- replace tenant form fields with Dashcode inputs
- update employee list actions and invitation button to Dashcode style with SweetAlert2 deletes
- restyle employee form with Dashcode inputs and roles selector

## Testing
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated, 686 problems)*
- `npm test` *(fails: matchMedia is not a function, nextTick is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68adc29f35f08323be2ce65cff674b47