### PR TITLE
Remove redundant page titles

### DIFF
--- a/frontend/src/views/ManualDetail.vue
+++ b/frontend/src/views/ManualDetail.vue
@@ -1,15 +1,14 @@
 <template>
   <div v-if="manual">
-    <div class="flex justify-between items-center mb-4">
-      <h2 class="text-xl font-bold">{{ manual.file?.filename }}</h2>
-      <button
-        class="text-yellow-500 text-xl"
-        :aria-pressed="isFavorite"
-        @click="store.toggleFavorite(manual.id)"
-      >
-        {{ isFavorite ? '★' : '☆' }}
-      </button>
-    </div>
+      <div class="flex justify-end items-center mb-4">
+        <button
+          class="text-yellow-500 text-xl"
+          :aria-pressed="isFavorite"
+          @click="store.toggleFavorite(manual.id)"
+        >
+          {{ isFavorite ? '★' : '☆' }}
+        </button>
+      </div>
     <div class="text-sm text-gray-500 mb-4">
       Last updated: {{ new Date(manual.updated_at).toLocaleString() }}
     </div>

--- a/frontend/src/views/ManualList.vue
+++ b/frontend/src/views/ManualList.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">Manuals</h2>
-    <div class="flex gap-2 mb-4">
+    <div>
+      <div class="flex gap-2 mb-4">
       <input
         v-model="search"
         @input="onSearch"

--- a/frontend/src/views/ReportsDashboard.vue
+++ b/frontend/src/views/ReportsDashboard.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="mx-auto max-w-7xl space-y-8 p-6">
-    <div
-      class="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center"
-    >
-      <h2 class="text-3xl font-bold tracking-tight">Reports</h2>
+    <div class="flex justify-end mb-4">
       <div class="flex flex-wrap items-end gap-2">
         <Select v-model="range" class="w-40">
           <option value="today">Today</option>

--- a/frontend/src/views/appointments/AppointmentForm.vue
+++ b/frontend/src/views/appointments/AppointmentForm.vue
@@ -1,9 +1,6 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">
-      {{ isEdit ? 'Edit' : 'Create' }} Appointment
-    </h2>
-    <form @submit.prevent="submitForm" class="max-w-lg space-y-4">
+    <div>
+      <form @submit.prevent="submitForm" class="max-w-lg space-y-4">
       <VueSelect label="Type" :error="typeError">
         <vSelect
           v-model="typeId"

--- a/frontend/src/views/appointments/AppointmentsList.vue
+++ b/frontend/src/views/appointments/AppointmentsList.vue
@@ -1,15 +1,14 @@
 <template>
-  <div>
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-xl font-bold">Appointments</h2>
-      <RouterLink
-        class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
-        :to="{ name: 'appointments.create' }"
-      >
-        <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
-        New
-      </RouterLink>
-    </div>
+    <div>
+      <div class="flex items-center justify-end mb-4">
+        <RouterLink
+          class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
+          :to="{ name: 'appointments.create' }"
+        >
+          <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
+          New
+        </RouterLink>
+      </div>
     <div class="flex gap-4 mb-4">
       <select v-model="statusFilter" class="border rounded p-2">
         <option value="">All Statuses</option>

--- a/frontend/src/views/employees/EmployeeForm.vue
+++ b/frontend/src/views/employees/EmployeeForm.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <h2 class="text-xl font-bold mb-4">{{ isEdit ? 'Edit' : 'Invite' }} Employee</h2>
     <form @submit.prevent="submit" class="grid gap-4 max-w-lg">
       <Textinput label="Name" v-model="form.name" />
       <Textinput label="Email" type="email" v-model="form.email" />

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">Employees</h2>
-    <div class="mb-4">
+    <div>
+      <div class="mb-4">
       <Button
         btnClass="btn-primary"
         text="Invite Employee"

--- a/frontend/src/views/home/Dashboard.vue
+++ b/frontend/src/views/home/Dashboard.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="space-y-8">
-    <h2 class="text-3xl font-bold tracking-tight">
-      {{ t('routes.dashboard') }}
-    </h2>
-
     <!-- Loading state -->
     <div v-if="loading" class="space-y-6">
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">

--- a/frontend/src/views/manuals/ManualsList.vue
+++ b/frontend/src/views/manuals/ManualsList.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">Manuals</h2>
-    <div class="flex flex-wrap items-center gap-2 mb-4">
+    <div>
+      <div class="flex flex-wrap items-center gap-2 mb-4">
       <input
         v-model="search"
         placeholder="Search"

--- a/frontend/src/views/reports/Reports.vue
+++ b/frontend/src/views/reports/Reports.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="mx-auto max-w-7xl space-y-8 p-6">
-    <div
-      class="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center"
-    >
-      <h2 class="text-3xl font-bold tracking-tight">Reports</h2>
+    <div class="flex justify-end mb-4">
       <div class="flex flex-wrap items-end gap-2">
         <Dropdown>
           <template #default>

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -1,8 +1,7 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">Tenants</h2>
-    <DashcodeServerTable
-      :key="tableKey"
+    <div>
+      <DashcodeServerTable
+        :key="tableKey"
       :columns="columns"
       :fetcher="fetchTenants"
     >

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
-    <h2 class="text-xl font-bold mb-4">{{ isEdit ? 'Edit' : 'Create' }} Type</h2>
-    <form @submit.prevent="onSubmit" class="grid grid-cols-2 gap-8">
+    <div>
+      <form @submit.prevent="onSubmit" class="grid grid-cols-2 gap-8">
       <div>
         <div class="mb-4">
           <label class="block font-medium mb-1" for="name">Name<span class="text-red-600">*</span></label>

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -1,15 +1,14 @@
 <template>
-  <div>
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-xl font-bold">Appointment Types</h2>
-      <RouterLink
-        class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
-        :to="{ name: 'types.create' }"
+    <div>
+      <div class="flex items-center justify-end mb-4">
+        <RouterLink
+          class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
+          :to="{ name: 'types.create' }"
         >
-        <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
-        Add Type
-      </RouterLink>
-    </div>
+          <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
+          Add Type
+        </RouterLink>
+      </div>
     <DashcodeServerTable
       :key="tableKey"
       :columns="columns"


### PR DESCRIPTION
## Summary
- remove duplicated page headings to rely on breadcrumbs across views
- adjust list and form layouts after heading removal

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute 'btnClass' must be hyphenated and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af3fdeb03c83239ee0e94121743d84