### PR TITLE
Expose allowed status transitions

### DIFF
--- a/backend/app/Http/Controllers/Api/StatusController.php
+++ b/backend/app/Http/Controllers/Api/StatusController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Status;
 use Illuminate\Http\Request;
 use App\Http\Resources\StatusResource;
+use App\Services\StatusFlowService;
 
 class StatusController extends Controller
 {
@@ -118,6 +119,21 @@ class StatusController extends Controller
         return (new StatusResource($copy))
             ->response()
             ->setStatusCode(201);
+    }
+
+    public function transitions(Status $status, StatusFlowService $flow)
+    {
+        $names = $flow->allowedTransitions($status->name);
+        $query = Status::query()->whereIn('name', $names);
+
+        if ($status->tenant_id) {
+            $query->where('tenant_id', $status->tenant_id);
+        } else {
+            $query->whereNull('tenant_id');
+        }
+
+        $statuses = $query->get();
+        return StatusResource::collection($statuses);
     }
 }
 

--- a/backend/app/Models/Appointment.php
+++ b/backend/app/Models/Appointment.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Carbon\Carbon;
+use App\Services\StatusFlowService;
 
 class Appointment extends Model
 {
@@ -46,14 +47,7 @@ class Appointment extends Model
         'form_schema',
     ];
 
-    protected static $transitions = [
-        self::STATUS_DRAFT => [self::STATUS_ASSIGNED],
-        self::STATUS_ASSIGNED => [self::STATUS_IN_PROGRESS],
-        self::STATUS_IN_PROGRESS => [self::STATUS_COMPLETED],
-        self::STATUS_COMPLETED => [self::STATUS_REJECTED, self::STATUS_REDO],
-        self::STATUS_REJECTED => [self::STATUS_ASSIGNED],
-        self::STATUS_REDO => [self::STATUS_ASSIGNED],
-    ];
+    protected static $transitions = StatusFlowService::DEFAULT_TRANSITIONS;
 
     public function photos(): HasMany
     {

--- a/backend/app/Services/StatusFlowService.php
+++ b/backend/app/Services/StatusFlowService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services;
+
+class StatusFlowService
+{
+    /**
+     * Default allowed transitions between statuses.
+     *
+     * @var array<string, array<int, string>>
+     */
+    public const DEFAULT_TRANSITIONS = [
+        'draft' => ['assigned'],
+        'assigned' => ['in_progress'],
+        'in_progress' => ['completed'],
+        'completed' => ['rejected', 'redo'],
+        'rejected' => ['assigned'],
+        'redo' => ['assigned'],
+    ];
+
+    /**
+     * Get allowed transitions for a given status.
+     *
+     * @param string $status
+     * @param array|null $map Optional transitions override
+     * @return array
+     */
+    public function allowedTransitions(string $status, ?array $map = null): array
+    {
+        $map = $map ?? self::DEFAULT_TRANSITIONS;
+        return $map[$status] ?? [];
+    }
+
+    /**
+     * Determine if transition is allowed.
+     */
+    public function canTransition(string $from, string $to, ?array $map = null): bool
+    {
+        return in_array($to, $this->allowedTransitions($from, $map), true);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -61,6 +61,7 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     Route::apiResource('appointment-types', AppointmentTypeController::class)->only(['index', 'show']);
     Route::apiResource('roles', RoleController::class)->only(['index', 'show']);
     Route::apiResource('statuses', StatusController::class)->only(['index', 'show']);
+    Route::get('statuses/{status}/transitions', [StatusController::class, 'transitions']);
     Route::apiResource('teams', TeamController::class)->only(['index', 'show']);
 
     Route::post('appointment-types', [AppointmentTypeController::class, 'store'])->middleware(Ability::class . ':types.manage')->name('appointment-types.store');

--- a/frontend/src/stores/statuses.ts
+++ b/frontend/src/stores/statuses.ts
@@ -9,6 +9,10 @@ export const useStatusesStore = defineStore('statuses', {
       const { data } = await api.get('/statuses', { params });
       return data;
     },
+    async fetchTransitions(id: number) {
+      const { data } = await api.get(`/statuses/${id}/transitions`);
+      return data;
+    },
     async copyToTenant(id: number, tenantId?: string | number) {
       const payload: any = {};
       if (tenantId) payload.tenant_id = tenantId;

--- a/frontend/src/views/appointments/StatusChanger.vue
+++ b/frontend/src/views/appointments/StatusChanger.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="flex items-center gap-2">
+    <Select
+      v-model="selected"
+      :options="options"
+      placeholder="Change status"
+      classInput="min-w-[160px]"
+    />
+    <Button
+      text="Update"
+      btnClass="btn-dark btn-sm"
+      :isDisabled="!selected"
+      @click="apply"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import Select from '@/components/ui/Select/index.vue';
+import Button from '@/components/ui/Button/index.vue';
+import { useStatusesStore } from '@/stores/statuses';
+import api from '@/services/api';
+import { useNotify } from '@/plugins/notify';
+
+const props = defineProps<{ appointmentId: number; statusId: number }>();
+const emit = defineEmits<{ (e: 'updated', statusId: number): void }>();
+
+const store = useStatusesStore();
+const notify = useNotify();
+
+const transitions = ref<any[]>([]);
+const selected = ref<number | null>(null);
+
+onMounted(async () => {
+  transitions.value = await store.fetchTransitions(props.statusId);
+});
+
+const options = computed(() =>
+  transitions.value.map((s: any) => ({ value: s.id, label: s.name }))
+);
+
+async function apply() {
+  const target = transitions.value.find((s: any) => s.id === selected.value);
+  if (!target) return;
+  try {
+    await api.patch(`/appointments/${props.appointmentId}`, { status: target.name });
+    emit('updated', target.id);
+    notify.success('Status updated');
+  } catch (e: any) {
+    if (e.status === 422) {
+      notify.error('Invalid status transition');
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add `StatusFlowService` to centralize status transition rules
- expose `/statuses/{id}/transitions` endpoint and use it on appointments UI
- show only valid status options and validate transitions

## Testing
- `composer test` *(fails: Failed to assert that the response count matched the expected 3)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b03bdebc6c83239cd715c67bbd6a2f