### PR TITLE
Fix logout button in profile menu

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/Profile.vue
+++ b/frontend/src/components/ui/Header/Navtools/Profile.vue
@@ -119,9 +119,9 @@ const ProfileMenu = [
   {
     label: 'Logout',
     icon: 'heroicons-outline:login',
-    link: () => {
-      router.push('/');
-      localStorage.removeItem('activeUser');
+    link: async () => {
+      await authStore.logout();
+      router.push('/auth/login');
     },
   },
 ];


### PR DESCRIPTION
## Summary
- call auth store logout from profile menu and route to login

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aed418389083238ae832ccabb1389f