### PR TITLE
Persist theme customizer and dark mode selections

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -44,6 +44,21 @@ app.config.globalProperties.$store = {};
 const themeSettingsStore = useThemeSettingsStore();
 app.config.globalProperties.$store.themeSettingsStore = themeSettingsStore;
 
+// Apply any saved theme customizer settings on startup and persist future
+// changes so user preferences survive page reloads and new sessions.
+document.body.classList.remove(
+  themeSettingsStore.theme === "dark" ? "light" : "dark"
+);
+document.body.classList.add(themeSettingsStore.theme);
+document.body.classList.toggle("semi-dark", themeSettingsStore.semidark);
+if (localStorage.getItem("monochrome")) {
+  document.documentElement.classList.add("grayscale");
+}
+
+themeSettingsStore.$subscribe((_, state) => {
+  localStorage.setItem("themeSettings", JSON.stringify(state));
+});
+
 router.isReady().then(() => {
   app.mount("#app");
 });

--- a/frontend/src/store/themeSettings.js
+++ b/frontend/src/store/themeSettings.js
@@ -1,28 +1,36 @@
 import { defineStore } from "pinia";
 
+// Default state for the theme customizer.  When the store initializes we merge
+// any persisted settings from localStorage so that user choices persist across
+// refreshes and future logins.
+const defaultState = {
+  sidebarCollaspe: false,
+  sidebarHidden: false,
+  mobielSidebar: false,
+  semidark: false,
+  monochrome: false,
+  semiDarkTheme: "semi-light",
+  isDark: false,
+  skin: "default",
+  theme: "light",
+  isOpenSettings: false,
+  cWidth: "full",
+  menuLayout: "vertical",
+  navbarType: "sticky",
+  isMouseHovered: false,
+  footerType: "static",
+  direction: false,
+  cartOpener: false,
+  chartColors: {
+    title: "red",
+  },
+};
+
 export const useThemeSettingsStore = defineStore("themeSettings", {
-  state: () => ({
-    sidebarCollaspe: false,
-    sidebarHidden: false,
-    mobielSidebar: false,
-    semidark: false,
-    monochrome: false,
-    semiDarkTheme: "semi-light",
-    isDark: false,
-    skin: "default",
-    theme: "light",
-    isOpenSettings: false,
-    cWidth: "full",
-    menuLayout: "vertical",
-    navbarType: "sticky",
-    isMouseHovered: false,
-    footerType: "static",
-    direction: false,
-    cartOpener: false,
-    chartColors: {
-      title: "red",
-    },
-  }),
+  state: () => {
+    const saved = localStorage.getItem("themeSettings");
+    return saved ? { ...defaultState, ...JSON.parse(saved) } : { ...defaultState };
+  },
   actions: {
     setSidebarCollasp() {
       this.sidebarCollasp = !this.sidebarCollasp;

--- a/frontend/src/stores/themeSettings.js
+++ b/frontend/src/stores/themeSettings.js
@@ -1,28 +1,38 @@
 import { defineStore } from "pinia";
 
+// Default state for the theme customizer.  We merge any persisted values from
+// localStorage with these defaults when the store is first created so that user
+// preferences survive refreshes and future logins.
+const defaultState = {
+  sidebarCollaspe: false,
+  sidebarHidden: false,
+  mobielSidebar: false,
+  semidark: false,
+  monochrome: false,
+  semiDarkTheme: "semi-light",
+  isDark: false,
+  skin: "default",
+  theme: "light",
+  isOpenSettings: false,
+  cWidth: "full",
+  menuLayout: "vertical",
+  navbarType: "sticky",
+  isMouseHovered: false,
+  footerType: "static",
+  direction: false,
+  cartOpener: false,
+  chartColors: {
+    title: "red",
+  },
+};
+
 export const useThemeSettingsStore = defineStore("themeSettings", {
-  state: () => ({
-    sidebarCollaspe: false,
-    sidebarHidden: false,
-    mobielSidebar: false,
-    semidark: false,
-    monochrome: false,
-    semiDarkTheme: "semi-light",
-    isDark: false,
-    skin: "default",
-    theme: "light",
-    isOpenSettings: false,
-    cWidth: "full",
-    menuLayout: "vertical",
-    navbarType: "sticky",
-    isMouseHovered: false,
-    footerType: "static",
-    direction: false,
-    cartOpener: false,
-    chartColors: {
-      title: "red",
-    },
-  }),
+  // Load any previously saved settings from localStorage.  If none are found we
+  // fall back to the defaults above.
+  state: () => {
+    const saved = localStorage.getItem("themeSettings");
+    return saved ? { ...defaultState, ...JSON.parse(saved) } : { ...defaultState };
+  },
   actions: {
     setSidebarCollasp() {
       this.sidebarCollasp = !this.sidebarCollasp;


### PR DESCRIPTION
## Summary
- load and apply saved theme settings from localStorage so user customizations persist
- sync theme customizer state to localStorage on changes and reapply at startup

## Testing
- `npm test`
- `npx playwright test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run lint` *(fails: 17 errors, 672 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aed9c78bf083239b6734ad8ccf7b56