### PR TITLE
Normalize appointment assignee payload

### DIFF
--- a/backend/app/Http/Controllers/Api/AppointmentController.php
+++ b/backend/app/Http/Controllers/Api/AppointmentController.php
@@ -19,7 +19,7 @@ class AppointmentController extends Controller
     public function index(Request $request)
     {
         $appointments = Appointment::where('tenant_id', $request->user()->tenant_id)
-            ->with('type')
+            ->with(['type', 'assignee'])
             ->paginate($request->query('per_page', 15));
 
         return AppointmentResource::collection($appointments->items())->additional([
@@ -58,6 +58,7 @@ class AppointmentController extends Controller
         $this->formSchemaService->mapAssignee($type->form_schema ?? [], $data);
 
         $appointment = Appointment::create($data);
+        $appointment->load('type', 'assignee');
 
         return (new AppointmentResource($appointment))
             ->response()
@@ -67,7 +68,7 @@ class AppointmentController extends Controller
     public function show(Appointment $appointment)
     {
         $this->authorize('view', $appointment);
-        return new AppointmentResource($appointment->load('photos', 'comments', 'type'));
+        return new AppointmentResource($appointment->load('photos', 'comments', 'type', 'assignee'));
     }
 
     public function update(Request $request, Appointment $appointment)
@@ -129,7 +130,7 @@ class AppointmentController extends Controller
         $appointment->fill($data);
         $appointment->save();
 
-        return new AppointmentResource($appointment->load('photos', 'comments', 'type'));
+        return new AppointmentResource($appointment->load('photos', 'comments', 'type', 'assignee'));
     }
 
     public function destroy(Appointment $appointment)

--- a/backend/app/Http/Resources/AppointmentResource.php
+++ b/backend/app/Http/Resources/AppointmentResource.php
@@ -2,12 +2,26 @@
 
 namespace App\Http\Resources;
 
+use App\Models\Team;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AppointmentResource extends JsonResource
 {
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        $data = parent::toArray($request);
+
+        if ($this->assignee) {
+            $kind = $this->assignee instanceof Team ? 'team' : 'employee';
+            $data['assignee'] = [
+                'id' => $this->assignee->id,
+                'kind' => $kind,
+                'label' => $this->assignee->name,
+            ];
+        } else {
+            $data['assignee'] = null;
+        }
+
+        return $data;
     }
 }

--- a/frontend/src/stores/appointments.ts
+++ b/frontend/src/stores/appointments.ts
@@ -6,10 +6,30 @@ export const useAppointmentsStore = defineStore('appointments', {
     appointments: [] as any[],
   }),
   actions: {
+    normalize(payload: any) {
+      if (payload.assignee) {
+        payload.assignee = {
+          kind: payload.assignee.kind,
+          id: payload.assignee.id,
+          label: payload.assignee.label,
+        };
+      }
+      return payload;
+    },
+    toPayload(payload: any) {
+      const data = { ...payload };
+      if (payload.assignee) {
+        data.assignee = {
+          kind: payload.assignee.kind,
+          id: payload.assignee.id,
+        };
+      }
+      return data;
+    },
     async fetch() {
       try {
         const { data } = await api.get('/appointments');
-        this.appointments = data;
+        this.appointments = data.map((a: any) => this.normalize(a));
       } catch (e) {
         this.appointments = [];
       }
@@ -19,28 +39,16 @@ export const useAppointmentsStore = defineStore('appointments', {
       return this.appointments.find((a: any) => a.id == id);
     },
     async create(payload: any) {
-      const data = { ...payload };
-      if (payload.assignee) {
-        data.assignee = {
-          kind: payload.assignee.kind,
-          id: payload.assignee.id,
-        };
-      }
-      const res = await api.post('/appointments', data);
-      this.appointments.push(res.data);
-      return res.data;
+      const res = await api.post('/appointments', this.toPayload(payload));
+      const appt = this.normalize(res.data);
+      this.appointments.push(appt);
+      return appt;
     },
     async update(id: string, payload: any) {
-      const data = { ...payload };
-      if (payload.assignee) {
-        data.assignee = {
-          kind: payload.assignee.kind,
-          id: payload.assignee.id,
-        };
-      }
-      const { data: updated } = await api.patch(`/appointments/${id}`, data);
-      this.appointments = this.appointments.map((a: any) => (a.id === id ? updated : a));
-      return updated;
+      const { data: updated } = await api.patch(`/appointments/${id}`, this.toPayload(payload));
+      const appt = this.normalize(updated);
+      this.appointments = this.appointments.map((a: any) => (a.id === id ? appt : a));
+      return appt;
     },
   },
 });

--- a/frontend/src/views/appointments/AppointmentDetails.vue
+++ b/frontend/src/views/appointments/AppointmentDetails.vue
@@ -15,6 +15,7 @@
         <li>Started: {{ format(appointment.started_at) || '—' }}</li>
         <li>Completed: {{ format(appointment.completed_at) || '—' }}</li>
         <li>SLA End: {{ format(appointment.sla_end_at) || '—' }}</li>
+        <li>Assignee: {{ appointment.assignee?.label || '—' }}</li>
         <li>SLA: {{ slaStatus }}</li>
       </ul>
       <div class="flex flex-wrap gap-2 mt-2">

--- a/frontend/src/views/appointments/AppointmentForm.vue
+++ b/frontend/src/views/appointments/AppointmentForm.vue
@@ -107,9 +107,8 @@ onMounted(async () => {
     slaEndAt.value = appt.sla_end_at || '';
     status.value = appt.status;
     originalStatus.value = appt.status;
-    if (appt.assignee_type && appt.assignee_id) {
-      const kind = appt.assignee_type.includes('Team') ? 'team' : 'employee';
-      assignee.value = { kind, id: appt.assignee_id };
+    if (appt.assignee) {
+      assignee.value = { kind: appt.assignee.kind, id: appt.assignee.id };
     }
     const map = appt.type?.statuses || {};
     const allowed = Array.from(new Set([...Object.keys(map), ...Object.values(map).flat()]));


### PR DESCRIPTION
## Summary
- include normalized assignee object in appointment API responses
- handle assignee object in SPA form and store
- display assignee label on appointment details

## Testing
- `composer test` *(fails: Tests\\Feature\\SuperAdminRoleVisibilityTest)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03968a38c83238b70ebfbefb141ae