### PR TITLE
fix: ensure dev server recompile and suppress Sass warnings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,6 +56,7 @@
         "@vitejs/plugin-vue": "5.0.4",
         "autoprefixer": "10.4.16",
         "axios-mock-adapter": "1.21.2",
+        "cross-env": "^7.0.3",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-vue": "9.23.0",
@@ -3056,6 +3057,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "test": "vitest run tests/unit tests/*.test.ts && playwright test tests/e2e",
+    "dev": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite",
+    "build": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite build",
+    "preview": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite preview",
+    "test": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vitest run tests/unit tests/*.test.ts && cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api playwright test tests/e2e",
     "lint": "eslint src --ext .ts,.vue",
     "format": "prettier --write ."
   },
@@ -69,6 +69,7 @@
     "jsdom": "22.1.0",
     "postcss": "8.4.31",
     "prettier": "3.2.5",
+    "cross-env": "^7.0.3",
     "sass-embedded": "^1.77.5",
     "tailwindcss": "3.4.3",
     "typescript": "5.3.3",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,10 +2,29 @@ import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import path from 'path';
 
+// Silence deprecation warnings from Dart Sass' legacy JS API and
+// ensure file changes are detected in environments where file system
+// events are unreliable (e.g. Docker or network mounts).
+process.env.SASS_SILENCE_DEPRECATIONS = 'legacy-js-api';
+
 export default defineConfig({
   plugins: [vue()],
   base: '',
   envPrefix: ['VITE_', 'API_'],
+  server: {
+    watch: {
+      // Use polling so `npm run dev` recompiles when files change
+      usePolling: true,
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Avoid Dart Sass legacy API deprecation warnings
+        silenceDeprecations: ['legacy-js-api'],
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## Summary
- force Vite to use polling for file changes and silence Dart Sass legacy API warnings
- wire cross-env in NPM scripts and configure Sass to suppress deprecated API messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aec33791b88323b1bef048a50e8da7