### PR TITLE
fix: ensure role timestamps default to current

### DIFF
--- a/backend/database/migrations/2025_01_01_110200_fix_role_timestamps.php
+++ b/backend/database/migrations/2025_01_01_110200_fix_role_timestamps.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn(['created_at', 'updated_at']);
+        });
+
+        Schema::table('roles', function (Blueprint $table) {
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn(['created_at', 'updated_at']);
+        });
+
+        Schema::table('roles', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- fix role timestamps by recreating columns with current timestamp defaults

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b009d79a3c8323b8a3ce71a448cb1b