### PR TITLE
Add regression tests for tenant scoping and assignments

### DIFF
--- a/backend/tests/Feature/AppointmentsAssigneeTest.php
+++ b/backend/tests/Feature/AppointmentsAssigneeTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Appointment;
+use App\Models\AppointmentType;
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AppointmentsAssigneeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_assignee_persisted_when_creating_appointment(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $adminRole = Role::create(['name' => 'ClientAdmin', 'slug' => 'client_admin', 'tenant_id' => $tenant->id]);
+
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $employee = User::create([
+            'name' => 'Employee',
+            'email' => 'emp@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $admin->roles()->attach($adminRole->id, ['tenant_id' => $tenant->id]);
+
+        $type = AppointmentType::create([
+            'name' => 'General',
+            'tenant_id' => $tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'assignee_field' => ['kind' => 'assignee'],
+                ],
+            ],
+        ]);
+
+        Sanctum::actingAs($admin);
+
+        $payload = [
+            'appointment_type_id' => $type->id,
+            'assignee' => ['kind' => 'employee', 'id' => $employee->id],
+        ];
+
+        $id = $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/appointments', $payload)
+            ->assertStatus(201)
+            ->json('id');
+
+        $appointment = Appointment::find($id);
+        $this->assertEquals(User::class, $appointment->assignee_type);
+        $this->assertEquals($employee->id, $appointment->assignee_id);
+    }
+}

--- a/backend/tests/Feature/RolesTest.php
+++ b/backend/tests/Feature/RolesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class RolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_role_assignment_persists(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $adminRole = Role::create(['name' => 'ClientAdmin', 'slug' => 'client_admin', 'tenant_id' => $tenant->id]);
+        $role = Role::create(['name' => 'Tester', 'slug' => 'tester', 'tenant_id' => $tenant->id]);
+
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $admin->roles()->attach($adminRole->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($admin);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/roles/{$role->id}/assign", ['user_id' => $user->id])
+            ->assertStatus(200);
+
+        $this->assertTrue(
+            $user->roles()->where('roles.id', $role->id)->wherePivot('tenant_id', $tenant->id)->exists()
+        );
+    }
+}

--- a/backend/tests/Feature/TeamsTest.php
+++ b/backend/tests/Feature/TeamsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TeamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_team_membership_sync(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $adminRole = Role::create(['name' => 'ClientAdmin', 'slug' => 'client_admin', 'tenant_id' => $tenant->id]);
+
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user1 = User::create([
+            'name' => 'User1',
+            'email' => 'user1@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user2 = User::create([
+            'name' => 'User2',
+            'email' => 'user2@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $admin->roles()->attach($adminRole->id, ['tenant_id' => $tenant->id]);
+        $team = Team::create(['tenant_id' => $tenant->id, 'name' => 'Alpha', 'description' => '']);
+        Sanctum::actingAs($admin);
+
+        \DB::table('team_employee')->insert([
+            ['team_id' => $team->id, 'employee_id' => $user1->id],
+            ['team_id' => $team->id, 'employee_id' => $user2->id],
+        ]);
+
+        $members = $team->belongsToMany(User::class, 'team_employee', 'team_id', 'employee_id')->get();
+        $this->assertCount(2, $members);
+    }
+}

--- a/backend/tests/Feature/TenantScopeTest.php
+++ b/backend/tests/Feature/TenantScopeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TenantScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_bypasses_tenant_scope(): void
+    {
+        $tenant = Tenant::create(['name' => 'One']);
+        $role = Role::create(['name' => 'SuperAdmin', 'slug' => 'super_admin', 'tenant_id' => $tenant->id]);
+        $user = User::create([
+            'name' => 'SA',
+            'email' => 'sa@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/roles')->assertStatus(200);
+    }
+
+    public function test_tenant_isolation_enforced(): void
+    {
+        $tenant1 = Tenant::create(['name' => 'One']);
+        $tenant2 = Tenant::create(['name' => 'Two']);
+        $role = Role::create(['name' => 'ClientAdmin', 'slug' => 'client_admin', 'tenant_id' => $tenant1->id]);
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant1->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant1->id]);
+        Sanctum::actingAs($user);
+
+        $this->withHeader('X-Tenant-ID', $tenant2->id)
+            ->getJson('/api/roles')
+            ->assertStatus(403);
+    }
+}

--- a/frontend/tests/e2e/appointments-assignee.spec.ts
+++ b/frontend/tests/e2e/appointments-assignee.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test';
+
+// No running server in the environment; this test documents the expected flow.
+test.skip('assigns appointment to an employee', async ({ page }) => {
+  await page.goto('/appointments');
+  await page.getByRole('button', { name: 'View' }).first().click();
+  await page.getByRole('button', { name: 'Edit' }).click();
+  await page.getByRole('button', { name: 'Assign' }).click();
+  await page.getByRole('option', { name: /John Doe/ }).click();
+  await page.getByRole('button', { name: 'Submit' }).click();
+});

--- a/frontend/tests/e2e/roles.spec.ts
+++ b/frontend/tests/e2e/roles.spec.ts
@@ -1,0 +1,13 @@
+import { test } from '@playwright/test';
+
+// No running server in the environment; this test documents the expected flow.
+test.skip('creates a role and assigns it to a user', async ({ page }) => {
+  await page.goto('/roles');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await page.getByPlaceholder('Role name').fill('Tester');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('row', { name: /Tester/ }).getByRole('button', { name: 'Assign' }).click();
+  await page.getByPlaceholder('Search user').fill('John');
+  await page.getByRole('option', { name: /John Doe/ }).click();
+  await page.getByRole('button', { name: 'Assign' }).click();
+});

--- a/frontend/tests/e2e/teams.spec.ts
+++ b/frontend/tests/e2e/teams.spec.ts
@@ -1,0 +1,13 @@
+import { test } from '@playwright/test';
+
+// No running server in the environment; this test documents the expected flow.
+test.skip('creates a team and adds members', async ({ page }) => {
+  await page.goto('/teams');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await page.getByPlaceholder('Team name').fill('Alpha');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await page.getByRole('row', { name: /Alpha/ }).getByRole('button', { name: 'Edit' }).click();
+  await page.getByPlaceholder('Add members').fill('John');
+  await page.getByRole('option', { name: /John Doe/ }).click();
+  await page.getByRole('button', { name: 'Save' }).click();
+});

--- a/frontend/tests/unit/components/AssigneePicker.spec.ts
+++ b/frontend/tests/unit/components/AssigneePicker.spec.ts
@@ -1,0 +1,23 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { createApp, nextTick } from 'vue';
+import AssigneePicker from '@/components/appointments/AssigneePicker.vue';
+
+const fetchAssignees = vi.fn().mockResolvedValue([]);
+
+vi.mock('@/stores/lookups', () => ({
+  useLookupsStore: () => ({
+    assignees: { teams: [], employees: [] },
+    fetchAssignees,
+  }),
+}));
+
+describe('AssigneePicker', () => {
+  it('fetches assignees on mount when none loaded', async () => {
+    const app = createApp(AssigneePicker, { modelValue: null });
+    const div = document.createElement('div');
+    app.mount(div);
+    await nextTick();
+    expect(fetchAssignees).toHaveBeenCalledWith('all');
+  });
+});

--- a/frontend/tests/unit/stores/roles.spec.ts
+++ b/frontend/tests/unit/stores/roles.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useRolesStore } from '@/stores/roles';
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import api from '@/services/api';
+
+describe('roles store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('fetches roles with params', async () => {
+    (api.get as any).mockResolvedValue({ data: [{ id: 1 }] });
+    const store = useRolesStore();
+    await store.fetch({ scope: 'tenant', tenantId: '1' });
+    expect(api.get).toHaveBeenCalledWith('/roles', {
+      params: { scope: 'tenant', tenant_id: '1' },
+    });
+    expect(store.roles).toEqual([{ id: 1 }]);
+  });
+
+  it('assigns role to user', async () => {
+    (api.post as any).mockResolvedValue({});
+    const store = useRolesStore();
+    await store.assignUser({ roleId: 2, userId: 3, tenantId: '4' });
+    expect(api.post).toHaveBeenCalledWith('/roles/2/assign', {
+      user_id: 3,
+      tenant_id: '4',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add backend tests for tenant scoping, role assignment, team membership and appointment assignee persistence
- cover frontend assignee picker and roles store
- document e2e flows for roles, teams and appointment assignment

## Testing
- `php artisan test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02f217a348323bcc42f10175cfc8c