### PR TITLE
Log HTTP requests

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -10,6 +10,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\SecurityHeaders::class,
         \App\Http\Middleware\RequestId::class,
         \App\Http\Middleware\ETag::class,
+        \App\Http\Middleware\LogRequests::class,
     ];
 
     protected $middlewareAliases = [

--- a/backend/app/Http/Middleware/LogRequests.php
+++ b/backend/app/Http/Middleware/LogRequests.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class LogRequests
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        Log::info(sprintf(
+            '%s %s %s',
+            $request->method(),
+            $request->fullUrl(),
+            $response->status()
+        ));
+
+        return $response;
+    }
+}


### PR DESCRIPTION
## Summary
- add middleware to log method, URL, and status for each request
- register logging middleware in HTTP kernel

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68af37deef008323bd68406d4c5d85d5