### PR TITLE
feat: replace page zoom transitions with fade

### DIFF
--- a/frontend/src/Layout/AppLayout.vue
+++ b/frontend/src/Layout/AppLayout.vue
@@ -24,3 +24,14 @@
   import Settings from './Settings.vue'
   import { Transition } from 'vue'
   </script>
+<style>
+/* Simple fade transition for page navigation */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/Layout/DashcodeLayout.vue
+++ b/frontend/src/Layout/DashcodeLayout.vue
@@ -98,12 +98,13 @@ export default {
 <style lang="scss">
 .router-animation-enter-active,
 .router-animation-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  /* Use only a fade effect without zooming */
+  transition: opacity 0.2s ease;
 }
 .router-animation-enter-from,
 .router-animation-leave-to {
+  /* Start and end states for fading */
   opacity: 0;
-  transform: translate3d(0, 4%, 0) scale(0.93);
 }
 
 @keyframes slideLeftTransition {


### PR DESCRIPTION
## Summary
- remove zoom effect from router transition and use simple fade
- add fade transition styling for AppLayout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aefe49b2f8832392539b14de08f036