### PR TITLE
Use fade transitions between pages

### DIFF
--- a/dashcode-full-source-code/src/Layout/index.vue
+++ b/dashcode-full-source-code/src/Layout/index.vue
@@ -43,9 +43,9 @@
         >
           <Breadcrumbs v-if="!this.$route.meta.hide" />
           <router-view v-slot="{ Component }">
-            <transition name="router-animation" mode="out-in" appear>
-              <component :is="Component"></component>
-            </transition>
+            <Transition name="fade" mode="out-in">
+              <component :is="Component" />
+            </Transition>
           </router-view>
         </div>
       </div>
@@ -96,14 +96,12 @@ export default {
 };
 </script>
 <style lang="scss">
-.router-animation-enter-active,
-.router-animation-leave-active {
-  /* Use only a fade effect without zooming */
+.fade-enter-active,
+.fade-leave-active {
   transition: opacity 0.2s ease;
 }
-.router-animation-enter-from,
-.router-animation-leave-to {
-  /* Start and end states for fading */
+.fade-enter-from,
+.fade-leave-to {
   opacity: 0;
 }
 

--- a/frontend/src/Layout/AppLayout.vue
+++ b/frontend/src/Layout/AppLayout.vue
@@ -6,7 +6,7 @@
         <main class="flex-1 p-4">
           <Breadcrumbs />
           <div class="relative">
-            <Transition name="page" mode="out-in">
+            <Transition name="fade" mode="out-in">
               <router-view />
             </Transition>
           </div>
@@ -26,12 +26,12 @@
   </script>
 <style>
 /* Fade-only transition for page navigation */
-.page-enter-active,
-.page-leave-active {
+.fade-enter-active,
+.fade-leave-active {
   transition: opacity 0.3s ease;
 }
-.page-enter-from,
-.page-leave-to {
+.fade-enter-from,
+.fade-leave-to {
   opacity: 0;
 }
 </style>

--- a/frontend/src/Layout/DashcodeLayout.vue
+++ b/frontend/src/Layout/DashcodeLayout.vue
@@ -43,9 +43,9 @@
         >
           <Breadcrumbs v-if="!this.$route.meta.hide" />
           <router-view v-slot="{ Component }">
-            <transition name="router-animation" mode="in-out" appear>
-              <component :is="Component"></component>
-            </transition>
+            <Transition name="fade" mode="out-in">
+              <component :is="Component" />
+            </Transition>
           </router-view>
         </div>
       </div>
@@ -96,14 +96,12 @@ export default {
 };
 </script>
 <style lang="scss">
-.router-animation-enter-active,
-.router-animation-leave-active {
-  /* Use only a fade effect without zooming */
+.fade-enter-active,
+.fade-leave-active {
   transition: opacity 0.2s ease;
 }
-.router-animation-enter-from,
-.router-animation-leave-to {
-  /* Start and end states for fading */
+.fade-enter-from,
+.fade-leave-to {
   opacity: 0;
 }
 


### PR DESCRIPTION
## Summary
- replace router page transition animations with opacity-only fade transitions
- update layout transition styles to remove slide movement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af0454573c83238193563417ceb517