### PR TITLE
refactor: switch from primeicons to iconify

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,6 @@
         "idb": "7.1.1",
         "pdfjs-dist": "3.11.174",
         "pinia": "2.1.7",
-        "primeicons": "^7.0.0",
         "primevue": "^4.3.7",
         "simplebar-vue": "^2.3.3",
         "tailwind-merge": "^3.3.1",
@@ -6369,12 +6368,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/primeicons": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/primeicons/-/primeicons-7.0.0.tgz",
-      "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw==",
-      "license": "MIT"
     },
     "node_modules/primevue": {
       "version": "4.3.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "idb": "7.1.1",
     "pdfjs-dist": "3.11.174",
     "pinia": "2.1.7",
-    "primeicons": "^7.0.0",
     "primevue": "^4.3.7",
     "simplebar-vue": "^2.3.3",
     "tailwind-merge": "^3.3.1",
@@ -50,8 +49,8 @@
     "vue-toastification": "^2.0.0-rc.5",
     "vue3-apexcharts": "1.4.1",
     "vue3-click-away": "^1.2.4",
-    "vue3-perfect-scrollbar": "^1.6.1",
-    "vue3-dropzone": "^2.2.1"
+    "vue3-dropzone": "^2.2.1",
+    "vue3-perfect-scrollbar": "^1.6.1"
   },
   "devDependencies": {
     "@playwright/test": "1.55.0",

--- a/frontend/src/components/layout/AppShell.vue
+++ b/frontend/src/components/layout/AppShell.vue
@@ -9,11 +9,14 @@
         <template #start>
           <Button
             class="mr-2 md:hidden"
-            icon="pi pi-bars"
             aria-label="Menu"
             @click="sidebarOpen = true"
             text
-          />
+          >
+            <template #icon>
+              <Icon icon="heroicons-outline:bars-3" class="w-5 h-5" />
+            </template>
+          </Button>
           <div class="flex items-center gap-2">
             <img
               v-if="branding.logo"
@@ -36,20 +39,29 @@
           <Button @click="toggleDensity" :label="t('actions.toggleDensity')" text />
           <Bell />
           <Button
-            icon="pi pi-search"
             aria-label="Command"
             @click="open(paletteActions.value)"
             text
-          />
-          <Avatar
-            icon="pi pi-user"
-            class="cursor-pointer"
-            @click="profileMenu?.toggle($event)"
-          />
+          >
+            <template #icon>
+              <Icon icon="heroicons-outline:magnifying-glass" class="w-5 h-5" />
+            </template>
+          </Button>
+          <Avatar class="cursor-pointer" @click="profileMenu?.toggle($event)">
+            <template #icon>
+              <Icon icon="heroicons-outline:user" class="w-5 h-5" />
+            </template>
+          </Avatar>
           <TieredMenu ref="profileMenu" :model="profileItems" popup />
         </template>
       </Menubar>
-      <Breadcrumb :home="home" :model="breadcrumbs" class="px-4 py-2" />
+      <Breadcrumb :home="home" :model="breadcrumbs" class="px-4 py-2">
+        <template #home>
+          <RouterLink :to="home.to" class="p-breadcrumb-home">
+            <Icon icon="heroicons-outline:home" class="w-5 h-5" />
+          </RouterLink>
+        </template>
+      </Breadcrumb>
     </header>
     <Sidebar v-model:visible="sidebarOpen">
       <nav class="w-56 p-2 space-y-1">
@@ -65,7 +77,7 @@
           ]"
           @click="sidebarOpen = false"
         >
-          <i :class="item.icon"></i>
+          <Icon :icon="item.icon" class="w-5 h-5" />
           <span>{{ item.label }}</span>
         </RouterLink>
       </nav>
@@ -94,6 +106,7 @@ import { useBrandingStore } from '@/stores/branding';
 import { useAuthStore } from '@/stores/auth';
 import CommandPalette from './CommandPalette.vue';
 import { useCommandPalette } from '@/composables/useCommandPalette';
+import Icon from '@/components/ui/Icon';
 
 const theme = ref<'light' | 'dark'>('light');
 const density = ref<'compact' | ''>('');
@@ -126,20 +139,20 @@ const isAdmin = computed(() =>
 
 const menuItems = computed(() => {
   const items = [
-    { label: t('routes.appointments'), icon: 'pi pi-calendar', to: '/appointments' },
+    { label: t('routes.appointments'), icon: 'heroicons-outline:calendar', to: '/appointments' },
   ];
   if (isAdmin.value) {
-    items.push({ label: t('routes.manuals'), icon: 'pi pi-book', to: '/manuals' });
+    items.push({ label: t('routes.manuals'), icon: 'heroicons-outline:book-open', to: '/manuals' });
   }
   items.push(
-    { label: t('routes.reports'), icon: 'pi pi-chart-bar', to: '/reports' },
-    { label: t('routes.settings'), icon: 'pi pi-cog', to: '/settings' },
+    { label: t('routes.reports'), icon: 'heroicons-outline:chart-bar', to: '/reports' },
+    { label: t('routes.settings'), icon: 'heroicons-outline:cog-6-tooth', to: '/settings' },
   );
   if (isAdmin.value) {
-    items.push({ label: t('routes.employees'), icon: 'pi pi-users', to: '/employees' });
+    items.push({ label: t('routes.employees'), icon: 'heroicons-outline:users', to: '/employees' });
   }
   if (auth.user?.roles?.some((r: any) => r.name === 'SuperAdmin')) {
-    items.push({ label: t('routes.tenants'), icon: 'pi pi-building', to: '/tenants' });
+    items.push({ label: t('routes.tenants'), icon: 'heroicons-outline:building-office', to: '/tenants' });
   }
   return items;
 });
@@ -155,7 +168,7 @@ const breadcrumbs = computed(() =>
     .filter((r) => r.meta?.breadcrumb)
     .map((r) => ({ label: t(r.meta.breadcrumb as string), to: r.path })),
 );
-const home = { icon: 'pi pi-home', to: '/' };
+const home = { to: '/' };
 
 function toggleTheme() {
   theme.value = theme.value === 'dark' ? 'light' : 'dark';

--- a/frontend/src/components/notifications/Bell.vue
+++ b/frontend/src/components/notifications/Bell.vue
@@ -1,5 +1,8 @@
 <template>
-  <Button icon="pi pi-bell" class="p-overlay-badge" text to="/notifications">
+  <Button class="p-overlay-badge" text to="/notifications">
+    <template #icon>
+      <Icon icon="heroicons-outline:bell" class="w-5 h-5" />
+    </template>
     <Badge v-if="unreadCount" :value="unreadCount" />
   </Button>
 </template>
@@ -11,6 +14,7 @@ import { storeToRefs } from 'pinia';
 import Button from 'primevue/button';
 import Badge from 'primevue/badge';
 import { useNotificationStore } from '@/stores/notifications';
+import Icon from '@/components/ui/Icon';
 
 const store = useNotificationStore();
 const { unreadCount } = storeToRefs(store);

--- a/frontend/src/views/AppointmentList.vue
+++ b/frontend/src/views/AppointmentList.vue
@@ -10,12 +10,11 @@
           :placeholder="t('appointments.filters.global')"
           class="mr-2"
         />
-        <Button
-          v-if="isAdmin"
-          :label="t('appointments.new')"
-          icon="pi pi-plus"
-          @click="openNew"
-        />
+        <Button v-if="isAdmin" :label="t('appointments.new')" @click="openNew">
+          <template #icon>
+            <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
+          </template>
+        </Button>
       </template>
     </Toolbar>
     <DataTable
@@ -70,16 +69,16 @@
       <Column v-if="isAdmin" :header="t('actions.actions')">
         <template #body="slotProps">
           <div class="flex gap-2">
-            <Button
-              icon="pi pi-pencil"
-              class="p-button-rounded p-button-text"
-              @click="openEdit(slotProps.data)"
-            />
-            <Button
-              icon="pi pi-trash"
-              class="p-button-rounded p-button-text"
-              @click="confirmDelete(slotProps.data)"
-            />
+            <Button class="p-button-rounded p-button-text" @click="openEdit(slotProps.data)">
+              <template #icon>
+                <Icon icon="heroicons-outline:pencil" class="w-5 h-5" />
+              </template>
+            </Button>
+            <Button class="p-button-rounded p-button-text" @click="confirmDelete(slotProps.data)">
+              <template #icon>
+                <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
+              </template>
+            </Button>
           </div>
         </template>
       </Column>
@@ -88,7 +87,11 @@
     <Dialog v-model:visible="showCreate" :header="t('appointments.new')" modal>
       <div class="flex flex-col gap-3">
         <InputText v-model="form.title" :placeholder="t('appointments.form.title')" />
-        <Calendar v-model="form.scheduled_at" show-icon date-format="yy-mm-dd" />
+        <Calendar v-model="form.scheduled_at" show-icon date-format="yy-mm-dd">
+          <template #icon>
+            <Icon icon="heroicons-outline:calendar" class="w-5 h-5" />
+          </template>
+        </Calendar>
         <Dropdown
           v-model="form.status"
           :options="statusOptions"
@@ -108,7 +111,11 @@
     <Dialog v-model:visible="showEdit" :header="t('appointments.edit')" modal>
       <div class="flex flex-col gap-3">
         <InputText v-model="form.title" :placeholder="t('appointments.form.title')" />
-        <Calendar v-model="form.scheduled_at" show-icon date-format="yy-mm-dd" />
+        <Calendar v-model="form.scheduled_at" show-icon date-format="yy-mm-dd">
+          <template #icon>
+            <Icon icon="heroicons-outline:calendar" class="w-5 h-5" />
+          </template>
+        </Calendar>
         <Dropdown
           v-model="form.status"
           :options="statusOptions"
@@ -148,6 +155,7 @@ import { useNotify } from '@/plugins/notify';
 import Swal from 'sweetalert2';
 import { useI18n } from 'vue-i18n';
 import { filterAppointments, Appointment } from '@/utils/appointmentFilters';
+import Icon from '@/components/ui/Icon';
 
 const { t } = useI18n();
 const notify = useNotify();


### PR DESCRIPTION
## Summary
- replace PrimeIcons usage with Iconify components in layout, notifications, and appointment list
- drop PrimeIcons dependency

## Testing
- `npm test` (fails: Test timed out/nextTick is not a function)
- `npm run lint` (warnings and 13 errors)


------
https://chatgpt.com/codex/tasks/task_e_68adcc766064832386aa4160246e90d6