### PR TITLE
Allow Super Admin to manage footer text

### DIFF
--- a/backend/database/seeders/TenantSettingsSeeder.php
+++ b/backend/database/seeders/TenantSettingsSeeder.php
@@ -10,11 +10,20 @@ class TenantSettingsSeeder extends Seeder
     public function run(): void
     {
         DB::table('tenant_settings')->insert([
-            'tenant_id' => 1,
-            'key' => 'branding',
-            'value' => json_encode(['name' => 'Default Brand']),
-            'created_at' => now(),
-            'updated_at' => now(),
+            [
+                'tenant_id' => 1,
+                'key' => 'branding',
+                'value' => json_encode(['name' => 'Default Brand']),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'tenant_id' => 1,
+                'key' => 'footer',
+                'value' => 'Default footer',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
         ]);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -68,6 +68,8 @@ Route::middleware(['auth:sanctum', 'tenant'])->group(function () {
     Route::get('settings/branding', [SettingsController::class, 'getBranding']);
     Route::put('settings/branding', [SettingsController::class, 'updateBranding']);
     Route::put('settings/profile', [SettingsController::class, 'updateProfile']);
+    Route::get('settings/footer', [SettingsController::class, 'getFooter']);
+    Route::put('settings/footer', [SettingsController::class, 'updateFooter']);
 
     Route::prefix('gdpr')->group(function () {
         Route::get('export', [GdprController::class, 'export']);

--- a/backend/tests/Feature/FooterSettingsRoutesTest.php
+++ b/backend/tests/Feature/FooterSettingsRoutesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class FooterSettingsRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $tenant = Tenant::create(['name' => 'Test Tenant']);
+        $role = Role::create(['name' => 'SuperAdmin', 'tenant_id' => $tenant->id]);
+        $user = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+        $this->tenant = $tenant;
+    }
+
+    public function test_super_admin_can_update_and_get_footer(): void
+    {
+        $payload = ['text' => 'New footer'];
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->putJson('/api/settings/footer', $payload)
+            ->assertStatus(200)
+            ->assertJsonPath('text', 'New footer');
+
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->getJson('/api/settings/footer')
+            ->assertStatus(200)
+            ->assertJsonPath('text', 'New footer');
+    }
+
+    public function test_client_admin_cannot_update_footer(): void
+    {
+        $tenant = Tenant::create(['name' => 'Another Tenant']);
+        $role = Role::create(['name' => 'ClientAdmin', 'tenant_id' => $tenant->id]);
+        $user = User::create([
+            'name' => 'Client',
+            'email' => 'client@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->putJson('/api/settings/footer', ['text' => 'Forbidden'])
+            ->assertStatus(403);
+    }
+}
+


### PR DESCRIPTION
## Summary
- enable Super Admin-only footer setting management
- seed default footer text
- cover footer settings routes with feature tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aed811175c832389af9cd726bdd604