### PR TITLE
feat: add team management and assignee lookup

### DIFF
--- a/backend/app/Http/Controllers/Api/LookupController.php
+++ b/backend/app/Http/Controllers/Api/LookupController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class LookupController extends Controller
+{
+    protected function getTenantId(Request $request): int
+    {
+        if ($request->user()->hasRole('SuperAdmin')) {
+            $tenantId = app('tenant_id');
+            if (! $tenantId) {
+                abort(400, 'Tenant ID required');
+            }
+            return (int) $tenantId;
+        }
+
+        return (int) $request->user()->tenant_id;
+    }
+
+    public function assignees(Request $request)
+    {
+        $tenantId = $this->getTenantId($request);
+        $type = $request->query('type', 'all');
+
+        $results = collect();
+
+        if ($type === 'all' || $type === 'teams') {
+            $teams = Team::where('tenant_id', $tenantId)->get()
+                ->map(fn ($team) => ['id' => $team->id, 'label' => $team->name, 'kind' => 'team']);
+            $results = $results->merge($teams);
+        }
+
+        if ($type === 'all' || $type === 'employees') {
+            $employees = User::where('tenant_id', $tenantId)->get()
+                ->map(fn ($user) => ['id' => $user->id, 'label' => $user->name, 'kind' => 'employee']);
+            $results = $results->merge($employees);
+        }
+
+        return $results->values();
+    }
+}

--- a/backend/app/Http/Controllers/Api/TeamController.php
+++ b/backend/app/Http/Controllers/Api/TeamController.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TeamUpsertRequest;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class TeamController extends Controller
+{
+    protected function ensureAdmin(Request $request): void
+    {
+        if (! $request->user()->hasRole('ClientAdmin') && ! $request->user()->hasRole('SuperAdmin')) {
+            abort(403);
+        }
+    }
+
+    protected function getTenantId(Request $request): int
+    {
+        if ($request->user()->hasRole('SuperAdmin')) {
+            $tenantId = app('tenant_id');
+            if (! $tenantId) {
+                abort(400, 'Tenant ID required');
+            }
+            return (int) $tenantId;
+        }
+
+        return (int) $request->user()->tenant_id;
+    }
+
+    public function index(Request $request)
+    {
+        $tenantId = $this->getTenantId($request);
+        return Team::where('tenant_id', $tenantId)->with('employees')->get();
+    }
+
+    public function store(TeamUpsertRequest $request)
+    {
+        $this->ensureAdmin($request);
+
+        $data = $request->validated();
+        $tenantId = $this->getTenantId($request);
+        $data['tenant_id'] = $request->user()->hasRole('SuperAdmin') ? ($data['tenant_id'] ?? $tenantId) : $tenantId;
+
+        $team = Team::create($data);
+
+        return response()->json($team->load('employees'), 201);
+    }
+
+    public function show(Request $request, Team $team)
+    {
+        $tenantId = $this->getTenantId($request);
+        if ($team->tenant_id !== $tenantId) {
+            abort(404);
+        }
+
+        return $team->load('employees');
+    }
+
+    public function update(TeamUpsertRequest $request, Team $team)
+    {
+        $this->ensureAdmin($request);
+
+        $tenantId = $this->getTenantId($request);
+        if ($team->tenant_id !== $tenantId) {
+            abort(404);
+        }
+
+        $data = $request->validated();
+        $data['tenant_id'] = $team->tenant_id;
+        $team->update($data);
+
+        return $team->load('employees');
+    }
+
+    public function destroy(Request $request, Team $team)
+    {
+        $this->ensureAdmin($request);
+
+        $tenantId = $this->getTenantId($request);
+        if ($team->tenant_id !== $tenantId) {
+            abort(404);
+        }
+
+        $team->delete();
+
+        return response()->noContent();
+    }
+
+    public function syncEmployees(Request $request, Team $team)
+    {
+        $this->ensureAdmin($request);
+
+        $tenantId = $this->getTenantId($request);
+        if ($team->tenant_id !== $tenantId) {
+            abort(404);
+        }
+
+        $data = $request->validate([
+            'employee_ids' => ['required', 'array'],
+            'employee_ids.*' => ['integer', 'exists:users,id'],
+        ]);
+
+        $employeeIds = User::whereIn('id', $data['employee_ids'])
+            ->where('tenant_id', $tenantId)
+            ->pluck('id')
+            ->all();
+
+        $team->employees()->sync($employeeIds);
+
+        return $team->load('employees');
+    }
+}

--- a/backend/app/Http/Requests/TeamUpsertRequest.php
+++ b/backend/app/Http/Requests/TeamUpsertRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TeamUpsertRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $teamId = $this->route('team')?->id;
+        $tenantId = $this->user() && $this->user()->hasRole('SuperAdmin')
+            ? ($this->input('tenant_id') ?? app('tenant_id'))
+            : $this->user()->tenant_id;
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:100',
+                Rule::unique('teams')->where(fn ($q) => $q->where('tenant_id', $tenantId))->ignore($teamId),
+            ],
+            'description' => ['nullable', 'string'],
+            'tenant_id' => ['nullable', 'exists:tenants,id'],
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -17,6 +17,8 @@ use App\Http\Controllers\Api\TenantController;
 use App\Http\Controllers\Api\GdprController;
 use App\Http\Controllers\Api\RoleController;
 use App\Http\Controllers\Api\StatusController;
+use App\Http\Controllers\Api\TeamController;
+use App\Http\Controllers\Api\LookupController;
 use App\Http\Middleware\EnsureTenantScope;
 use App\Http\Middleware\Ability;
 
@@ -58,6 +60,7 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     Route::apiResource('appointment-types', AppointmentTypeController::class)->only(['index', 'show']);
     Route::apiResource('roles', RoleController::class)->only(['index', 'show']);
     Route::apiResource('statuses', StatusController::class)->only(['index', 'show']);
+    Route::apiResource('teams', TeamController::class)->only(['index', 'show']);
 
     Route::post('appointment-types', [AppointmentTypeController::class, 'store'])->middleware(Ability::class . ':types.manage')->name('appointment-types.store');
     Route::match(['put', 'patch'], 'appointment-types/{appointment_type}', [AppointmentTypeController::class, 'update'])->middleware(Ability::class . ':types.manage')->name('appointment-types.update');
@@ -67,6 +70,11 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     Route::match(['put', 'patch'], 'roles/{role}', [RoleController::class, 'update'])->middleware(Ability::class . ':roles.manage')->name('roles.update');
     Route::delete('roles/{role}', [RoleController::class, 'destroy'])->middleware(Ability::class . ':roles.manage')->name('roles.destroy');
     Route::post('roles/{role}/assign', [RoleController::class, 'assign'])->middleware(Ability::class . ':roles.manage')->name('roles.assign');
+
+    Route::post('teams', [TeamController::class, 'store'])->middleware(Ability::class . ':teams.manage')->name('teams.store');
+    Route::match(['put', 'patch'], 'teams/{team}', [TeamController::class, 'update'])->middleware(Ability::class . ':teams.manage')->name('teams.update');
+    Route::delete('teams/{team}', [TeamController::class, 'destroy'])->middleware(Ability::class . ':teams.manage')->name('teams.destroy');
+    Route::post('teams/{team}/employees', [TeamController::class, 'syncEmployees'])->middleware(Ability::class . ':teams.manage');
 
     Route::post('statuses', [StatusController::class, 'store'])->middleware(Ability::class . ':statuses.manage')->name('statuses.store');
     Route::match(['put', 'patch'], 'statuses/{status}', [StatusController::class, 'update'])->middleware(Ability::class . ':statuses.manage')->name('statuses.update');
@@ -106,4 +114,6 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         Route::get('materials', [ReportController::class, 'materials']);
         Route::get('export', [ReportController::class, 'export']);
     });
+
+    Route::get('lookups/assignees', [LookupController::class, 'assignees']);
 });


### PR DESCRIPTION
## Summary
- add tenant-scoped Teams CRUD controller with membership sync
- expose assignee lookup endpoint for teams and employees
- validate team creation/update with per-tenant unique names

## Testing
- `cd backend && composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b0252c02fc83238b3eee4a6b299582