### PR TITLE
fix: correct constant data import paths

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/DesktopMenu.vue
+++ b/frontend/src/components/ui/Header/Navtools/DesktopMenu.vue
@@ -101,7 +101,7 @@
   </ul>
 </template>
 <script>
-import { topMenu } from "../../../constant/data.js";
+import { topMenu } from "@/constant/data";
 import Icon from "../../Icon";
 export default {
   components: {

--- a/frontend/src/components/ui/Header/Navtools/Message.vue
+++ b/frontend/src/components/ui/Header/Navtools/Message.vue
@@ -91,7 +91,7 @@
 import Dropdown from "@/components/Dropdown";
 import Icon from "@/components/Icon";
 import { MenuItem } from "@headlessui/vue";
-import { message } from "../../../constant/data";
+import { message } from "@/constant/data";
 export default {
   components: {
     Icon,

--- a/frontend/src/components/ui/Header/Navtools/Notification.vue
+++ b/frontend/src/components/ui/Header/Navtools/Notification.vue
@@ -88,7 +88,7 @@
 import Dropdown from "@/components/Dropdown";
 import Icon from "@/components/Icon";
 import { MenuItem } from "@headlessui/vue";
-import { notifications } from "../../../constant/data";
+import { notifications } from "@/constant/data";
 export default {
   components: {
     Icon,

--- a/frontend/src/components/ui/Sidebar/MobileSidebar.vue
+++ b/frontend/src/components/ui/Sidebar/MobileSidebar.vue
@@ -58,7 +58,7 @@
 <script>
 import { Icon } from "@iconify/vue";
 import { defineComponent } from "vue";
-import { menuItems } from "../../constant/data";
+import { menuItems } from "@/constant/data";
 import Navmenu from "./Navmenu";
 import { useThemeSettingsStore } from "@/store/themeSettings";
 const themeSettingsStore = useThemeSettingsStore();

--- a/frontend/src/components/ui/Sidebar/index.vue
+++ b/frontend/src/components/ui/Sidebar/index.vue
@@ -149,7 +149,7 @@
 <script>
 // import { Icon } from "@iconify/vue";
 import { defineComponent } from "vue";
-import { menuItems } from "../../constant/data";
+import { menuItems } from "@/constant/data";
 import Navmenu from "./Navmenu";
 import { gsap } from "gsap";
 import simplebar from "simplebar-vue";


### PR DESCRIPTION
## Summary
- fix broken menu data imports by switching to project alias

## Testing
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated, 13 errors, 644 warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adde3d4348832397ca244251518a33