### PR TITLE
fix(api): remove dependency on root public folder

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -27,5 +27,4 @@ return Application::configure(
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //
-    })->create()
-    ->usePublicPath(dirname(__DIR__, 2).'/public');
+    })->create();

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+// Determine if the application is in maintenance mode...
+if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
+    require $maintenance;
+}
+
+// Register the Composer autoloader...
+require __DIR__.'/../vendor/autoload.php';
+
+// Bootstrap Laravel and handle the request...
+/** @var Application $app */
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$app->handleRequest(Request::capture());

--- a/backend/server.php
+++ b/backend/server.php
@@ -2,10 +2,13 @@
 
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
-$publicPath = __DIR__.'/../public';
+// Resolve the public path relative to the backend directory. This allows the
+// backend to operate as a standalone API without relying on a public folder at
+// the project root.
+$publicPath = __DIR__ . '/public';
 
-if ($uri !== '/' && file_exists($publicPath.$uri)) {
+if ($uri !== '/' && file_exists($publicPath . $uri)) {
     return false;
 }
 
-require_once $publicPath.'/index.php';
+require_once $publicPath . '/index.php';


### PR DESCRIPTION
## Summary
- load API directly from backend's own public folder
- drop external public path configuration
- add minimal public/index.php for API bootstrap

## Testing
- `composer test` *(fails: Failed to open required '/workspace/asbuild/backend/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68aef8ea736c83239d076f740d9f253e