### PR TITLE
feat: add scoped type and status management

### DIFF
--- a/frontend/src/components/forms/JsonSchemaForm.vue
+++ b/frontend/src/components/forms/JsonSchemaForm.vue
@@ -61,6 +61,10 @@
           :disabled="readonly"
           @change="validateField(name)"
         />
+        <AssigneePicker
+          v-else-if="fieldType(prop) === 'assignee'"
+          v-model="form[name]"
+        />
       </template>
       <div v-if="errors[name]" class="text-red-600 text-sm mt-1">{{ errors[name] }}</div>
     </div>
@@ -69,6 +73,7 @@
 
 <script setup lang="ts">
 import { reactive, watch, onMounted } from 'vue';
+import AssigneePicker from '@/components/appointments/AssigneePicker.vue';
 
 interface Schema {
   properties: Record<string, any>;
@@ -106,6 +111,7 @@ function isRequired(name: string) {
 
 function fieldType(prop: any) {
   if (prop.enum) return 'enum';
+  if (prop['x-control'] === 'assignee') return 'assignee';
   if (prop.type === 'number' || prop.type === 'integer') return 'number';
   if (prop.type === 'boolean') return 'boolean';
   if (prop.type === 'string' && prop.format === 'date') return 'date';

--- a/frontend/src/stores/statuses.ts
+++ b/frontend/src/stores/statuses.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia';
+import api from '@/services/api';
+
+export const useStatusesStore = defineStore('statuses', {
+  actions: {
+    async fetch(scope: 'tenant' | 'global' | 'all', tenantId?: string | number) {
+      const params: any = { scope };
+      if (tenantId) params.tenant_id = tenantId;
+      const { data } = await api.get('/statuses', { params });
+      return data;
+    },
+    async copyToTenant(id: number, tenantId?: string | number) {
+      const payload: any = {};
+      if (tenantId) payload.tenant_id = tenantId;
+      const { data } = await api.post(`/statuses/${id}/copy-to-tenant`, payload);
+      return data;
+    },
+  },
+});

--- a/frontend/src/stores/types.ts
+++ b/frontend/src/stores/types.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia';
+import api from '@/services/api';
+
+export const useTypesStore = defineStore('types', {
+  actions: {
+    async fetch(scope: 'tenant' | 'global' | 'all', tenantId?: string | number) {
+      const params: any = { scope };
+      if (tenantId) params.tenant_id = tenantId;
+      const { data } = await api.get('/appointment-types', { params });
+      return data;
+    },
+    async copyToTenant(id: number, tenantId?: string | number) {
+      const payload: any = {};
+      if (tenantId) payload.tenant_id = tenantId;
+      const { data } = await api.post(`/appointment-types/${id}/copy-to-tenant`, payload);
+      return data;
+    },
+  },
+});

--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
     <form @submit.prevent="onSubmit" class="max-w-md grid gap-4">
+      <div v-if="auth.isSuperAdmin">
+        <label class="block font-medium mb-1" for="tenant">Tenant</label>
+        <select id="tenant" v-model="tenantId" class="border rounded p-2 w-full">
+          <option value="">Global</option>
+          <option v-for="t in tenantStore.tenants" :key="t.id" :value="t.id">{{ t.name }}</option>
+        </select>
+      </div>
       <div>
         <label class="block font-medium mb-1" for="name">Name<span class="text-red-600">*</span></label>
         <input id="name" v-model="name" class="border rounded p-2 w-full" />
@@ -19,19 +26,28 @@
 import { ref, computed, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '@/services/api';
+import { useAuthStore } from '@/stores/auth';
+import { useTenantStore } from '@/stores/tenant';
 
 const route = useRoute();
 const router = useRouter();
+const auth = useAuthStore();
+const tenantStore = useTenantStore();
 
 const name = ref('');
 const serverError = ref('');
+const tenantId = ref<string | number | ''>('');
 
 const isEdit = computed(() => route.name === 'statuses.edit');
 
 onMounted(async () => {
+  if (auth.isSuperAdmin && !tenantStore.tenants.length) {
+    await tenantStore.loadTenants();
+  }
   if (isEdit.value) {
     const { data } = await api.get(`/statuses/${route.params.id}`);
     name.value = data.name;
+    tenantId.value = data.tenant_id || '';
   }
 });
 
@@ -40,7 +56,10 @@ const canSubmit = computed(() => !!name.value);
 async function onSubmit() {
   serverError.value = '';
   if (!canSubmit.value) return;
-  const payload = { name: name.value };
+  const payload: any = { name: name.value };
+  if (auth.isSuperAdmin) {
+    payload.tenant_id = tenantId.value || undefined;
+  }
   try {
     if (isEdit.value) {
       await api.patch(`/statuses/${route.params.id}`, payload);

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -1,6 +1,15 @@
 <template>
   <div>
-    <div class="flex items-center justify-end mb-4">
+    <div class="flex items-center justify-between mb-4">
+      <select
+        v-model="scope"
+        @change="changeScope"
+        class="border rounded px-2 py-1"
+      >
+        <option v-for="opt in scopeOptions" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
       <RouterLink
         class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
         :to="{ name: 'statuses.create' }"
@@ -22,6 +31,14 @@
           <button class="text-red-600" title="Delete" @click="remove(row.id)">
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
+          <button
+            v-if="auth.isSuperAdmin || !row.tenant_id"
+            class="text-green-600"
+            title="Copy to Tenant"
+            @click="copy(row.id)"
+          >
+            <Icon icon="heroicons-outline:document-duplicate" class="w-5 h-5" />
+          </button>
         </div>
       </template>
     </DashcodeServerTable>
@@ -29,16 +46,38 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
-import api from '@/services/api';
 import Swal from 'sweetalert2';
 import Icon from '@/components/ui/Icon';
+import api from '@/services/api';
+import { useAuthStore } from '@/stores/auth';
+import { useTenantStore } from '@/stores/tenant';
+import { useStatusesStore } from '@/stores/statuses';
 
 const router = useRouter();
 const tableKey = ref(0);
 const all = ref<any[]>([]);
+const scope = ref<'tenant' | 'global' | 'all'>('tenant');
+const auth = useAuthStore();
+const tenantStore = useTenantStore();
+const statusesStore = useStatusesStore();
+
+if (auth.isSuperAdmin) {
+  scope.value = 'all';
+}
+
+const scopeOptions = computed(() => {
+  const opts = [
+    { value: 'tenant', label: 'Tenant' },
+    { value: 'all', label: 'All' },
+  ];
+  if (auth.isSuperAdmin) {
+    opts.splice(1, 0, { value: 'global', label: 'Global' });
+  }
+  return opts;
+});
 
 const columns = [
   { label: 'ID', field: 'id', sortable: true },
@@ -47,8 +86,8 @@ const columns = [
 
 async function fetchStatuses({ page, perPage, sort, search }: any) {
   if (!all.value.length) {
-    const { data } = await api.get('/statuses');
-    all.value = data;
+    const tenantId = auth.isSuperAdmin ? tenantStore.currentTenantId : undefined;
+    all.value = await statusesStore.fetch(scope.value, tenantId);
   }
   let rows = all.value.slice();
   if (search) {
@@ -74,6 +113,11 @@ function reload() {
   tableKey.value++;
 }
 
+function changeScope() {
+  all.value = [];
+  reload();
+}
+
 function edit(id: number) {
   router.push({ name: 'statuses.edit', params: { id } });
 }
@@ -89,5 +133,29 @@ async function remove(id: number) {
     all.value = [];
     reload();
   }
+}
+
+async function copy(id: number) {
+  let tenantId: string | number | undefined;
+  if (auth.isSuperAdmin) {
+    if (!tenantStore.tenants.length) {
+      await tenantStore.loadTenants();
+    }
+    const inputOptions = tenantStore.tenants.reduce(
+      (acc: any, t: any) => ({ ...acc, [t.id]: t.name }),
+      {},
+    );
+    const res = await Swal.fire({
+      title: 'Copy to tenant',
+      input: 'select',
+      inputOptions,
+      showCancelButton: true,
+    });
+    if (!res.isConfirmed || !res.value) return;
+    tenantId = res.value;
+  }
+  await statusesStore.copyToTenant(id, tenantId);
+  all.value = [];
+  reload();
 }
 </script>


### PR DESCRIPTION
## Summary
- allow filtering types and statuses by scope and copy global entries to tenants
- let super admins assign tenant scope on type and status forms
- support assignee field in schema editor and renderer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02dd08bec8323b5dd0840aea0c809