### PR TITLE
feat: add quick add menu and simplify profile dropdown

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/AddNew.vue
+++ b/frontend/src/components/ui/Header/Navtools/AddNew.vue
@@ -1,0 +1,58 @@
+<template>
+  <div
+    v-if="items.length"
+    class="relative"
+    @mouseenter="open = true"
+    @mouseleave="open = false"
+  >
+    <span
+      class="lg:h-[32px] lg:w-[32px] lg:bg-slate-100 lg:dark:bg-slate-900 dark:text-white cursor-pointer rounded-full text-[20px] flex items-center justify-center"
+    >
+      <Icon icon="heroicons-outline:plus" />
+    </span>
+    <div
+      v-show="open"
+      class="absolute left-0 top-[58px] w-[180px] rounded bg-white dark:bg-slate-800 shadow-dropdown border border-slate-100 dark:border-slate-700 z-[9999]"
+    >
+      <div
+        v-for="(item, i) in items"
+        :key="i"
+        class="px-4 py-2 text-sm flex items-center space-x-2 rtl:space-x-reverse cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-700 first:rounded-t last:rounded-b text-slate-600 dark:text-slate-300"
+        @click="go(item.link)"
+      >
+        <Icon :icon="item.icon" class="text-lg" />
+        <span class="flex-1">{{ item.label }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import Icon from '@/components/Icon';
+import { addNewOptions } from '@/constant/data';
+import { useAuthStore } from '@/stores/auth';
+
+const open = ref(false);
+const router = useRouter();
+const auth = useAuthStore();
+
+const roles = computed(() => auth.user?.roles?.map((r: any) => r.name) || []);
+
+const items = computed(() =>
+  addNewOptions.filter((i) => {
+    if (!i.admin) return true;
+    return roles.value.some((r) => ['ClientAdmin', 'SuperAdmin'].includes(r));
+  })
+);
+
+const go = (name: string) => {
+  open.value = false;
+  router.push({ name });
+};
+</script>
+
+<style scoped>
+</style>
+

--- a/frontend/src/components/ui/Header/Navtools/Profile.vue
+++ b/frontend/src/components/ui/Header/Navtools/Profile.vue
@@ -66,14 +66,34 @@ const initials = computed(() => {
   return (first + last).toUpperCase();
 });
 
+// Items currently visible in the profile dropdown
 const ProfileMenu = [
   {
     label: 'Profile',
     icon: 'heroicons-outline:user',
     link: () => {
-      router.push('profile');
+      router.push({ name: 'settings.profile' });
     },
   },
+  {
+    label: 'Settings',
+    icon: 'heroicons-outline:cog',
+    link: () => {
+      router.push({ name: 'settings' });
+    },
+  },
+  {
+    label: 'Logout',
+    icon: 'heroicons-outline:login',
+    link: async () => {
+      await authStore.logout();
+      router.push('/auth/login');
+    },
+  },
+];
+
+// Previously available items kept for potential future use
+const ProfileMenuStack = [
   {
     label: 'Chat',
     icon: 'heroicons-outline:chat',
@@ -96,13 +116,6 @@ const ProfileMenu = [
     },
   },
   {
-    label: 'Settings',
-    icon: 'heroicons-outline:cog',
-    link: () => {
-      router.push('settings');
-    },
-  },
-  {
     label: 'Price',
     icon: 'heroicons-outline:credit-card',
     link: () => {
@@ -114,14 +127,6 @@ const ProfileMenu = [
     icon: 'heroicons-outline:information-circle',
     link: () => {
       router.push('faq');
-    },
-  },
-  {
-    label: 'Logout',
-    icon: 'heroicons-outline:login',
-    link: async () => {
-      await authStore.logout();
-      router.push('/auth/login');
     },
   },
 ];

--- a/frontend/src/components/ui/Header/index.vue
+++ b/frontend/src/components/ui/Header/index.vue
@@ -57,6 +57,7 @@
         <div
           class="nav-tools flex items-center lg:space-x-5 space-x-3 rtl:space-x-reverse"
         >
+          <AddNew />
           <SwitchDark />
           <Message v-if="window.width > 768" />
           <Notification v-if="window.width > 768" />
@@ -79,6 +80,7 @@ import Logo from "./Navtools/Logo.vue";
 import MobileLogo from "./Navtools/MobileLogo.vue";
 import window from "@/mixins/window";
 import HandleMobileMenu from "./Navtools/HandleMobileMenu.vue";
+import AddNew from "./Navtools/AddNew.vue";
 
 export default {
   mixins: [window],
@@ -93,6 +95,7 @@ export default {
     Logo,
     MobileLogo,
     HandleMobileMenu,
+    AddNew,
   },
 
   methods: {

--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -99,6 +99,33 @@ export const topMenu = [
   },
 ];
 
+// Quick access options for creating new resources
+export const addNewOptions = [
+  {
+    label: 'Appointment',
+    icon: 'heroicons-outline:calendar',
+    link: 'appointments.create',
+  },
+  {
+    label: 'Type',
+    icon: 'heroicons-outline:tag',
+    link: 'types.create',
+    admin: true,
+  },
+  {
+    label: 'Manual',
+    icon: 'heroicons-outline:book-open',
+    link: 'manuals.create',
+    admin: true,
+  },
+  {
+    label: 'Employee',
+    icon: 'heroicons-outline:users',
+    link: 'employees.create',
+    admin: true,
+  },
+];
+
 export const notifications = [
   {
     title: "Your order is placed",


### PR DESCRIPTION
## Summary
- trim dead profile menu entries and stash them for future use
- introduce hover quick-add menu for creating common items

## Testing
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed5485f188323b22dd636ccfc18c1