### PR TITLE
Fix sidebar overlap and restore theme settings panel

### DIFF
--- a/frontend/src/Layout/DashcodeLayout.vue
+++ b/frontend/src/Layout/DashcodeLayout.vue
@@ -85,11 +85,11 @@ export default {
         this.$store.themeSettingsStore.menuLayout === "horizontal" ||
         this.$store.themeSettingsStore.sidebarHidden
       ) {
-        return "ltr:ml-0 rtl:mr-0";
+        return "ms-0";
       } else if (this.$store.themeSettingsStore.sidebarCollasp) {
-        return "ltr:ml-[72px] rtl:mr-[72px]";
+        return "ms-[72px]";
       } else {
-        return "ltr:ml-[248px] rtl:mr-[248px]";
+        return "ms-[248px]";
       }
     },
   },

--- a/frontend/src/components/ui/Settings/index.vue
+++ b/frontend/src/components/ui/Settings/index.vue
@@ -6,20 +6,18 @@
         this.$store.themeSettingsStore.isOpenSettings =
           !this.$store.themeSettingsStore.isOpenSettings
       "
-      class="fixed ltr:md:right-[-32px] ltr:right-0 rtl:left-0 rtl:md:left-[-32px] top-1/2 z-[888] translate-y-1/2 bg-slate-800 text-slate-50 dark:bg-slate-700 dark:text-slate-300 cursor-pointer transform rotate-90 flex items-center text-sm font-medium px-2 py-2 shadow-deep ltr:rounded-b rtl:rounded-t"
+      class="fixed md:-end-8 end-0 top-1/2 z-[888] translate-y-1/2 bg-slate-800 text-slate-50 dark:bg-slate-700 dark:text-slate-300 cursor-pointer transform rotate-90 flex items-center text-sm font-medium px-2 py-2 shadow-deep rounded-b"
     >
       <Icon
         icon="heroicons:cog-6-tooth"
         class="text-slate-50 text-lg animate-spin"
       />
-      <span class="hidden md:inline-block ltr:ml-2 rtl:mr-2"
-        >Settings</span
-      ></span
-    >
+      <span class="hidden md:inline-block ms-2">Settings</span>
+    </span>
     <Transition name="lefttranslate" @after-leave="persistSettings">
       <div
         v-show="this.$store.themeSettingsStore.isOpenSettings"
-        class="setting-wrapper fixed ltr:right-0 rtl:left-0 top-0 md:w-[400px] w-[300px] bg-white dark:bg-slate-800 h-screen z-[9999] px-6 md:pb-6 pb-[100px] shadow-base2 dark:shadow-base3 border border-gray-5002 dark:border-slate-700"
+        class="setting-wrapper fixed end-0 top-0 md:w-[400px] w-[300px] bg-white dark:bg-slate-800 h-screen z-[9999] px-6 md:pb-6 pb-[100px] shadow-base2 dark:shadow-base3 border border-gray-5002 dark:border-slate-700"
       >
         <header
           class="flex items-center justify-between border-b border-slate-100 dark:border-slate-700 -mx-6 px-6 py-[15px] mb-6"

--- a/frontend/src/components/ui/Sidebar/index.vue
+++ b/frontend/src/components/ui/Sidebar/index.vue
@@ -190,7 +190,7 @@ export default defineComponent({
 </script>
 <style lang="scss">
 .sidebar-wrapper {
-  @apply fixed ltr:left-0 rtl:right-0 top-0   h-screen   z-[999];
+  @apply fixed start-0 top-0 h-screen z-[999];
   transition: width 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
   will-change: width;
 }


### PR DESCRIPTION
## Summary
- use logical `ms` margins in layout to prevent sidebar overlap
- position settings panel with logical `end` utilities
- anchor sidebar using `start-0` for consistent placement

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af0b88e67083239247b404a8d56b4b