### PR TITLE
fix pinia store initialization in nav tools

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/MonochromeMode.vue
+++ b/frontend/src/components/ui/Header/Navtools/MonochromeMode.vue
@@ -6,19 +6,14 @@
     <Icon icon="mdi:palette-outline" class="font-bold" />
   </span>
 </template>
-<script>
+<script setup>
 import Icon from "@/components/Icon";
 import { useThemeSettingsStore } from "@/store/themeSettings";
+
 const themeSettingsStore = useThemeSettingsStore();
-export default {
-  components: {
-    Icon,
-  },
-  methods: {
-    toggleMonochrome() {
-      themeSettingsStore.toggleMonochrome();
-    },
-  },
-};
+
+function toggleMonochrome() {
+  themeSettingsStore.toggleMonochrome();
+}
 </script>
 <style lang=""></style>

--- a/frontend/src/components/ui/Header/Navtools/SwitchDark.vue
+++ b/frontend/src/components/ui/Header/Navtools/SwitchDark.vue
@@ -3,30 +3,18 @@
     @click="toogleDark"
     class="h-[28px] w-[28px] lg:h-[32px] lg:w-[32px] lg:bg-slate-100 lg:dark:bg-slate-900 dark:text-white text-slate-900 cursor-pointer rounded-full text-[20px] flex flex-col items-center justify-center"
   >
-    <Icon
-      icon="heroicons-outline:moon"
-      v-if="!this.$store.themeSettingsStore.isDark"
-    />
-    <Icon
-      icon="heroicons-outline:sun"
-      v-else-if="this.$store.themeSettingsStore.isDark"
-    />
+    <Icon icon="heroicons-outline:moon" v-if="!themeSettingsStore.isDark" />
+    <Icon icon="heroicons-outline:sun" v-else />
   </span>
 </template>
-<script>
+<script setup>
 import Icon from "@/components/Icon";
 import { useThemeSettingsStore } from "@/store/themeSettings";
+
 const themeSettingsStore = useThemeSettingsStore();
 
-export default {
-  components: {
-    Icon,
-  },
-  methods: {
-    toogleDark() {
-      themeSettingsStore.toogleDark();
-    },
-  },
-};
+function toogleDark() {
+  themeSettingsStore.toogleDark();
+}
 </script>
 <style lang=""></style>


### PR DESCRIPTION
## Summary
- use theme settings store within setup in SwitchDark and MonochromeMode components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade95bef2083238e7a883b0476bafc