### PR TITLE
Fix null user handling in theme settings endpoint

### DIFF
--- a/backend/app/Http/Controllers/Api/SettingsController.php
+++ b/backend/app/Http/Controllers/Api/SettingsController.php
@@ -90,7 +90,8 @@ class SettingsController extends Controller
 
     public function getTheme(Request $request)
     {
-        return response()->json($request->user()->theme_settings ?? []);
+        $user = $request->user();
+        return response()->json($user?->theme_settings ?? []);
     }
 
     public function updateTheme(Request $request)

--- a/backend/tests/Feature/ThemeSettingsRoutesTest.php
+++ b/backend/tests/Feature/ThemeSettingsRoutesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ThemeSettingsRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_get_theme_settings(): void
+    {
+        $tenant = Tenant::create(['name' => 'Test Tenant']);
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        Sanctum::actingAs($user);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->getJson('/api/settings/theme')
+            ->assertStatus(200)
+            ->assertExactJson([]);
+    }
+}


### PR DESCRIPTION
## Summary
- Guard `getTheme` route against missing authenticated user
- Add feature test for retrieving theme settings

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aede6b2fb08323a02db6404d2f2282