### PR TITLE
Remove zoom effect from route transition

### DIFF
--- a/dashcode-full-source-code/src/Layout/index.vue
+++ b/dashcode-full-source-code/src/Layout/index.vue
@@ -96,34 +96,17 @@ export default {
 };
 </script>
 <style lang="scss">
-.router-animation-enter-active {
-  animation: coming 0.2s;
-  animation-delay: 0.1s;
+.router-animation-enter-active,
+.router-animation-leave-active {
+  /* Use only a fade effect without zooming */
+  transition: opacity 0.2s ease;
+}
+.router-animation-enter-from,
+.router-animation-leave-to {
+  /* Start and end states for fading */
   opacity: 0;
 }
-.router-animation-leave-active {
-  animation: going 0.2s;
-}
 
-@keyframes going {
-  from {
-    transform: translate3d(0, 0, 0) scale(1);
-  }
-  to {
-    transform: translate3d(0, 4%, 0) scale(0.93);
-    opacity: 0;
-  }
-}
-@keyframes coming {
-  from {
-    transform: translate3d(0, 4%, 0) scale(0.93);
-    opacity: 0;
-  }
-  to {
-    transform: translate3d(0, 0, 0) scale(1);
-    opacity: 1;
-  }
-}
 @keyframes slideLeftTransition {
   0% {
     opacity: 0;


### PR DESCRIPTION
## Summary
- simplify router transition animation to a fade-only effect, removing zooming

## Testing
- `npm run lint` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68aeff28180083239083dd73fa123dfd