### PR TITLE
Fix dropdown menu closing in header AddNew component

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/AddNew.vue
+++ b/frontend/src/components/ui/Header/Navtools/AddNew.vue
@@ -3,7 +3,7 @@
     v-if="items.length"
     class="relative"
     @mouseenter="open = true"
-    @mouseleave="open = false"
+    @mouseleave="handleMouseLeave"
   >
     <span
       class="lg:h-[32px] lg:w-[32px] lg:bg-slate-100 lg:dark:bg-slate-900 dark:text-white cursor-pointer rounded-full text-[20px] flex items-center justify-center"
@@ -50,6 +50,15 @@ const items = computed(() =>
 const go = (name: string) => {
   open.value = false;
   router.push({ name });
+};
+
+const handleMouseLeave = (e: MouseEvent) => {
+  const current = e.currentTarget as HTMLElement;
+  const related = e.relatedTarget as Node | null;
+  if (related && current.contains(related)) {
+    return;
+  }
+  open.value = false;
 };
 </script>
 


### PR DESCRIPTION
## Summary
- Prevent AddNew dropdown from closing when moving cursor from plus icon to menu
- Handle mouse leave events more accurately to keep dropdown open while hovering menu

## Testing
- `npm test`
- `npm run lint` *(fails: 17 errors, 670 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aed6a370f08323b0cdf40a4c768429