### PR TITLE
Link appointment types with status flows

### DIFF
--- a/backend/app/Http/Controllers/Api/AppointmentTypeController.php
+++ b/backend/app/Http/Controllers/Api/AppointmentTypeController.php
@@ -55,10 +55,11 @@ class AppointmentTypeController extends Controller
             'name' => ($nameRequired ? 'required' : 'sometimes') . '|string|max:255',
             'form_schema' => 'nullable|json',
             'fields_summary' => 'nullable|json',
+            'statuses' => ($nameRequired ? 'required' : 'sometimes') . '|json',
         ];
         $validated = $request->validate($rules);
 
-        foreach (['form_schema', 'fields_summary'] as $field) {
+        foreach (['form_schema', 'fields_summary', 'statuses'] as $field) {
             if (isset($validated[$field])) {
                 $validated[$field] = json_decode($validated[$field], true);
             }

--- a/backend/app/Models/Appointment.php
+++ b/backend/app/Models/Appointment.php
@@ -84,7 +84,8 @@ class Appointment extends Model
 
     public function canTransitionTo(string $status): bool
     {
-        return in_array($status, self::$transitions[$this->status] ?? []);
+        $transitions = $this->type->statuses ?? self::$transitions;
+        return in_array($status, $transitions[$this->status] ?? []);
     }
 
     public function getSlaStatusAttribute(): string

--- a/backend/app/Models/AppointmentType.php
+++ b/backend/app/Models/AppointmentType.php
@@ -11,11 +11,13 @@ class AppointmentType extends Model
         'name',
         'form_schema',
         'fields_summary',
+        'statuses',
     ];
 
     protected $casts = [
         'form_schema' => 'array',
         'fields_summary' => 'array',
+        'statuses' => 'array',
     ];
 
     public function appointments(): HasMany

--- a/backend/database/migrations/2025_01_01_190100_add_statuses_to_appointment_types_table.php
+++ b/backend/database/migrations/2025_01_01_190100_add_statuses_to_appointment_types_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('appointment_types', function (Blueprint $table) {
+            $table->json('statuses')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('appointment_types', function (Blueprint $table) {
+            $table->dropColumn('statuses');
+        });
+    }
+};

--- a/backend/tests/Feature/AppointmentCommentRoutesTest.php
+++ b/backend/tests/Feature/AppointmentCommentRoutesTest.php
@@ -41,6 +41,10 @@ class AppointmentCommentRoutesTest extends TestCase
             'name' => 'Type A',
             'form_schema' => ['type' => 'object', 'properties' => ['note' => ['type' => 'string']], 'required' => ['note']],
             'fields_summary' => ['note' => 'string'],
+            'statuses' => [
+                'draft' => ['assigned'],
+                'assigned' => ['in_progress'],
+            ],
         ]);
 
         $appointment = Appointment::create([

--- a/backend/tests/Feature/AppointmentRoutesTest.php
+++ b/backend/tests/Feature/AppointmentRoutesTest.php
@@ -47,6 +47,10 @@ class AppointmentRoutesTest extends TestCase
             'name' => 'Type A',
             'form_schema' => ['type' => 'object', 'properties' => ['note' => ['type' => 'string']], 'required' => ['note']],
             'fields_summary' => ['note' => 'string'],
+            'statuses' => [
+                'draft' => ['assigned'],
+                'assigned' => ['in_progress'],
+            ],
         ]);
 
         // store

--- a/backend/tests/Feature/AppointmentTypeRoutesTest.php
+++ b/backend/tests/Feature/AppointmentTypeRoutesTest.php
@@ -46,6 +46,10 @@ class AppointmentTypeRoutesTest extends TestCase
             'name' => 'Type A',
             'form_schema' => json_encode(['type' => 'object', 'properties' => ['note' => ['type' => 'string']], 'required' => ['note']]),
             'fields_summary' => json_encode(['note' => 'string']),
+            'statuses' => json_encode([
+                'draft' => ['assigned'],
+                'assigned' => ['in_progress'],
+            ]),
         ];
         $typeId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->postJson('/api/appointment-types', $payload)


### PR DESCRIPTION
## Summary
- require statuses when creating appointment types
- derive appointment status transitions from type-defined flows
- add migration for statuses column on appointment types

## Testing
- `php vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b0052522808323ae5e43a24f421b8c