### PR TITLE
Enable CORS only for development and preview

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ command }) => ({
   base: '',
   envPrefix: ['VITE_', 'API_'],
   server: {
+    cors: { origin: '*' },
     watch: {
       // Use polling so `npm run dev` recompiles when files change
       usePolling: true,
@@ -19,6 +20,9 @@ export default defineConfig(({ command }) => ({
     // Disable Vite's HMR client in build/previews to avoid
     // unnecessary websocket connections in production builds.
     ...(command !== 'serve' ? { hmr: false } : {}),
+  },
+  preview: {
+    cors: { origin: '*' },
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
## Summary
- allow all origins on Vite dev and preview servers

## Testing
- `npm test`
- `npm run lint` *(fails: 17 errors, 673 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aef11d164c8323853a4a6fa17f6e6d