### PR TITLE
feat: add assignee lookup endpoint and cache

### DIFF
--- a/backend/app/Http/Controllers/Api/LookupController.php
+++ b/backend/app/Http/Controllers/Api/LookupController.php
@@ -30,17 +30,29 @@ class LookupController extends Controller
         $results = collect();
 
         if ($type === 'all' || $type === 'teams') {
-            $teams = Team::where('tenant_id', $tenantId)->get()
-                ->map(fn ($team) => ['id' => $team->id, 'label' => $team->name, 'kind' => 'team']);
+            $teams = Team::where('tenant_id', $tenantId)
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(fn ($team) => [
+                    'id' => $team->id,
+                    'label' => $team->name,
+                    'kind' => 'team',
+                ]);
             $results = $results->merge($teams);
         }
 
         if ($type === 'all' || $type === 'employees') {
-            $employees = User::where('tenant_id', $tenantId)->get()
-                ->map(fn ($user) => ['id' => $user->id, 'label' => $user->name, 'kind' => 'employee']);
+            $employees = User::where('tenant_id', $tenantId)
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(fn ($user) => [
+                    'id' => $user->id,
+                    'label' => $user->name,
+                    'kind' => 'employee',
+                ]);
             $results = $results->merge($employees);
         }
 
-        return $results->values();
+        return $results->sortBy('label')->values();
     }
 }

--- a/frontend/src/stores/lookups.ts
+++ b/frontend/src/stores/lookups.ts
@@ -7,17 +7,40 @@ export const useLookupsStore = defineStore('lookups', {
       teams: [] as any[],
       employees: [] as any[],
     },
+    assigneeFetchedAt: {
+      teams: 0,
+      employees: 0,
+    },
   }),
   actions: {
     async fetchAssignees(type: 'all' | 'teams' | 'employees' = 'all') {
+      const ttl = 5 * 60 * 1000; // 5 minutes
+      const now = Date.now();
+
+      const cacheValid = (t: 'teams' | 'employees') =>
+        this.assignees[t].length && now - this.assigneeFetchedAt[t] < ttl;
+
+      if (type === 'all') {
+        if (cacheValid('teams') && cacheValid('employees')) {
+          return [...this.assignees.teams, ...this.assignees.employees];
+        }
+      } else if (cacheValid(type)) {
+        return this.assignees[type];
+      }
+
       const { data } = await api.get('/lookups/assignees', { params: { type } });
+
       if (type === 'all') {
         this.assignees.teams = data.filter((a: any) => a.kind === 'team');
         this.assignees.employees = data.filter((a: any) => a.kind === 'employee');
+        this.assigneeFetchedAt.teams = now;
+        this.assigneeFetchedAt.employees = now;
       } else {
         // @ts-ignore
         this.assignees[type] = data;
+        this.assigneeFetchedAt[type] = now;
       }
+
       return data;
     },
   },


### PR DESCRIPTION
## Summary
- sort team and employee results in assignee lookups endpoint
- cache assignee lookup results per type for 5 minutes in SPA store

## Testing
- `composer test` (fails: response count expected 3 got 2)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b038305784832383fafb499d8b2230