### PR TITLE
Add missing components and cart store for frontend

### DIFF
--- a/frontend/src/components/Button/GroupButton.vue
+++ b/frontend/src/components/Button/GroupButton.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="btn-group">
+    <Button
+      v-for="(item, i) in groupButtons"
+      :key="i"
+      :text="item.title"
+      :class="{ active: activeIndex === i }"
+      @click="activeIndex = activeIndex === i ? null : i"
+      :btnClass="btnClass"
+      :icon="item.icon"
+      :iconPosition="item.iconPosition"
+    />
+  </div>
+</template>
+<script>
+import Button from "./index";
+export default {
+  components: {
+    Button,
+  },
+  props: {
+    btnClass: {
+      type: String,
+      default: "btn-outline-primary",
+    },
+    groupButtons: {
+      type: Array,
+      default: () => [
+        {
+          title: "Weekly",
+        },
+        {
+          title: "Monthly",
+        },
+        {
+          title: "Yearly",
+        },
+      ],
+    },
+  },
+  data() {
+    return {
+      activeIndex: 0,
+    };
+  },
+};
+</script>
+<style lang="scss">
+.btn-group {
+  @apply flex items-start;
+  > button {
+    @apply rounded-none ltr:first:rounded-l-md rtl:first:rounded-r-md ltr:last:rounded-r-md rtl:last:rounded-l-md;
+  }
+  .btn-outline-primary,
+  .btn-outline-secondary,
+  .btn-outline-success,
+  .btn-outline-info,
+  .btn-outline-warning,
+  .btn-outline-danger,
+  .btn-outline-dark,
+  .btn-outline-light {
+    @apply ltr:border-r-0 ltr:last:border rtl:border-l-0 rtl:last:border;
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .btn-success,
+  .btn-info,
+  .btn-warning,
+  .btn-danger,
+  .btn-dark,
+  .btn-light {
+    @apply ltr:border-r ltr:border-r-white rtl:border-l rtl:border-l-white ltr:border-opacity-10 rtl:border-opacity-10  last:border-r-0 hover:ring-0 hover:ring-offset-0 bg-opacity-90;
+    &.active {
+      @apply bg-opacity-100;
+    }
+  }
+}
+</style>

--- a/frontend/src/components/Button/index.vue
+++ b/frontend/src/components/Button/index.vue
@@ -1,0 +1,217 @@
+<template>
+  <button
+    :disabled="isDisabled"
+    class="btn inline-flex justify-center"
+    :class="`
+    ${isLoading ? ' pointer-events-none' : ''}
+    ${isDisabled ? ' opacity-40 cursor-not-allowed' : ''}
+    ${btnClass}
+    `"
+    v-bind="$attrs"
+    v-if="!link && !div"
+  >
+    <template v-if="!isLoading && !$slots.default">
+      <span class="flex items-center">
+        <span
+          :class="`
+          ${iconPosition === 'right' ? 'order-1 ltr:ml-2 rtl:mr-2' : ' '}
+          ${text && iconPosition === 'left' ? 'ltr:mr-2 rtl:ml-2' : ''}
+          
+          ${iconClass}
+          
+          `"
+          v-if="icon"
+          ><Icon :icon="icon"
+        /></span>
+        <span v-if="text">{{ text }}</span>
+      </span>
+    </template>
+    <template v-if="isLoading">
+      <svg
+        class="animate-spin ltr:-ml-1 ltr:mr-3 rtl:-mr-1 rtl:ml-3 h-5 w-5"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        :class="loadingClass"
+      >
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        ></circle>
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+      Loading ...
+    </template>
+    <div v-if="$slots.default && !isLoading">
+      <slot></slot>
+    </div>
+  </button>
+
+  <router-link
+    :to="link"
+    class="btn inline-flex justify-center"
+    :class="`
+    ${isLoading ? ' pointer-events-none' : ''}
+    ${isDisabled ? ' opacity-40 cursor-not-allowed' : ''}
+    ${btnClass}
+    `"
+    v-if="link && !div"
+  >
+    <template v-if="!isLoading && !$slots.default">
+      <span class="flex items-center">
+        <span
+          :class="`
+          ${iconPosition === 'right' ? 'order-1 ltr:ml-2 rtl:mr-2' : ' '}
+          ${text && iconPosition === 'left' ? 'ltr:mr-2 rtl:ml-2' : ''}
+          
+          ${iconClass}
+          
+          `"
+          v-if="icon"
+          ><Icon :icon="icon"
+        /></span>
+        <span v-if="text">{{ text }}</span>
+      </span>
+    </template>
+    <template v-if="isLoading">
+      <svg
+        class="animate-spin -ml-1 mr-3 h-5 w-5"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        :class="loadingClass"
+      >
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        ></circle>
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+      Loading ...
+    </template>
+    <div v-if="$slots.default && !isLoading">
+      <slot></slot>
+    </div>
+  </router-link>
+  <div
+    class="btn inline-flex justify-center"
+    :class="`
+    ${isLoading ? ' pointer-events-none' : ''}
+    ${isDisabled ? ' opacity-40 cursor-not-allowed' : ''}
+    ${btnClass}
+    `"
+    v-if="div && !link"
+  >
+    <template v-if="!isLoading && !$slots.default">
+      <span class="flex items-center">
+        <span
+          :class="`
+          ${iconPosition === 'right' ? 'order-1 ltr:ml-2 rtl:mr-2' : ' '}
+          ${text && iconPosition === 'left' ? 'ltr:mr-2 rtl:ml-2' : ''}
+          
+          ${iconClass}
+          
+          `"
+          v-if="icon"
+          ><Icon :icon="icon"
+        /></span>
+        <span v-if="text">{{ text }}</span>
+      </span>
+    </template>
+    <template v-if="isLoading">
+      <svg
+        class="animate-spin -ml-1 mr-3 h-5 w-5"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        :class="loadingClass"
+      >
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        ></circle>
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+      Loading ...
+    </template>
+    <div v-if="$slots.default && !isLoading">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+<script>
+import Icon from "@/components/Icon";
+export default {
+  components: {
+    Icon,
+  },
+  name: "Button",
+  props: {
+    text: {
+      type: String,
+      default: "",
+    },
+    isDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
+    btnClass: {
+      type: String,
+      default: "bg-primary-500 text-white",
+    },
+    icon: {
+      type: String,
+      default: "",
+    },
+    iconPosition: {
+      type: String,
+      default: "left",
+    },
+    iconClass: {
+      type: String,
+      default: "text-[20px]",
+    },
+    loadingClass: {
+      type: String,
+      default: "",
+    },
+    link: {
+      type: String,
+      default: "",
+    },
+    div: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+<style lang="scss"></style>

--- a/frontend/src/components/Dropdown/SplitDropdown.vue
+++ b/frontend/src/components/Dropdown/SplitDropdown.vue
@@ -1,0 +1,169 @@
+<template>
+  <Menu as="div" class="relative" :class="parentClass">
+    <div class="split-btngroup flex">
+      <button class="btn flex-1" :class="labelClass">{{ label }}</button>
+      <MenuButton class="flex-0 px-3" :class="labelClass">
+        <Icon :icon="splitIcon"
+      /></MenuButton>
+    </div>
+    <Transition
+      enter-active-class="transition duration-100 ease-out"
+      enter-from-class="transform scale-95 opacity-0"
+      enter-to-class="transform scale-100 opacity-100"
+      leave-active-class="transition duration-75 ease-in"
+      leave-from-class="transform scale-100 opacity-100"
+      leave-to-class="transform scale-95 opacity-0"
+    >
+      <MenuItems
+        :class="classMenuItems"
+        class="absolute ltr:right-0 rtl:left-0 origin-top-right rounded bg-white dark:bg-slate-800 dark:border dark:border-slate-700 shadow-dropdown z-[9999]"
+      >
+        <div v-if="!$slots.menus">
+          <MenuItem v-slot="{ active }" v-for="(item, i) in items" :key="i">
+            <router-link
+              :class="`${
+                active
+                  ? 'bg-slate-100 text-slate-900 dark:bg-slate-600 dark:text-slate-300 dark:bg-opacity-50'
+                  : 'text-slate-600 dark:text-slate-300'
+              } block   ${classItem}  ${
+                item.hasDivider
+                  ? 'border-t border-slate-100 dark:border-slate-700'
+                  : ''
+              }`"
+              :to="item.link"
+              v-if="item.link"
+            >
+              <div class="flex items-center" v-if="item.icon">
+                <span class="block text-xl ltr:mr-3 rtl:ml-3">
+                  <Icon :icon="item.icon"
+                /></span>
+                <span class="block text-sm">{{ item.label }}</span>
+              </div>
+              <span v-else class="block text-sm">{{ item.label }}</span>
+            </router-link>
+            <span
+              :class="`${active ? 'bg-slate-100 text-slate-800' : ''}  ${
+                item.hasDivider === true
+                  ? 'border-t border-gray-500 dark:border-slate-700'
+                  : ''
+              }  block ${classItem}`"
+              v-else
+            >
+              <div class="flex items-center" v-if="item.icon">
+                <span class="block text-xl ltr:mr-3 rtl:ml-3">
+                  <Icon :icon="item.icon"
+                /></span>
+                <span class="block text-sm">{{ item.label }}</span>
+              </div>
+              <span v-else class="block text-sm">{{ item.label }}</span>
+            </span>
+          </MenuItem>
+        </div>
+        <div v-else class="paglawrapper">
+          <slot name="menus"></slot>
+        </div>
+      </MenuItems>
+    </Transition>
+  </Menu>
+</template>
+
+<script>
+import Icon from "@/components/Icon";
+import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/vue";
+export default {
+  components: {
+    Menu,
+    MenuButton,
+    MenuItems,
+    MenuItem,
+    Icon,
+  },
+  props: {
+    label: {
+      type: String,
+      default: "DropDown",
+    },
+    labelClass: {
+      type: String,
+      default: "btn-primary",
+    },
+    classMenuItems: {
+      type: String,
+      default: " mt-2 w-[220px]",
+    },
+    classItem: {
+      type: String,
+      default: "px-4 py-2",
+    },
+    splitIcon: {
+      type: String,
+      default: "heroicons-outline:chevron-down",
+    },
+    parentClass: {
+      type: String,
+      default: "inline-block",
+    },
+    items: {
+      type: Array,
+
+      default: () => [
+        {
+          label: "Action",
+          link: "#",
+        },
+        {
+          label: "Another action",
+          link: "#",
+        },
+        {
+          label: "Something else here",
+          link: "#",
+        },
+        {
+          label: "Separated link",
+          link: "#",
+          hasDivider: true,
+        },
+      ],
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.split-btngroup {
+  .btn {
+    @apply ltr:rounded-r-none rtl:rounded-l-none hover:ring-0;
+  }
+  button {
+    @apply ltr:last:rounded-r-md rtl:last:rounded-l-md  last:border-l last:border-white last:border-opacity-[0.10];
+    &:hover {
+      box-shadow: none !important;
+    }
+  }
+  [class*="btn-outline-"] {
+    @apply ltr:last:border-l-0 rtl:last:border-r-0  focus:bg-transparent focus:text-inherit;
+  }
+  .btn-outline-primary {
+    @apply focus:text-primary-500 last:border-primary-500;
+  }
+  .btn-outline-secondary {
+    @apply focus:text-secondary-500 last:border-secondary-500;
+  }
+  .btn-outline-success {
+    @apply focus:text-success-500 last:border-success-500;
+  }
+  .btn-outline-danger {
+    @apply focus:text-danger-500 last:border-danger-500;
+  }
+  .btn-outline-warning {
+    @apply focus:text-warning-500 last:border-warning-500;
+  }
+  .btn-outline-info {
+    @apply focus:text-info-500 last:border-info-500;
+  }
+  .btn-outline-light {
+    @apply focus:text-slate-600 last:border-[#E0EAFF];
+  }
+}
+</style>

--- a/frontend/src/components/Dropdown/index.vue
+++ b/frontend/src/components/Dropdown/index.vue
@@ -1,0 +1,126 @@
+<template>
+  <Menu as="div" class="relative" :class="parentClass">
+    <MenuButton v-if="$slots.default" class="block w-full">
+      <slot></slot>
+    </MenuButton>
+    <MenuButton v-else :class="labelClass" class="block w-full">{{
+      label
+    }}</MenuButton>
+    <Transition
+      enter-active-class="transition duration-100 ease-out"
+      enter-from-class="transform scale-95 opacity-0"
+      enter-to-class="transform scale-100 opacity-100"
+      leave-active-class="transition duration-75 ease-in"
+      leave-from-class="transform scale-100 opacity-100"
+      leave-to-class="transform scale-95 opacity-0"
+    >
+      <MenuItems
+        :class="classMenuItems"
+        class="absolute ltr:right-0 rtl:left-0 origin-top-right rounded bg-white dark:bg-slate-800 dark:border dark:border-slate-700 shadow-dropdown z-[9999]"
+      >
+        <div v-if="!$slots.menus">
+          <MenuItem v-slot="{ active }" v-for="(item, i) in items" :key="i">
+            <router-link
+              :class="`${
+                active
+                  ? 'bg-slate-100 text-slate-900 dark:bg-slate-600 dark:text-slate-300 dark:bg-opacity-50'
+                  : 'text-slate-600 dark:text-slate-300'
+              } block   ${classItem}  ${
+                item.hasDivider
+                  ? 'border-t border-slate-100 dark:border-slate-700'
+                  : ''
+              }`"
+              :to="item.link"
+              v-if="item.link"
+            >
+              <div class="flex items-center" v-if="item.icon">
+                <span class="block text-xl ltr:mr-3 rtl:ml-3">
+                  <Icon :icon="item.icon"
+                /></span>
+                <span class="block text-sm">{{ item.label }}</span>
+              </div>
+              <span v-else class="block text-sm">{{ item.label }}</span>
+            </router-link>
+            <span
+              :class="`${active ? 'bg-slate-100 text-slate-800' : ''}  ${
+                item.hasDivider === true
+                  ? 'border-t border-gray-500 dark:border-slate-700'
+                  : ''
+              }  block ${classItem}`"
+              v-else
+            >
+              <div class="flex items-center" v-if="item.icon">
+                <span class="block text-xl ltr:mr-3 rtl:ml-3">
+                  <Icon :icon="item.icon"
+                /></span>
+                <span class="block text-sm">{{ item.label }}</span>
+              </div>
+              <span v-else class="block text-sm">{{ item.label }}</span>
+            </span>
+          </MenuItem>
+        </div>
+        <template v-else>
+          <slot name="menus"></slot>
+        </template>
+      </MenuItems>
+    </Transition>
+  </Menu>
+</template>
+
+<script>
+import Icon from "@/components/Icon";
+import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/vue";
+export default {
+  components: {
+    Menu,
+    MenuButton,
+    MenuItems,
+    MenuItem,
+    Icon,
+  },
+  props: {
+    label: {
+      type: String,
+      default: "DropDown",
+    },
+    labelClass: {
+      type: String,
+    },
+    classMenuItems: {
+      type: String,
+      default: "mt-2 w-[220px]",
+    },
+    classItem: {
+      type: String,
+      default: "px-4 py-2",
+    },
+    parentClass: {
+      type: String,
+      default: "inline-block",
+    },
+    items: {
+      type: Array,
+
+      default: () => [
+        {
+          label: "Action",
+          link: "#",
+        },
+        {
+          label: "Another action",
+          link: "#",
+        },
+        {
+          label: "Something else here",
+          link: "#",
+        },
+        {
+          label: "Separated link",
+          link: "#",
+          hasDivider: true,
+        },
+      ],
+    },
+  },
+};
+</script>

--- a/frontend/src/components/Ecommerce/counter-button.vue
+++ b/frontend/src/components/Ecommerce/counter-button.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="flex space-x-4 rtl:space-x-reverse items-center">
+    <div
+      class="flex-1 h-8 flex border border-1 border-slate-900 delay-150 ease-in-out dark:border-slate-600 divide-x-[1px] rtl:divide-x-reverse text-sm font-normal divide-slate-900 dark:divide-slate-600 rounded"
+    >
+      <button
+        @click="decrement"
+        :disabled="cartProduct.quantity === 1"
+        type="button"
+        class="flex-none px-2 dark:text-white text-slate-900 hover:bg-slate-900 hover:text-white dark:hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Icon icon="eva:minus-fill" />
+      </button>
+
+      <div
+        class="flex-1 w-[62px] text-center text-slate-900 dark:text-slate-300 flex items-center justify-center"
+      >
+        {{ cartProduct.quantity }}
+      </div>
+      <button
+        @click="increment"
+        :disabled="cartProduct.quantity === 10"
+        type="button"
+        class="flex-none px-2 disabled:cursor-not-allowed disabled:opacity-50 text-slate-900 hover:bg-slate-900 hover:text-white dark:text-white dark:hover:bg-slate-700 rtl:dark:hover:rounded-l ltr:dark:hover:rounded-r"
+      >
+        <Icon icon="eva:plus-fill" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Icon from "@/components/Icon";
+import { ref } from "vue";
+import { cartStore } from "@/store/cart";
+
+const cart = cartStore();
+
+const props = defineProps({
+  product: Object,
+});
+
+const increment = () => cart.addToCart(cartProduct);
+const decrement = () => {
+  cartProduct.quantity === 1 ? "" : cartProduct.quantity--;
+  cart.getTotalPrice();
+};
+
+const cartProduct = cart.getItems.find((item) => item.id == props.product.id);
+</script>
+
+<style scoped></style>

--- a/frontend/src/store/cart.js
+++ b/frontend/src/store/cart.js
@@ -1,0 +1,50 @@
+import { defineStore } from "pinia";
+
+export const cartStore = defineStore("cart", {
+  state: () => ({
+    items: [],
+    totalPrice: 0,
+  }),
+  actions: {
+    addToCart(product) {
+      const itemFound = this.items.find((item) => item.id === product.id);
+
+      if (itemFound) {
+        itemFound.quantity += 1;
+        // this.totalPrice += itemFound.price;
+      } else {
+        this.items.push({ ...product, quantity: 1 });
+        // this.totalPrice += product.price;
+      }
+
+      this.getTotalPrice();
+    },
+
+    removeFromCart(item) {
+      let itemFound = this.items.find((i) => item.id == i.id);
+      if (itemFound) {
+        this.items = this.items.filter((i) => item.id !== i.id);
+      }
+
+      this.getTotalPrice();
+    },
+    removeAllFromCart() {
+      this.items = [];
+      this.totalPrice = 0;
+    },
+
+    getTotalPrice() {
+      this.totalPrice = 0;
+      this.items.map((product) => {
+        let quantity = parseInt(product.quantity);
+        let pricePerUnit = parseInt(product.price);
+        this.totalPrice += pricePerUnit * quantity;
+      });
+    },
+  },
+  getters: {
+    getItems() {
+      return this.items;
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add button, dropdown, and ecommerce counter components used by header
- Introduce cart store for cart drawer and counter button

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68ade81ba9a0832389566a008e796a93