### PR TITLE
Allow super admins to view roles across tenants

### DIFF
--- a/backend/app/Http/Controllers/Api/RoleController.php
+++ b/backend/app/Http/Controllers/Api/RoleController.php
@@ -31,6 +31,11 @@ class RoleController extends Controller
     public function index(Request $request)
     {
         $this->ensureAdmin($request);
+
+        if ($request->user()->hasRole('SuperAdmin') && ! app()->bound('tenant_id')) {
+            return Role::all();
+        }
+
         $tenantId = $this->getTenantId($request);
         return Role::where('tenant_id', $tenantId)->get();
     }

--- a/backend/tests/Feature/SuperAdminRoleVisibilityTest.php
+++ b/backend/tests/Feature/SuperAdminRoleVisibilityTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SuperAdminRoleVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_view_roles_from_all_tenants_without_header(): void
+    {
+        $rootTenant = Tenant::create(['name' => 'Root']);
+        $superRole = Role::create([
+            'name' => 'SuperAdmin',
+            'tenant_id' => $rootTenant->id,
+            'level' => 0,
+        ]);
+
+        $superUser = User::create([
+            'name' => 'Super',
+            'email' => 'super@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $rootTenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $superUser->roles()->attach($superRole->id, ['tenant_id' => $rootTenant->id]);
+        Sanctum::actingAs($superUser);
+
+        $tenantA = Tenant::create(['name' => 'Tenant A']);
+        $tenantB = Tenant::create(['name' => 'Tenant B']);
+        Role::create(['name' => 'ClientAdmin', 'tenant_id' => $tenantA->id, 'level' => 1]);
+        Role::create(['name' => 'ClientAdmin', 'tenant_id' => $tenantB->id, 'level' => 1]);
+
+        $this->getJson('/api/roles')
+            ->assertStatus(200)
+            ->assertJsonCount(3);
+    }
+}


### PR DESCRIPTION
## Summary
- Let super admins list roles from all tenants without specifying a tenant
- Cover super-admin role visibility with a feature test

## Testing
- `cd backend && ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b00795e4748323924859793af7e1e0