### PR TITLE
Use fade-only transitions for page content

### DIFF
--- a/frontend/src/Layout/AppLayout.vue
+++ b/frontend/src/Layout/AppLayout.vue
@@ -25,17 +25,13 @@
   import { Transition } from 'vue'
   </script>
 <style>
-/* Slide and fade transition for page navigation */
+/* Fade-only transition for page navigation */
 .page-enter-active,
 .page-leave-active {
-  transition: opacity 0.3s, transform 0.3s;
+  transition: opacity 0.3s ease;
 }
-.page-enter-from {
-  opacity: 0;
-  transform: translateX(20px);
-}
+.page-enter-from,
 .page-leave-to {
   opacity: 0;
-  transform: translateX(-20px);
 }
 </style>


### PR DESCRIPTION
## Summary
- simplify page navigation transitions to fade-only in `AppLayout.vue`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af020a2c4c83239038537aa5ae3f59