### PR TITLE
Allow x-tenant-id header in CORS configuration

### DIFF
--- a/backend/config/security.php
+++ b/backend/config/security.php
@@ -16,7 +16,7 @@ return [
             )
         ),
         'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-        'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With'],
+        'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Tenant-Id'],
     ],
     'csp' => "default-src 'self'; frame-ancestors 'none'; object-src 'none';",
     'max_upload_size' => 5120, // 5 MB

--- a/backend/tests/SecurityHeadersTest.php
+++ b/backend/tests/SecurityHeadersTest.php
@@ -11,5 +11,6 @@ class SecurityHeadersTest extends TestCase
         $response->assertStatus(204);
         $response->assertHeader('Access-Control-Allow-Origin', config('security.cors.allowed_origins')[0]);
         $response->assertHeader('Access-Control-Allow-Credentials', 'true');
+        $response->assertHeader('Access-Control-Allow-Headers', implode(',', config('security.cors.allowed_headers')));
     }
 }


### PR DESCRIPTION
## Summary
- permit `X-Tenant-Id` in CORS allowed headers
- cover preflight header list in tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68af39151bac8323951b2ba512a7673a