### PR TITLE
fix: resolve circular auth store import

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 import notify from '@/plugins/notify';
-import { useAuthStore } from '@/stores/auth';
 
 export interface ApiError {
   message: string;
@@ -67,6 +66,7 @@ api.interceptors.response.use(
 
     if (status === 401 && !config._retry) {
       config._retry = true;
+      const { useAuthStore } = await import('@/stores/auth');
       const auth = useAuthStore();
       if (auth.refreshToken) {
         try {


### PR DESCRIPTION
## Summary
- avoid circular dependency by lazily importing auth store in API service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeda9d09a083238fffe3778dde5eef