### PR TITLE
Normalize ISO 8601 date handling across backend and frontend

### DIFF
--- a/backend/app/Http/Resources/AppointmentResource.php
+++ b/backend/app/Http/Resources/AppointmentResource.php
@@ -4,9 +4,12 @@ namespace App\Http\Resources;
 
 use App\Models\Team;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class AppointmentResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
         $data = parent::toArray($request);
@@ -22,6 +25,6 @@ class AppointmentResource extends JsonResource
             $data['assignee'] = null;
         }
 
-        return $data;
+        return $this->formatDates($data);
     }
 }

--- a/backend/app/Http/Resources/AppointmentTypeResource.php
+++ b/backend/app/Http/Resources/AppointmentTypeResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class AppointmentTypeResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/backend/app/Http/Resources/Concerns/FormatsDateTimes.php
+++ b/backend/app/Http/Resources/Concerns/FormatsDateTimes.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Concerns;
+
+use DateTimeInterface;
+
+trait FormatsDateTimes
+{
+    protected function formatDates(array $data): array
+    {
+        array_walk_recursive($data, function (&$value) {
+            if ($value instanceof DateTimeInterface) {
+                $value = $value->toIso8601String();
+            }
+        });
+
+        return $data;
+    }
+}

--- a/backend/app/Http/Resources/EmployeeResource.php
+++ b/backend/app/Http/Resources/EmployeeResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class EmployeeResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/backend/app/Http/Resources/ManualResource.php
+++ b/backend/app/Http/Resources/ManualResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class ManualResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/backend/app/Http/Resources/NotificationResource.php
+++ b/backend/app/Http/Resources/NotificationResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class NotificationResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/backend/app/Http/Resources/RoleResource.php
+++ b/backend/app/Http/Resources/RoleResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class RoleResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/backend/app/Http/Resources/StatusResource.php
+++ b/backend/app/Http/Resources/StatusResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class StatusResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/backend/app/Http/Resources/TeamResource.php
+++ b/backend/app/Http/Resources/TeamResource.php
@@ -3,11 +3,14 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
 
 class TeamResource extends JsonResource
 {
+    use FormatsDateTimes;
+
     public function toArray($request): array
     {
-        return parent::toArray($request);
+        return $this->formatDates(parent::toArray($request));
     }
 }

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -1,0 +1,11 @@
+export function parseISO(value: string | number | Date): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+export function toISO(value: string | number | Date): string {
+  return parseISO(value).toISOString();
+}
+
+export function formatDisplay(value: string | number | Date, options?: Intl.DateTimeFormatOptions): string {
+  return parseISO(value).toLocaleString(undefined, options);
+}

--- a/frontend/src/views/appointments/AppointmentDetails.vue
+++ b/frontend/src/views/appointments/AppointmentDetails.vue
@@ -79,6 +79,7 @@ import CommentsThread from '@/components/comments/CommentsThread.vue';
 import CommentEditor from '@/components/comments/CommentEditor.vue';
 import StatusChanger from './StatusChanger.vue';
 import { useStatusesStore } from '@/stores/statuses';
+import { formatDisplay, parseISO, toISO } from '@/utils/datetime';
 
 const route = useRoute();
 
@@ -103,7 +104,7 @@ const tabs = [
 const activeTab = ref('details');
 
 function format(date?: string) {
-  return date ? new Date(date).toLocaleString() : '';
+  return date ? formatDisplay(date) : '';
 }
 
 const slaStatus = computed(() => {
@@ -111,8 +112,8 @@ const slaStatus = computed(() => {
   if (!appt) return 'none';
   if (appt.sla_status) return appt.sla_status;
   if (!appt.sla_end_at) return 'none';
-  const reference = appt.completed_at || new Date().toISOString();
-  return new Date(reference) <= new Date(appt.sla_end_at)
+  const reference = appt.completed_at || toISO(new Date());
+  return parseISO(reference) <= parseISO(appt.sla_end_at)
     ? 'within'
     : 'breached';
 });

--- a/frontend/src/views/appointments/AppointmentForm.vue
+++ b/frontend/src/views/appointments/AppointmentForm.vue
@@ -61,6 +61,7 @@ import * as yup from 'yup';
 import vSelect from 'vue-select';
 import { useNotify } from '@/plugins/notify';
 import AssigneePicker from '@/components/appointments/AssigneePicker.vue';
+import { toISO } from '@/utils/datetime';
 
 const notify = useNotify();
 const router = useRouter();
@@ -102,9 +103,9 @@ onMounted(async () => {
     const appt = res.data;
     typeId.value = appt.type?.id || appt.appointment_type_id;
     formData.value = appt.form_data || {};
-    scheduledAt.value = appt.scheduled_at || '';
-    slaStartAt.value = appt.sla_start_at || '';
-    slaEndAt.value = appt.sla_end_at || '';
+    scheduledAt.value = appt.scheduled_at ? toISO(appt.scheduled_at) : '';
+    slaStartAt.value = appt.sla_start_at ? toISO(appt.sla_start_at) : '';
+    slaEndAt.value = appt.sla_end_at ? toISO(appt.sla_end_at) : '';
     status.value = appt.status;
     originalStatus.value = appt.status;
     if (appt.assignee) {
@@ -121,9 +122,9 @@ onMounted(async () => {
 function onTypeChange() {
   formData.value = {};
   const t = types.value.find((t) => t.id === typeId.value);
-  scheduledAt.value = t?.scheduled_at || '';
-  slaStartAt.value = t?.sla_start_at || '';
-  slaEndAt.value = t?.sla_end_at || '';
+  scheduledAt.value = t?.scheduled_at ? toISO(t.scheduled_at) : '';
+  slaStartAt.value = t?.sla_start_at ? toISO(t.sla_start_at) : '';
+  slaEndAt.value = t?.sla_end_at ? toISO(t.sla_end_at) : '';
   assignee.value = null;
 }
 
@@ -174,9 +175,9 @@ const submitForm = handleSubmit(async () => {
     appointment_type_id: typeId.value,
     form_data: formData.value,
   };
-  if (scheduledAt.value) payload.scheduled_at = scheduledAt.value;
-  if (slaStartAt.value) payload.sla_start_at = slaStartAt.value;
-  if (slaEndAt.value) payload.sla_end_at = slaEndAt.value;
+  if (scheduledAt.value) payload.scheduled_at = toISO(scheduledAt.value);
+  if (slaStartAt.value) payload.sla_start_at = toISO(slaStartAt.value);
+  if (slaEndAt.value) payload.sla_end_at = toISO(slaEndAt.value);
   if (assignee.value) payload.assignee = assignee.value;
   try {
     if (isEdit.value) {

--- a/frontend/src/views/appointments/AppointmentsList.vue
+++ b/frontend/src/views/appointments/AppointmentsList.vue
@@ -56,6 +56,7 @@ import api from '@/services/api';
 import { useNotify } from '@/plugins/notify';
 import Icon from '@/components/ui/Icon';
 import Swal from 'sweetalert2';
+import { parseISO, formatDisplay } from '@/utils/datetime';
 
 const router = useRouter();
 const notify = useNotify();
@@ -111,15 +112,15 @@ async function fetchAppointments({ page, perPage, sort, search }: any) {
     rows = rows.filter((r) => r.status === statusFilter.value);
   }
   if (startDate.value) {
-    const start = new Date(startDate.value);
+    const start = parseISO(startDate.value);
     rows = rows.filter(
-      (r) => r.scheduled_at && new Date(r.scheduled_at) >= start,
+      (r) => r.scheduled_at && parseISO(r.scheduled_at) >= start,
     );
   }
   if (endDate.value) {
-    const end = new Date(endDate.value);
+    const end = parseISO(endDate.value);
     rows = rows.filter(
-      (r) => r.scheduled_at && new Date(r.scheduled_at) <= end,
+      (r) => r.scheduled_at && parseISO(r.scheduled_at) <= end,
     );
   }
   if (search) {
@@ -143,10 +144,10 @@ async function fetchAppointments({ page, perPage, sort, search }: any) {
     id: r.id,
     type: r.type?.name || '—',
     status: `<span class="px-2 py-1 rounded-full text-xs font-semibold ${statusClasses[r.status] ?? ''}">${r.status.replace(/_/g, ' ')}</span>`,
-    scheduled_at: r.scheduled_at,
-    sla_end_at: r.sla_end_at,
-    started_at: r.started_at,
-    completed_at: r.completed_at,
+    scheduled_at: r.scheduled_at ? formatDisplay(r.scheduled_at) : '',
+    sla_end_at: r.sla_end_at ? formatDisplay(r.sla_end_at) : '',
+    started_at: r.started_at ? formatDisplay(r.started_at) : '',
+    completed_at: r.completed_at ? formatDisplay(r.completed_at) : '',
   }));
   return { rows: paged, total };
 }

--- a/frontend/src/views/appointments/CalendarView.vue
+++ b/frontend/src/views/appointments/CalendarView.vue
@@ -49,6 +49,7 @@ import { useCalendarStore } from '@/stores/calendar';
 import { useStatusesStore } from '@/stores/statuses';
 import { useTypesStore } from '@/stores/types';
 import { useLookupsStore } from '@/stores/lookups';
+import { toISO } from '@/utils/datetime';
 
 const router = useRouter();
 const store = useCalendarStore();
@@ -89,7 +90,9 @@ async function loadEvents(info?: { startStr: string; endStr: string }) {
     type_id: typeId.value,
     status_id: statusId.value,
   } as any;
-  await store.fetch(currentRange.value.startStr, currentRange.value.endStr);
+  const start = toISO(currentRange.value.startStr);
+  const end = toISO(currentRange.value.endStr);
+  await store.fetch(start, end);
 }
 
 watch([teamId, employeeId, typeId, statusId], () => {
@@ -104,7 +107,7 @@ const calendarOptions = computed(() => ({
     loadEvents({ startStr: info.startStr, endStr: info.endStr });
   },
   dateClick(info: any) {
-    selectedDate.value = info.dateStr;
+    selectedDate.value = toISO(info.dateStr);
     showCreate.value = true;
   },
   eventClick(info: any) {

--- a/frontend/src/views/home/Dashboard.vue
+++ b/frontend/src/views/home/Dashboard.vue
@@ -55,6 +55,7 @@ import ChartCard from '@/components/reports/ChartCard.vue';
 import Card from '@/components/ui/Card/index.vue';
 import Skeleton from '@/components/ui/Skeleton.vue';
 import Button from '@/components/ui/Button/index.vue';
+import { parseISO } from '@/utils/datetime';
 
 interface Kpi {
   label: string;
@@ -84,7 +85,10 @@ async function fetchData() {
   try {
     const { data } = await api.get('/reports/overview');
     kpis.value = data.kpis || [];
-    chartSeries.value = data.chart?.series || [];
+    chartSeries.value = (data.chart?.series || []).map((s: any) => ({
+      label: s.label,
+      data: (s.data || []).map((d: any) => ({ x: parseISO(d.x), y: d.y })),
+    }));
     chartType.value = data.chart?.type || 'line';
     chartTitle.value = data.chart?.title || t('dashboard.chart.trend');
   } catch (e) {


### PR DESCRIPTION
## Summary
- Format API dates as ISO 8601 strings with timezone
- Add frontend datetime utilities and apply across appointments and dashboard views

## Testing
- `composer test` *(fails: Tests\Feature\SuperAdminRoleVisibilityTest > super admin can view roles from all tenants without header)*
- `npm test` *(fails: roles store fetches roles with params)*

------
https://chatgpt.com/codex/tasks/task_e_68b043a433848323956a216fd3412e48