### PR TITLE
feat: show role levels and suggest next

### DIFF
--- a/backend/database/seeders/RoleSeeder.php
+++ b/backend/database/seeders/RoleSeeder.php
@@ -13,7 +13,8 @@ class RoleSeeder extends Seeder
             'id' => 1,
             'tenant_id' => 1,
             'name' => 'SuperAdmin',
-            'level' => 100,
+            // SuperAdmin is the root role; use level 0 so other roles can build from it
+            'level' => 0,
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -8,6 +8,8 @@
       <div>
         <label class="block font-medium mb-1" for="level">Level<span class="text-red-600">*</span></label>
         <input id="level" type="number" v-model.number="level" class="border rounded p-2 w-full" />
+        <!-- Show the suggested next level when creating a new role -->
+        <p v-if="!isEdit" class="text-xs text-gray-500 mt-1">Next level: {{ nextLevel }}</p>
       </div>
       <div v-if="serverError" class="text-red-600 text-sm">{{ serverError }}</div>
       <button
@@ -31,6 +33,7 @@ const notify = useNotify();
 
 const name = ref('');
 const level = ref(0);
+const nextLevel = ref<number | null>(null);
 const serverError = ref('');
 
 const isEdit = computed(() => route.name === 'roles.edit');
@@ -45,6 +48,11 @@ onMounted(async () => {
     }
     name.value = data.name;
     level.value = data.level;
+  } else {
+    const { data } = await api.get('/roles');
+    const maxLevel = data.length ? Math.max(...data.map((r: any) => r.level ?? 0)) : -1;
+    nextLevel.value = maxLevel + 1;
+    level.value = nextLevel.value;
   }
 });
 

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -45,6 +45,7 @@ const all = ref<any[]>([]);
 const columns = [
   { label: 'ID', field: 'id', sortable: true },
   { label: 'Name', field: 'name', sortable: true },
+  // Show the role hierarchy level in the table
   { label: 'Level', field: 'level', sortable: true },
 ];
 


### PR DESCRIPTION
## Summary
- set SuperAdmin level to 0
- display role levels in roles table
- suggest next level when creating a role

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00617e8408323874392bc2fe181d1