### PR TITLE
feat(frontend): simplify header and show user

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/Profile.vue
+++ b/frontend/src/components/ui/Header/Navtools/Profile.vue
@@ -2,12 +2,10 @@
   <Dropdown classMenuItems=" w-[180px] top-[58px] ">
     <div class="flex items-center">
       <div class="flex-1 ltr:mr-[10px] rtl:ml-[10px]">
-        <div class="lg:h-8 lg:w-8 h-7 w-7 rounded-full">
-          <img
-            :src= "profileImg"
-            alt=""
-            class="block w-full h-full object-cover rounded-full"
-          />
+        <div
+          class="lg:h-8 lg:w-8 h-7 w-7 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center text-slate-900 dark:text-white text-sm font-medium"
+        >
+          {{ initials }}
         </div>
       </div>
       <div
@@ -15,7 +13,7 @@
       >
         <span
           class="overflow-hidden text-ellipsis whitespace-nowrap w-[85px] block"
-          >Albert Flores</span
+          >{{ userName }}</span
         >
         <span class="text-base inline-block ltr:ml-[10px] rtl:mr-[10px]"
           ><Icon icon="heroicons-outline:chevron-down"></Icon
@@ -26,11 +24,11 @@
       <MenuItem v-slot="{ active }" v-for="(item, i) in ProfileMenu" :key="i">
         <div
           type="button"
-          :class="`${
+          :class="
             active
               ? 'bg-slate-100 dark:bg-slate-700 dark:bg-opacity-70 text-slate-900 dark:text-slate-300'
               : 'text-slate-600 dark:text-slate-300'
-          } `"
+          "
           class="inline-flex items-center space-x-2 rtl:space-x-reverse w-full px-4 py-2 first:rounded-t last:rounded-b font-normal cursor-pointer"
           @click="item.link()"
         >
@@ -45,81 +43,88 @@
     </template>
   </Dropdown>
 </template>
-<script>
-import { MenuItem } from "@headlessui/vue";
-import Dropdown from "@/components/Dropdown";
-import Icon from "@/components/Icon";
-import profileImg from "@/assets/images/logo/logo.svg"
-export default {
-  components: {
-    Icon,
-    Dropdown,
-    MenuItem,
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { MenuItem } from '@headlessui/vue';
+import Dropdown from '@/components/Dropdown';
+import Icon from '@/components/Icon';
+import { useAuthStore } from '@/stores/auth';
+import { useRouter } from 'vue-router';
+
+const authStore = useAuthStore();
+const router = useRouter();
+
+const userName = computed(() => authStore.user?.name || '');
+
+const initials = computed(() => {
+  const name = userName.value.trim();
+  if (!name) return '';
+  const parts = name.split(' ');
+  const first = parts[0]?.[0] || '';
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : '';
+  return (first + last).toUpperCase();
+});
+
+const ProfileMenu = [
+  {
+    label: 'Profile',
+    icon: 'heroicons-outline:user',
+    link: () => {
+      router.push('profile');
+    },
   },
-  data() {
-    return {
-      profileImg,
-      ProfileMenu: [
-        {
-          label: "Profile",
-          icon: "heroicons-outline:user",
-          link: () => {
-            this.$router.push("profile");
-          },
-        },
-        {
-          label: "Chat",
-          icon: "heroicons-outline:chat",
-          link: () => {
-            this.$router.push("chat");
-          },
-        },
-        {
-          label: "Email",
-          icon: "heroicons-outline:mail",
-          link: () => {
-            this.$router.push("email");
-          },
-        },
-        {
-          label: "Todo",
-          icon: "heroicons-outline:clipboard-check",
-          link: () => {
-            this.$router.push("todo");
-          },
-        },
-        {
-          label: "Settings",
-          icon: "heroicons-outline:cog",
-          link: () => {
-            this.$router.push("settings");
-          },
-        },
-        {
-          label: "Price",
-          icon: "heroicons-outline:credit-card",
-          link: () => {
-            this.$router.push("pricing");
-          },
-        },
-        {
-          label: "Faq",
-          icon: "heroicons-outline:information-circle",
-          link: () => {
-            this.$router.push("faq");
-          },
-        },
-        {
-          label: "Logout",
-          icon: "heroicons-outline:login",
-          link: () => {
-            this.$router.push("/");
-            localStorage.removeItem("activeUser");
-          },
-        },
-      ],
-    };
+  {
+    label: 'Chat',
+    icon: 'heroicons-outline:chat',
+    link: () => {
+      router.push('chat');
+    },
   },
-};
+  {
+    label: 'Email',
+    icon: 'heroicons-outline:mail',
+    link: () => {
+      router.push('email');
+    },
+  },
+  {
+    label: 'Todo',
+    icon: 'heroicons-outline:clipboard-check',
+    link: () => {
+      router.push('todo');
+    },
+  },
+  {
+    label: 'Settings',
+    icon: 'heroicons-outline:cog',
+    link: () => {
+      router.push('settings');
+    },
+  },
+  {
+    label: 'Price',
+    icon: 'heroicons-outline:credit-card',
+    link: () => {
+      router.push('pricing');
+    },
+  },
+  {
+    label: 'Faq',
+    icon: 'heroicons-outline:information-circle',
+    link: () => {
+      router.push('faq');
+    },
+  },
+  {
+    label: 'Logout',
+    icon: 'heroicons-outline:login',
+    link: () => {
+      router.push('/');
+      localStorage.removeItem('activeUser');
+    },
+  },
+];
 </script>
+
 <style lang=""></style>

--- a/frontend/src/components/ui/Header/index.vue
+++ b/frontend/src/components/ui/Header/index.vue
@@ -57,10 +57,7 @@
         <div
           class="nav-tools flex items-center lg:space-x-5 space-x-3 rtl:space-x-reverse"
         >
-          <LanguageVue />
           <SwitchDark />
-          <MonochromeMode />
-          <Carti />
           <Message v-if="window.width > 768" />
           <Notification v-if="window.width > 768" />
           <Profile v-if="window.width > 768" />
@@ -71,16 +68,13 @@
   </header>
 </template>
 <script>
-import Carti from "./Navtools/Carti.vue";
 import Profile from "./Navtools/Profile.vue";
 import Notification from "./Navtools/Notification.vue";
 import Message from "./Navtools/Message.vue";
 import SwitchDark from "./Navtools/SwitchDark.vue";
-import MonochromeMode from "./Navtools/MonochromeMode.vue";
 import Mainnav from "./horizental-nav.vue";
 import Icon from "../Icon";
 import SearchModal from "./Navtools/SearchModal.vue";
-import LanguageVue from "./Navtools/Language.vue";
 import Logo from "./Navtools/Logo.vue";
 import MobileLogo from "./Navtools/MobileLogo.vue";
 import window from "@/mixins/window";
@@ -89,15 +83,12 @@ import HandleMobileMenu from "./Navtools/HandleMobileMenu.vue";
 export default {
   mixins: [window],
   components: {
-    Carti,
     Profile,
     Notification,
     Message,
     SwitchDark,
-    MonochromeMode,
     Mainnav,
     Icon,
-    LanguageVue,
     SearchModal,
     Logo,
     MobileLogo,


### PR DESCRIPTION
## Summary
- remove language, cart, and palette actions from header
- display authenticated user's name with initial-based avatar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aed27e86cc8323ac6d6322e390e790