### PR TITLE
Seed demo tenant and document multi-tenant features

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend
+
+## Tenants, Roles, Teams & Assignees
+
+This demo application is multi-tenant. Requests include the tenant context via the `X-Tenant-ID` header. Roles with a `null` `tenant_id` are global and apply across all tenants. Tenant roles belong to a specific tenant and define an array of ability strings. Authorization—including super-admin detection—is enforced on the backend; any frontend flags are for UX only. The `super_admin` role uses the wildcard `"*"` ability to access everything.
+
+Teams group employees within a tenant. Users are attached to teams through the `team_employee` pivot table and gain role abilities via `role_user` records. When creating resources that support assignment, include an `assignee` field in the payload. The backend maps `{ kind: 'team' | 'employee', id: number }` to `assignee_type` and `assignee_id` fields.
+
+Run the tenant bootstrap seeder to populate a sample tenant with roles, a team, users, and default appointment types and statuses:
+
+```bash
+php artisan migrate:fresh --seed --seeder=TenantBootstrapSeeder
+```

--- a/backend/database/migrations/2025_01_01_110000_create_roles_table.php
+++ b/backend/database/migrations/2025_01_01_110000_create_roles_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('roles', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tenant_id')->nullable()->constrained()->cascadeOnDelete();
             $table->string('name');
             $table->timestamps();
         });

--- a/backend/database/migrations/2025_09_02_000001_make_roles_tenant_id_nullable.php
+++ b/backend/database/migrations/2025_09_02_000001_make_roles_tenant_id_nullable.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'sqlite') {
+            return; // fresh sqlite databases use the updated schema
+        }
+
+        if (Schema::hasTable('roles') && Schema::hasColumn('roles', 'tenant_id')) {
+            Schema::table('roles', function (Blueprint $table) {
+                $table->dropForeign(['tenant_id']);
+            });
+
+            if ($driver === 'mysql') {
+                DB::statement('ALTER TABLE roles MODIFY tenant_id BIGINT UNSIGNED NULL');
+            } else {
+                DB::statement('ALTER TABLE roles ALTER COLUMN tenant_id DROP NOT NULL');
+            }
+
+            Schema::table('roles', function (Blueprint $table) {
+                $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $driver = DB::getDriverName();
+        if ($driver === 'sqlite') {
+            return;
+        }
+
+        if (Schema::hasTable('roles') && Schema::hasColumn('roles', 'tenant_id')) {
+            Schema::table('roles', function (Blueprint $table) {
+                $table->dropForeign(['tenant_id']);
+            });
+
+            if ($driver === 'mysql') {
+                DB::statement('ALTER TABLE roles MODIFY tenant_id BIGINT UNSIGNED NOT NULL');
+            } else {
+                DB::statement('ALTER TABLE roles ALTER COLUMN tenant_id SET NOT NULL');
+            }
+
+            Schema::table('roles', function (Blueprint $table) {
+                $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+            });
+        }
+    }
+};

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use App\Models\Appointment;
+
+class TenantBootstrapSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Global role
+        DB::table('roles')->updateOrInsert(
+            ['tenant_id' => null, 'slug' => 'super_admin'],
+            [
+                'name' => 'Super Admin',
+                'level' => 0,
+                'abilities' => json_encode(['*']),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        // Tenant
+        DB::table('tenants')->updateOrInsert(
+            ['id' => 1],
+            [
+                'name' => 'Acme Vet',
+                'quota_storage_mb' => 0,
+                'features' => json_encode([]),
+                'phone' => '555-123-4567',
+                'address' => '1 Pet Street',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+        $tenantId = DB::table('tenants')->where('id', 1)->value('id');
+
+        // Tenant roles
+        $managerAbilities = ['appointments.manage', 'teams.manage', 'statuses.manage'];
+        $agentAbilities = ['appointments.view', 'appointments.update'];
+
+        DB::table('roles')->updateOrInsert(
+            ['tenant_id' => $tenantId, 'slug' => 'manager'],
+            [
+                'name' => 'Manager',
+                'level' => 1,
+                'abilities' => json_encode($managerAbilities),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+        $managerRoleId = DB::table('roles')->where('tenant_id', $tenantId)->where('slug', 'manager')->value('id');
+
+        DB::table('roles')->updateOrInsert(
+            ['tenant_id' => $tenantId, 'slug' => 'agent'],
+            [
+                'name' => 'Agent',
+                'level' => 2,
+                'abilities' => json_encode($agentAbilities),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+        $agentRoleId = DB::table('roles')->where('tenant_id', $tenantId)->where('slug', 'agent')->value('id');
+
+        // Team
+        DB::table('teams')->updateOrInsert(
+            ['tenant_id' => $tenantId, 'name' => 'Front Desk'],
+            [
+                'description' => 'Reception and coordination',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+        $teamId = DB::table('teams')->where('tenant_id', $tenantId)->where('name', 'Front Desk')->value('id');
+
+        // Employees
+        DB::table('users')->updateOrInsert(
+            ['email' => 'manager@acme.test'],
+            [
+                'name' => 'Maggie Manager',
+                'password' => Hash::make('password'),
+                'tenant_id' => $tenantId,
+                'phone' => '555-000-0001',
+                'address' => '1 Pet Street',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+        $managerId = DB::table('users')->where('email', 'manager@acme.test')->value('id');
+
+        DB::table('users')->updateOrInsert(
+            ['email' => 'agent@acme.test'],
+            [
+                'name' => 'Andy Agent',
+                'password' => Hash::make('password'),
+                'tenant_id' => $tenantId,
+                'phone' => '555-000-0002',
+                'address' => '2 Pet Street',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+        $agentId = DB::table('users')->where('email', 'agent@acme.test')->value('id');
+
+        // Assign roles to employees
+        DB::table('role_user')->updateOrInsert(
+            ['role_id' => $managerRoleId, 'user_id' => $managerId, 'tenant_id' => $tenantId],
+            ['created_at' => now(), 'updated_at' => now()]
+        );
+        DB::table('role_user')->updateOrInsert(
+            ['role_id' => $agentRoleId, 'user_id' => $agentId, 'tenant_id' => $tenantId],
+            ['created_at' => now(), 'updated_at' => now()]
+        );
+
+        // Assign employees to team
+        foreach ([$managerId, $agentId] as $employeeId) {
+            DB::table('team_employee')->updateOrInsert(
+                ['team_id' => $teamId, 'employee_id' => $employeeId],
+                ['created_at' => now(), 'updated_at' => now()]
+            );
+        }
+
+        // Default statuses
+        $defaultStatuses = [
+            Appointment::STATUS_DRAFT,
+            Appointment::STATUS_ASSIGNED,
+            Appointment::STATUS_IN_PROGRESS,
+            Appointment::STATUS_COMPLETED,
+        ];
+
+        foreach ($defaultStatuses as $status) {
+            DB::table('statuses')->updateOrInsert(
+                ['tenant_id' => $tenantId, 'name' => $status],
+                ['created_at' => now(), 'updated_at' => now()]
+            );
+        }
+
+        // Appointment type with assignee
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'assignee' => [
+                    'type' => 'object',
+                    'kind' => 'assignee',
+                    'properties' => [
+                        'kind' => ['type' => 'string', 'enum' => ['team', 'employee']],
+                        'id' => ['type' => 'integer'],
+                    ],
+                    'required' => ['kind', 'id'],
+                ],
+            ],
+            'required' => ['assignee'],
+        ];
+
+        $fieldsSummary = ['assignee' => 'Assignee'];
+
+        $transitions = [
+            Appointment::STATUS_DRAFT => [Appointment::STATUS_ASSIGNED],
+            Appointment::STATUS_ASSIGNED => [Appointment::STATUS_IN_PROGRESS],
+            Appointment::STATUS_IN_PROGRESS => [Appointment::STATUS_COMPLETED],
+            Appointment::STATUS_COMPLETED => [],
+        ];
+
+        DB::table('appointment_types')->updateOrInsert(
+            ['tenant_id' => $tenantId, 'name' => 'Basic'],
+            [
+                'form_schema' => json_encode($schema),
+                'fields_summary' => json_encode($fieldsSummary),
+                'statuses' => json_encode($transitions),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+    }
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,7 @@
+# Frontend
+
+## Tenant Switcher & Scope filters
+
+The UI includes a tenant switcher for users with access to multiple tenants. Selecting a tenant updates a frontend tenant store. Every API request reads the active tenant id from this store and sends it using the `X-Tenant-ID` header. After switching tenants, reload any data stores so the UI reflects the new scope.
+
+Many admin views offer scope filters that toggle between tenant-specific, global, or all records. Use these filters to view or manage roles, types, and statuses for the active tenant or across the system. Authorization remains enforced by the backend, so any frontend super-admin hints are purely for convenience.


### PR DESCRIPTION
## Summary
- allow `roles.tenant_id` to be nullable so global roles can be seeded
- clarify that backend authorization is authoritative and document tenant store behavior on the frontend

## Testing
- `php artisan test`
- `php artisan migrate:fresh --env=testing --database=sqlite --seeder=TenantBootstrapSeeder`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b030989fbc83239e7f1b5dbbcd638a