### PR TITLE
feat: add role hierarchy support

### DIFF
--- a/backend/app/Http/Controllers/Api/RoleController.php
+++ b/backend/app/Http/Controllers/Api/RoleController.php
@@ -41,12 +41,14 @@ class RoleController extends Controller
         $tenantId = $this->getTenantId($request);
         $data = $request->validate([
             'name' => 'required|string',
+            'level' => 'required|integer',
         ]);
         if ($data['name'] === 'SuperAdmin') {
             abort(403, 'SuperAdmin role cannot be created');
         }
         $role = Role::create([
             'name' => $data['name'],
+            'level' => $data['level'],
             'tenant_id' => $tenantId,
         ]);
         return response()->json($role, 201);
@@ -74,11 +76,15 @@ class RoleController extends Controller
         }
         $data = $request->validate([
             'name' => 'required|string',
+            'level' => 'required|integer',
         ]);
         if ($data['name'] === 'SuperAdmin') {
             abort(403, 'SuperAdmin role cannot be used');
         }
-        $role->update(['name' => $data['name']]);
+        $role->update([
+            'name' => $data['name'],
+            'level' => $data['level'],
+        ]);
         return $role;
     }
 

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -10,6 +10,7 @@ class Role extends Model
     protected $fillable = [
         'tenant_id',
         'name',
+        'level',
     ];
 
     public function users(): BelongsToMany

--- a/backend/database/migrations/2025_01_01_110100_add_level_to_roles_table.php
+++ b/backend/database/migrations/2025_01_01_110100_add_level_to_roles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->unsignedInteger('level')->default(0)->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn('level');
+        });
+    }
+};

--- a/backend/database/seeders/RoleSeeder.php
+++ b/backend/database/seeders/RoleSeeder.php
@@ -13,6 +13,7 @@ class RoleSeeder extends Seeder
             'id' => 1,
             'tenant_id' => 1,
             'name' => 'SuperAdmin',
+            'level' => 100,
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/tests/Feature/RoleRoutesTest.php
+++ b/backend/tests/Feature/RoleRoutesTest.php
@@ -40,7 +40,7 @@ class RoleRoutesTest extends TestCase
             ->getJson('/api/roles')
             ->assertStatus(200);
 
-        $payload = ['name' => 'Tester'];
+        $payload = ['name' => 'Tester', 'level' => 1];
         $roleId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
@@ -50,11 +50,12 @@ class RoleRoutesTest extends TestCase
             ->getJson("/api/roles/{$roleId}")
             ->assertStatus(200);
 
-        $update = ['name' => 'Updated'];
+        $update = ['name' => 'Updated', 'level' => 2];
         $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->putJson("/api/roles/{$roleId}", $update)
             ->assertStatus(200)
-            ->assertJsonPath('name', 'Updated');
+            ->assertJsonPath('name', 'Updated')
+            ->assertJsonPath('level', 2);
 
         $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->deleteJson("/api/roles/{$roleId}")

--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -5,6 +5,10 @@
         <label class="block font-medium mb-1" for="name">Name<span class="text-red-600">*</span></label>
         <input id="name" v-model="name" class="border rounded p-2 w-full" />
       </div>
+      <div>
+        <label class="block font-medium mb-1" for="level">Level<span class="text-red-600">*</span></label>
+        <input id="level" type="number" v-model.number="level" class="border rounded p-2 w-full" />
+      </div>
       <div v-if="serverError" class="text-red-600 text-sm">{{ serverError }}</div>
       <button
         type="submit"
@@ -26,6 +30,7 @@ const router = useRouter();
 const notify = useNotify();
 
 const name = ref('');
+const level = ref(0);
 const serverError = ref('');
 
 const isEdit = computed(() => route.name === 'roles.edit');
@@ -39,15 +44,18 @@ onMounted(async () => {
       return;
     }
     name.value = data.name;
+    level.value = data.level;
   }
 });
 
-const canSubmit = computed(() => !!name.value && name.value !== 'SuperAdmin');
+const canSubmit = computed(
+  () => !!name.value && name.value !== 'SuperAdmin' && Number.isInteger(level.value)
+);
 
 async function onSubmit() {
   serverError.value = '';
   if (!canSubmit.value) return;
-  const payload = { name: name.value };
+  const payload = { name: name.value, level: level.value };
   try {
     if (isEdit.value) {
       await api.patch(`/roles/${route.params.id}`, payload);

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -45,6 +45,7 @@ const all = ref<any[]>([]);
 const columns = [
   { label: 'ID', field: 'id', sortable: true },
   { label: 'Name', field: 'name', sortable: true },
+  { label: 'Level', field: 'level', sortable: true },
 ];
 
 async function fetchRoles({ page, perPage, sort, search }: any) {


### PR DESCRIPTION
## Summary
- add level column to roles for hierarchical ranking
- expose level in roles API and frontend forms
- cover role hierarchy CRUD in tests

## Testing
- `npm test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b002dd9f708323961768031a1f0356