### PR TITLE
feat: toggle console logging via API_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Foundation for a Laravel 11 backend and Vue 3 single-page application.
    - Enable the `imagick` extension
 3. Environment:
    - Copy `backend/.env.example` to `backend/.env` and adjust `APP_URL` and database credentials.
+   - Set `API_MODE=development` to stream logs to the console when running `php artisan serve`; use `production` to write logs to `storage/logs/laravel.log`.
    - Install dependencies and generate an app key:
      ```bash
      cd backend && composer install && php artisan key:generate

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,8 @@ APP_URL=https://example.com
 # Comma-separated list of allowed frontend origins for CORS
 FRONTEND_URL=http://localhost:5173,http://127.0.0.1:5173
 
+API_MODE=production
+
 LOG_CHANNEL=stack
 LOG_LEVEL=info
 

--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -9,7 +9,9 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['stderr'],
+            'channels' => env('API_MODE', 'production') === 'development'
+                ? ['stderr']
+                : ['single'],
             'ignore_exceptions' => false,
         ],
 
@@ -20,6 +22,12 @@ return [
                 'stream' => 'php://stderr',
             ],
             'formatter' => JsonFormatter::class,
+        ],
+
+        'single' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
     ],
 ];


### PR DESCRIPTION
## Summary
- add `API_MODE` env variable to switch between development and production
- stream logs to console when `API_MODE=development`
- document new variable in README

## Testing
- `composer install --no-interaction --no-progress`
- `php artisan test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68af3bdc3e10832384e1a83e5cf97337