### PR TITLE
feat: add scoped roles management and assignment UI

### DIFF
--- a/frontend/src/stores/roles.ts
+++ b/frontend/src/stores/roles.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia';
+import api from '@/services/api';
+
+interface FetchParams {
+  scope?: string;
+  tenantId?: string;
+}
+
+interface AssignPayload {
+  roleId: number;
+  userId: number;
+  tenantId?: string;
+}
+
+export const useRolesStore = defineStore('roles', {
+  state: () => ({
+    roles: [] as any[],
+  }),
+  actions: {
+    async fetch(params: FetchParams = {}) {
+      const { scope, tenantId } = params;
+      const { data } = await api.get('/roles', {
+        params: {
+          scope,
+          tenant_id: tenantId,
+        },
+      });
+      this.roles = data;
+    },
+    async create(payload: any) {
+      const { data } = await api.post('/roles', payload);
+      return data;
+    },
+    async update(id: number, payload: any) {
+      const { data } = await api.patch(`/roles/${id}`, payload);
+      return data;
+    },
+    async remove(id: number) {
+      await api.delete(`/roles/${id}`);
+      this.roles = this.roles.filter((r: any) => r.id !== id);
+    },
+    async assignUser(payload: AssignPayload) {
+      const { roleId, userId, tenantId } = payload;
+      await api.post(`/roles/${roleId}/assign`, {
+        user_id: userId,
+        tenant_id: tenantId,
+      });
+    },
+  },
+});
+

--- a/frontend/src/views/roles/AssignRoleModal.vue
+++ b/frontend/src/views/roles/AssignRoleModal.vue
@@ -1,0 +1,115 @@
+<template>
+  <TransitionRoot appear :show="true" as="template">
+    <Dialog as="div" class="relative z-50" @close="emit('close')">
+      <TransitionChild
+        as="template"
+        enter="duration-300 ease-out"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="duration-200 ease-in"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
+        <div class="fixed inset-0 bg-slate-900/60" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 overflow-y-auto">
+        <div class="flex min-h-full items-center justify-center p-4">
+          <TransitionChild
+            as="template"
+            enter="duration-300 ease-out"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <DialogPanel class="w-full max-w-md rounded-md bg-white dark:bg-slate-800 p-6">
+              <h2 class="text-lg font-bold mb-4">Assign Role</h2>
+              <form class="grid gap-4" @submit.prevent="onSubmit">
+                <VueSelect label="User">
+                  <vSelect
+                    v-model="userId"
+                    :options="users"
+                    :reduce="(u: any) => u.id"
+                    label="name"
+                    @search="searchUsers"
+                  />
+                </VueSelect>
+                <VueSelect v-if="auth.isSuperAdmin" label="Tenant">
+                  <vSelect
+                    v-model="tenantId"
+                    :options="tenantOptions"
+                    :reduce="(t: any) => t.id"
+                    label="name"
+                  />
+                </VueSelect>
+                <div class="flex justify-end gap-2 mt-4">
+                  <button type="button" class="btn btn-outline-secondary" @click="emit('close')">Cancel</button>
+                  <button type="submit" class="btn btn-primary">Assign</button>
+                </div>
+              </form>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import {
+  TransitionRoot,
+  TransitionChild,
+  Dialog,
+  DialogPanel,
+} from '@headlessui/vue';
+import VueSelect from '@/components/ui/Select/VueSelect.vue';
+import vSelect from 'vue-select';
+import { useAuthStore } from '@/stores/auth';
+import { useTenantStore } from '@/stores/tenant';
+import { useRolesStore } from '@/stores/roles';
+import api from '@/services/api';
+
+const props = defineProps<{ roleId: number }>();
+const emit = defineEmits(['assigned', 'close']);
+
+const auth = useAuthStore();
+const tenantStore = useTenantStore();
+const rolesStore = useRolesStore();
+
+const users = ref<any[]>([]);
+const userId = ref<number | null>(null);
+const tenantId = ref<string>('');
+
+const tenantOptions = computed(() => [
+  { id: '', name: 'Global' },
+  ...tenantStore.tenants.map((t: any) => ({ id: t.id, name: t.name })),
+]);
+
+async function searchUsers(search: string) {
+  if (!search) return;
+  const { data } = await api.get('/users', { params: { search } });
+  users.value = data;
+}
+
+async function onSubmit() {
+  if (!userId.value) return;
+  await rolesStore.assignUser({
+    roleId: props.roleId,
+    userId: userId.value,
+    tenantId: auth.isSuperAdmin ? tenantId.value || undefined : tenantStore.currentTenantId,
+  });
+  emit('assigned');
+  emit('close');
+}
+
+onMounted(async () => {
+  if (auth.isSuperAdmin) {
+    if (!tenantStore.tenants.length) await tenantStore.loadTenants();
+  } else {
+    tenantId.value = tenantStore.currentTenantId;
+  }
+});
+</script>

--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -6,10 +6,22 @@
         <input id="name" v-model="name" class="border rounded p-2 w-full" />
       </div>
       <div>
-        <label class="block font-medium mb-1" for="level">Level<span class="text-red-600">*</span></label>
-        <input id="level" type="number" v-model.number="level" class="border rounded p-2 w-full" />
-        <!-- Show the suggested next level when creating a new role -->
-        <p v-if="!isEdit" class="text-xs text-gray-500 mt-1">Next level: {{ nextLevel }}</p>
+        <label class="block font-medium mb-1" for="slug">Slug<span class="text-red-600">*</span></label>
+        <input id="slug" v-model="slug" class="border rounded p-2 w-full" />
+      </div>
+      <div>
+        <label class="block font-medium mb-1" for="abilities">Abilities (comma separated)</label>
+        <input id="abilities" v-model="abilities" class="border rounded p-2 w-full" />
+      </div>
+      <div v-if="auth.isSuperAdmin">
+        <VueSelect label="Tenant">
+          <vSelect
+            v-model="tenantId"
+            :options="tenantOptions"
+            :reduce="(t: any) => t.id"
+            label="name"
+          />
+        </VueSelect>
       </div>
       <div v-if="serverError" class="text-red-600 text-sm">{{ serverError }}</div>
       <button
@@ -26,19 +38,34 @@ import { ref, computed, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '@/services/api';
 import { useNotify } from '@/plugins/notify';
+import { useAuthStore } from '@/stores/auth';
+import { useTenantStore } from '@/stores/tenant';
+import VueSelect from '@/components/ui/Select/VueSelect.vue';
+import vSelect from 'vue-select';
 
 const route = useRoute();
 const router = useRouter();
 const notify = useNotify();
+const auth = useAuthStore();
+const tenantStore = useTenantStore();
 
 const name = ref('');
-const level = ref(0);
-const nextLevel = ref<number | null>(null);
+const slug = ref('');
+const abilities = ref('');
+const tenantId = ref<string>(auth.isSuperAdmin ? '' : tenantStore.currentTenantId);
 const serverError = ref('');
+
+const tenantOptions = computed(() => [
+  { id: '', name: 'Global' },
+  ...tenantStore.tenants.map((t: any) => ({ id: t.id, name: t.name })),
+]);
 
 const isEdit = computed(() => route.name === 'roles.edit');
 
 onMounted(async () => {
+  if (auth.isSuperAdmin && !tenantStore.tenants.length) {
+    await tenantStore.loadTenants();
+  }
   if (isEdit.value) {
     const { data } = await api.get(`/roles/${route.params.id}`);
     if (data.name === 'SuperAdmin') {
@@ -47,23 +74,28 @@ onMounted(async () => {
       return;
     }
     name.value = data.name;
-    level.value = data.level;
-  } else {
-    const { data } = await api.get('/roles');
-    const maxLevel = data.length ? Math.max(...data.map((r: any) => r.level ?? 0)) : -1;
-    nextLevel.value = maxLevel + 1;
-    level.value = nextLevel.value;
+    slug.value = data.slug || '';
+    abilities.value = (data.abilities || []).join(', ');
+    tenantId.value = data.tenant_id || '';
   }
 });
 
-const canSubmit = computed(
-  () => !!name.value && name.value !== 'SuperAdmin' && Number.isInteger(level.value)
-);
+const canSubmit = computed(() => !!name.value && !!slug.value && name.value !== 'SuperAdmin');
 
 async function onSubmit() {
   serverError.value = '';
   if (!canSubmit.value) return;
-  const payload = { name: name.value, level: level.value };
+  const payload: any = {
+    name: name.value,
+    slug: slug.value,
+    abilities: abilities.value
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t),
+  };
+  if (auth.isSuperAdmin) {
+    payload.tenant_id = tenantId.value || null;
+  }
   try {
     if (isEdit.value) {
       await api.patch(`/roles/${route.params.id}`, payload);


### PR DESCRIPTION
## Summary
- add Pinia roles store with scoped fetch and user assignment
- extend roles list with scope filter and assignment modal
- update role form for slug, abilities, and tenant selection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0293e7080832399d23b253393750a