### PR TITLE
feat: add assignee picker for appointments

### DIFF
--- a/frontend/src/components/appointments/AssigneePicker.vue
+++ b/frontend/src/components/appointments/AssigneePicker.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="space-y-2">
+    <Tabs v-model="tab" :tabs="tabs" />
+    <vSelect
+      v-model="selected"
+      :options="options"
+      label="label"
+      placeholder="Select assignee"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import vSelect from 'vue-select';
+import Tabs from '@/components/ui/Tabs.vue';
+import { useLookupsStore } from '@/stores/lookups';
+
+interface AssigneeValue {
+  kind: 'team' | 'employee';
+  id: number;
+}
+
+const props = defineProps<{ modelValue: AssigneeValue | null }>();
+const emit = defineEmits<{ (e: 'update:modelValue', value: AssigneeValue | null): void }>();
+
+const lookups = useLookupsStore();
+const tab = ref<'teams' | 'employees'>('teams');
+const selected = ref<any>(null);
+
+const tabs = [
+  { id: 'teams', label: 'Teams' },
+  { id: 'employees', label: 'Employees' },
+];
+
+const options = computed(() => lookups.assignees[tab.value]);
+
+onMounted(async () => {
+  if (!lookups.assignees.teams.length && !lookups.assignees.employees.length) {
+    await lookups.fetchAssignees('all');
+  }
+  if (props.modelValue) {
+    tab.value = props.modelValue.kind === 'team' ? 'teams' : 'employees';
+    const list = lookups.assignees[tab.value];
+    selected.value = list.find((a: any) => a.id === props.modelValue?.id) || null;
+  }
+});
+
+watch(
+  selected,
+  (val) => {
+    if (val) emit('update:modelValue', { kind: val.kind, id: val.id });
+    else emit('update:modelValue', null);
+  },
+  { deep: true },
+);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (!val) {
+      selected.value = null;
+      return;
+    }
+    tab.value = val.kind === 'team' ? 'teams' : 'employees';
+    const list = lookups.assignees[tab.value];
+    selected.value = list.find((a: any) => a.id === val.id) || null;
+  },
+  { deep: true },
+);
+</script>

--- a/frontend/src/stores/appointments.ts
+++ b/frontend/src/stores/appointments.ts
@@ -18,5 +18,29 @@ export const useAppointmentsStore = defineStore('appointments', {
       if (!this.appointments.length) await this.fetch();
       return this.appointments.find((a: any) => a.id == id);
     },
+    async create(payload: any) {
+      const data = { ...payload };
+      if (payload.assignee) {
+        data.assignee = {
+          kind: payload.assignee.kind,
+          id: payload.assignee.id,
+        };
+      }
+      const res = await api.post('/appointments', data);
+      this.appointments.push(res.data);
+      return res.data;
+    },
+    async update(id: string, payload: any) {
+      const data = { ...payload };
+      if (payload.assignee) {
+        data.assignee = {
+          kind: payload.assignee.kind,
+          id: payload.assignee.id,
+        };
+      }
+      const { data: updated } = await api.patch(`/appointments/${id}`, data);
+      this.appointments = this.appointments.map((a: any) => (a.id === id ? updated : a));
+      return updated;
+    },
   },
 });

--- a/frontend/src/stores/lookups.ts
+++ b/frontend/src/stores/lookups.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+import api from '@/services/api';
+
+export const useLookupsStore = defineStore('lookups', {
+  state: () => ({
+    assignees: {
+      teams: [] as any[],
+      employees: [] as any[],
+    },
+  }),
+  actions: {
+    async fetchAssignees(type: 'all' | 'teams' | 'employees' = 'all') {
+      const { data } = await api.get('/lookups/assignees', { params: { type } });
+      if (type === 'all') {
+        this.assignees.teams = data.filter((a: any) => a.kind === 'team');
+        this.assignees.employees = data.filter((a: any) => a.kind === 'employee');
+      } else {
+        // @ts-ignore
+        this.assignees[type] = data;
+      }
+      return data;
+    },
+  },
+});
+


### PR DESCRIPTION
## Summary
- add lookups store with assignee fetcher
- implement assignee picker component
- wire assignee selection into appointment form and store payload

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02b217ce08323baf22409d5b25472