### PR TITLE
fix: remove deprecated fullcalendar vdom import

### DIFF
--- a/frontend/src/views/appointments/Calendar.vue
+++ b/frontend/src/views/appointments/Calendar.vue
@@ -26,7 +26,6 @@ import { useRouter } from 'vue-router';
 import FullCalendar from '@fullcalendar/vue3';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
-import '@fullcalendar/core/vdom';
 import Modal from '@/components/ui/Modal';
 import { useAppointmentsStore } from '@/stores/appointments';
 


### PR DESCRIPTION
## Summary
- remove `@fullcalendar/core/vdom` import from calendar view to prevent Vite dependency scan errors

## Testing
- `npm run build` (fails: Rollup failed to resolve import "vee-validate")
- `npm run lint` (fails: 13 errors, 644 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ade1038c748323825290fedb748981