### PR TITLE
fix: use global content width on dashboard

### DIFF
--- a/frontend/src/views/home/Dashboard.vue
+++ b/frontend/src/views/home/Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mx-auto max-w-7xl space-y-8 p-6">
+  <div class="space-y-8">
     <h2 class="text-3xl font-bold tracking-tight">Dashboard</h2>
 
     <!-- Loading state -->


### PR DESCRIPTION
## Summary
- ensure dashboard respects global boxed or full-width layout

## Testing
- `npm run lint` *(fails: Attribute hyphenation errors in unrelated files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af0fba879883239440f7c53d310431