### PR TITLE
fix dashboard route alias and hide loader on route change

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,7 @@ const APP_NAME = import.meta.env.VITE_APP_NAME || 'AsBuild';
 export const routes = [
   {
     path: '/',
+    alias: '/dashboard',
     name: 'dashboard',
     component: () => import('@/views/home/Dashboard.vue'),
     meta: {
@@ -407,6 +408,13 @@ router.beforeEach(async (to, from, next) => {
   }
 
   next();
+});
+
+router.afterEach(() => {
+  const appLoading = document.getElementById('loading-bg');
+  if (appLoading) {
+    appLoading.style.display = 'none';
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- allow `/dashboard` route alias for dashboard view
- hide initial page loader after every navigation

## Testing
- `npm test`
- `npm run lint` *(fails: 17 errors, 670 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aebea7e4188323affa664ed26e6e97