### PR TITLE
feat(auth): add tenant scope and ability checks

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -16,5 +16,6 @@ class Kernel extends HttpKernel
     protected $middlewareAliases = [
         'tenant' => \App\Http\Middleware\ResolveTenant::class,
         'signed.url' => \App\Http\Middleware\SignedUrl::class,
+        'ability' => \App\Http\Middleware\Ability::class,
     ];
 }

--- a/backend/app/Http/Middleware/Ability.php
+++ b/backend/app/Http/Middleware/Ability.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class Ability
+{
+    public function handle(Request $request, Closure $next, string $code): Response
+    {
+        $user = $request->user();
+
+        if ($user->isSuperAdmin()) {
+            return $next($request);
+        }
+
+        $tenantId = $request->attributes->get('tenant_id', $user->tenant_id);
+
+        $roles = $user->rolesForTenant($tenantId)
+            ->merge($user->roles()->wherePivotNull('tenant_id')->get());
+
+        $abilities = $roles->pluck('abilities')->flatten()->filter()->unique()->all();
+
+        if ($abilities && ! in_array($code, $abilities)) {
+            return response()->json(['message' => 'forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Middleware/EnsureTenantScope.php
+++ b/backend/app/Http/Middleware/EnsureTenantScope.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Tenant;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureTenantScope
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        $tenantId = $request->header('X-Tenant-ID');
+
+        if ($user->isSuperAdmin()) {
+            if ($tenantId) {
+                $this->bindTenant($request, (int) $tenantId);
+            }
+            return $next($request);
+        }
+
+        if (! $tenantId || $user->tenant_id !== (int) $tenantId) {
+            return response()->json(['message' => 'forbidden'], 403);
+        }
+
+        $this->bindTenant($request, (int) $tenantId);
+
+        return $next($request);
+    }
+
+    protected function bindTenant(Request $request, int $tenantId): void
+    {
+        $tenant = Tenant::find($tenantId);
+        if ($tenant) {
+            Tenant::setCurrent($tenant);
+            $request->attributes->set('tenant_id', $tenantId);
+            app()->instance('tenant_id', $tenantId);
+            $settings = DB::table('tenant_settings')
+                ->where('tenant_id', $tenantId)
+                ->pluck('value', 'key')
+                ->toArray();
+            config(['tenant' => $settings]);
+        }
+    }
+}

--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -4,9 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\App;
 
 class Tenant extends Model
 {
+    protected static ?Tenant $current = null;
     protected $fillable = [
         'name',
         'quota_storage_mb',
@@ -22,5 +24,26 @@ class Tenant extends Model
     public function appointments(): HasMany
     {
         return $this->hasMany(Appointment::class);
+    }
+
+    public static function current(): ?Tenant
+    {
+        if (static::$current) {
+            return static::$current;
+        }
+
+        if (App::bound('tenant_id')) {
+            return static::$current = static::find(App::get('tenant_id'));
+        }
+
+        return null;
+    }
+
+    public static function setCurrent(?Tenant $tenant): void
+    {
+        static::$current = $tenant;
+        if ($tenant) {
+            App::instance('tenant_id', $tenant->id);
+        }
     }
 }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -44,8 +44,10 @@ class User extends Authenticatable
     public function isSuperAdmin(): bool
     {
         return $this->roles()
-            ->whereNull('roles.tenant_id')
-            ->where('slug', 'super_admin')
+            ->where(function ($q) {
+                $q->where('slug', 'super_admin')
+                    ->orWhere('name', 'SuperAdmin');
+            })
             ->exists();
     }
 

--- a/backend/app/Policies/AppointmentPolicy.php
+++ b/backend/app/Policies/AppointmentPolicy.php
@@ -4,11 +4,17 @@ namespace App\Policies;
 
 use App\Models\Appointment;
 use App\Models\User;
+use Illuminate\Support\Facades\Gate;
 
 class AppointmentPolicy extends TenantOwnedPolicy
 {
     public function create(User $user): bool
     {
         return true;
+    }
+
+    public function assign(User $user, Appointment $appointment): bool
+    {
+        return Gate::allows('appointments.assign') && $user->tenant_id === $appointment->tenant_id;
     }
 }

--- a/backend/app/Policies/AppointmentTypePolicy.php
+++ b/backend/app/Policies/AppointmentTypePolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AppointmentType;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class AppointmentTypePolicy extends TenantOwnedPolicy
+{
+    public function create(User $user): bool
+    {
+        return Gate::allows('types.manage');
+    }
+
+    public function update(User $user, AppointmentType $type): bool
+    {
+        return Gate::allows('types.manage') && parent::update($user, $type);
+    }
+
+    public function delete(User $user, AppointmentType $type): bool
+    {
+        return Gate::allows('types.manage') && parent::delete($user, $type);
+    }
+}

--- a/backend/app/Policies/RolePolicy.php
+++ b/backend/app/Policies/RolePolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class RolePolicy extends TenantOwnedPolicy
+{
+    public function create(User $user): bool
+    {
+        return Gate::allows('roles.manage');
+    }
+
+    public function update(User $user, Role $role): bool
+    {
+        return Gate::allows('roles.manage') && parent::update($user, $role);
+    }
+
+    public function delete(User $user, Role $role): bool
+    {
+        return Gate::allows('roles.manage') && parent::delete($user, $role);
+    }
+}

--- a/backend/app/Policies/StatusPolicy.php
+++ b/backend/app/Policies/StatusPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class StatusPolicy extends TenantOwnedPolicy
+{
+    public function create(User $user): bool
+    {
+        return Gate::allows('statuses.manage');
+    }
+
+    public function update(User $user, Status $status): bool
+    {
+        return Gate::allows('statuses.manage') && parent::update($user, $status);
+    }
+
+    public function delete(User $user, Status $status): bool
+    {
+        return Gate::allows('statuses.manage') && parent::delete($user, $status);
+    }
+}

--- a/backend/app/Policies/TeamPolicy.php
+++ b/backend/app/Policies/TeamPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+class TeamPolicy extends TenantOwnedPolicy
+{
+    public function create(User $user): bool
+    {
+        return Gate::allows('teams.manage');
+    }
+
+    public function update(User $user, Team $team): bool
+    {
+        return Gate::allows('teams.manage') && parent::update($user, $team);
+    }
+
+    public function delete(User $user, Team $team): bool
+    {
+        return Gate::allows('teams.manage') && parent::delete($user, $team);
+    }
+}

--- a/backend/app/Policies/TenantOwnedPolicy.php
+++ b/backend/app/Policies/TenantOwnedPolicy.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class TenantOwnedPolicy
 {
+    public function before(User $user, string $ability)
+    {
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+    }
+
     public function view(User $user, Model $model): bool
     {
         return $user->tenant_id === $model->tenant_id;

--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -3,9 +3,17 @@
 namespace App\Providers;
 
 use App\Models\Appointment;
+use App\Models\AppointmentType;
 use App\Models\Manual;
+use App\Models\Role;
+use App\Models\Status;
+use App\Models\Team;
 use App\Policies\AppointmentPolicy;
+use App\Policies\AppointmentTypePolicy;
 use App\Policies\ManualPolicy;
+use App\Policies\RolePolicy;
+use App\Policies\StatusPolicy;
+use App\Policies\TeamPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -13,7 +21,11 @@ class AuthServiceProvider extends ServiceProvider
 {
     protected $policies = [
         Appointment::class => AppointmentPolicy::class,
+        AppointmentType::class => AppointmentTypePolicy::class,
         Manual::class => ManualPolicy::class,
+        Role::class => RolePolicy::class,
+        Status::class => StatusPolicy::class,
+        Team::class => TeamPolicy::class,
     ];
 
     public function boot(): void
@@ -21,5 +33,27 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('belongs-to-tenant', function ($user, $tenantId) {
             return $user->tenant_id === $tenantId;
         });
+
+        Gate::define('roles.manage', fn ($user) => $this->hasAbility($user, 'roles.manage'));
+        Gate::define('teams.manage', fn ($user) => $this->hasAbility($user, 'teams.manage'));
+        Gate::define('appointments.assign', fn ($user) => $this->hasAbility($user, 'appointments.assign'));
+        Gate::define('types.manage', fn ($user) => $this->hasAbility($user, 'types.manage'));
+        Gate::define('statuses.manage', fn ($user) => $this->hasAbility($user, 'statuses.manage'));
+    }
+
+    protected function hasAbility($user, string $code): bool
+    {
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        $tenantId = app()->bound('tenant_id') ? (int) app('tenant_id') : $user->tenant_id;
+
+        $roles = $user->rolesForTenant($tenantId)
+            ->merge($user->roles()->wherePivotNull('tenant_id')->get());
+
+        $abilities = $roles->pluck('abilities')->flatten()->filter()->unique()->all();
+
+        return in_array($code, $abilities);
     }
 }


### PR DESCRIPTION
## Summary
- scope tenant data per request via EnsureTenantScope
- enforce role abilities with new Ability middleware and policies
- secure CRUD routes with ability checks and super-admin overrides

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b02208d2b483238453fd206f201407