### PR TITLE
Fix server path for Laravel backend

### DIFF
--- a/backend/app/Http/Middleware/SecurityHeaders.php
+++ b/backend/app/Http/Middleware/SecurityHeaders.php
@@ -30,6 +30,8 @@ class SecurityHeaders
             $response->headers->set('Access-Control-Allow-Origin', $origin);
         } elseif ($origin === '' && !empty($allowedOrigins)) {
             $response->headers->set('Access-Control-Allow-Origin', $allowedOrigins[0]);
+        } elseif (empty($allowedOrigins)) {
+            $response->headers->set('Access-Control-Allow-Origin', '*');
         }
         $response->headers->set('Access-Control-Allow-Credentials', 'true');
         $response->headers->set('Access-Control-Allow-Methods', implode(',', $cors['allowed_methods'] ?? ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']));

--- a/backend/server.php
+++ b/backend/server.php
@@ -1,0 +1,11 @@
+<?php
+
+$uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+
+$publicPath = __DIR__.'/../public';
+
+if ($uri !== '/' && file_exists($publicPath.$uri)) {
+    return false;
+}
+
+require_once $publicPath.'/index.php';


### PR DESCRIPTION
## Summary
- add a custom server.php pointing to ../public/index.php so running `php artisan serve` works when `public` lives one level up
- default CORS to `*` when no frontend origin is configured

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68aef41d4c2483239d435a0c20fe5073