### PR TITLE
refactor: remove dynamic imports for stores

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,11 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 import notify from '@/plugins/notify';
 
+let authGetter: (() => any) | null = null;
+export function registerAuthStore(getter: () => any) {
+  authGetter = getter;
+}
+
 export interface ApiError {
   message: string;
   status?: number;
@@ -64,10 +69,9 @@ api.interceptors.response.use(
       }
     }
 
-    if (status === 401 && !config._retry) {
+    if (status === 401 && !config._retry && authGetter) {
       config._retry = true;
-      const { useAuthStore } = await import('@/stores/auth');
-      const auth = useAuthStore();
+      const auth = authGetter();
       if (auth.refreshToken) {
         try {
           await auth.refresh();

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
-import api from '@/services/api';
+import api, { registerAuthStore } from '@/services/api';
+import { useThemeSettingsStore } from './themeSettings';
 import {
   getAccessToken,
   getRefreshToken,
@@ -39,7 +40,6 @@ export const useAuthStore = defineStore('auth', {
         setTokens(data.access_token, data.refresh_token);
         api.defaults.headers.common['Authorization'] =
           `Bearer ${data.access_token}`;
-        const { useThemeSettingsStore } = await import('./themeSettings');
         await useThemeSettingsStore().load();
       }
     },
@@ -91,3 +91,5 @@ export const useAuthStore = defineStore('auth', {
     },
   },
 });
+
+registerAuthStore(() => useAuthStore());


### PR DESCRIPTION
## Summary
- avoid circular dynamic import for auth store by registering store with API
- statically import theme settings store on login

## Testing
- `npm run lint` (fails: 17 errors, 673 warnings)
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aee80146a88323928bf9a12b936491