### PR TITLE
feat: allow custom appointment status flows

### DIFF
--- a/frontend/src/views/appointments/AppointmentDetails.vue
+++ b/frontend/src/views/appointments/AppointmentDetails.vue
@@ -19,11 +19,11 @@
       </ul>
       <div class="flex flex-wrap gap-2 mt-2">
         <Button
-          v-for="a in changeActions"
-          :key="a.value"
-          :text="`Mark ${a.label}`"
+          v-for="s in changeActions"
+          :key="s"
+          :text="`Mark ${s.replace(/_/g, ' ')}`"
           btnClass="btn-outline-primary btn-sm"
-          @click="updateStatus(a.value)"
+          @click="updateStatus(s)"
         />
       </div>
     </Card>
@@ -145,10 +145,9 @@ async function updateStatus(status: string) {
   }
 }
 
-const changeActions = [
-  { label: 'In Progress', value: 'in_progress' },
-  { label: 'Completed', value: 'completed' },
-  { label: 'Rejected', value: 'rejected' },
-  { label: 'Redo', value: 'redo' },
-];
+const changeActions = computed(() => {
+  const map = appointment.value?.type?.statuses || {};
+  const current = appointment.value?.status;
+  return map[current] || [];
+});
 </script>


### PR DESCRIPTION
## Summary
- load appointment status options from backend
- build appointment-type status sequences with drag-and-drop
- update appointment actions to honor custom transitions

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b00774f08c8323b342d364f754ffa7