### PR TITLE
feat: add form requests and frontend error handling

### DIFF
--- a/backend/app/Http/Controllers/Api/StatusController.php
+++ b/backend/app/Http/Controllers/Api/StatusController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Http\Resources\StatusResource;
 use App\Services\StatusFlowService;
 use App\Support\ListQuery;
+use App\Http\Requests\StatusUpsertRequest;
 
 class StatusController extends Controller
 {
@@ -43,13 +44,10 @@ class StatusController extends Controller
         ]);
     }
 
-    public function store(Request $request)
+    public function store(StatusUpsertRequest $request)
     {
         $this->ensureAdmin($request);
-        $data = $request->validate([
-            'name' => 'required|string',
-            'tenant_id' => 'sometimes|integer',
-        ]);
+        $data = $request->validated();
 
         if ($request->user()->hasRole('SuperAdmin')) {
             $data['tenant_id'] = $data['tenant_id'] ?? null;
@@ -66,16 +64,13 @@ class StatusController extends Controller
         return new StatusResource($status);
     }
 
-    public function update(Request $request, Status $status)
+    public function update(StatusUpsertRequest $request, Status $status)
     {
         $this->ensureAdmin($request);
         if (! $request->user()->hasRole('SuperAdmin') && $status->tenant_id !== $request->user()->tenant_id) {
             abort(403);
         }
-        $data = $request->validate([
-            'name' => 'required|string',
-            'tenant_id' => 'sometimes|integer',
-        ]);
+        $data = $request->validated();
 
         if ($request->user()->hasRole('SuperAdmin')) {
             if (array_key_exists('tenant_id', $data)) {

--- a/backend/app/Http/Requests/AppointmentUpsertRequest.php
+++ b/backend/app/Http/Requests/AppointmentUpsertRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Appointment;
+use App\Models\AppointmentType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class AppointmentUpsertRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $rules = [
+            'scheduled_at' => ['nullable', 'date'],
+            'sla_start_at' => ['nullable', 'date'],
+            'sla_end_at' => ['nullable', 'date'],
+            'kau_notes' => ['nullable', 'string'],
+            'appointment_type_id' => ['nullable', 'exists:appointment_types,id'],
+            'form_data' => ['nullable', 'array'],
+            'assignee' => ['nullable', 'array'],
+            'assignee.kind' => ['required_with:assignee', 'in:team,employee'],
+            'assignee.id' => ['required_with:assignee', 'integer'],
+        ];
+
+        if ($appointment = $this->route('appointment')) {
+            $typeId = $this->input('appointment_type_id', $appointment->appointment_type_id);
+            $type = $typeId ? AppointmentType::find($typeId) : null;
+            $allowed = collect($type->statuses ?? Appointment::$transitions)
+                ->flatMap(fn ($next, $current) => array_merge([$current], $next))
+                ->unique()
+                ->all();
+            $rules['status'] = ['nullable', Rule::in($allowed)];
+        }
+
+        return $rules;
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'scheduled_at' => 'scheduled date',
+            'sla_start_at' => 'SLA start',
+            'sla_end_at' => 'SLA end',
+            'kau_notes' => 'Kau notes',
+            'appointment_type_id' => 'appointment type',
+            'form_data' => 'form data',
+            'assignee.kind' => 'assignee type',
+            'assignee.id' => 'assignee',
+            'status' => 'status',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'required' => 'Please provide a :attribute.',
+            'date' => 'The :attribute must be a valid date.',
+            'in' => 'The selected :attribute is invalid.',
+            'exists' => 'The selected :attribute is invalid.',
+            'integer' => 'The :attribute must be an integer.',
+            'array' => 'The :attribute must be an array.',
+            'string' => 'The :attribute must be a string.',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/RoleUpsertRequest.php
+++ b/backend/app/Http/Requests/RoleUpsertRequest.php
@@ -32,4 +32,26 @@ class RoleUpsertRequest extends FormRequest
             'tenant_id' => ['nullable', 'exists:tenants,id'],
         ];
     }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'name',
+            'slug' => 'slug',
+            'abilities' => 'abilities',
+            'tenant_id' => 'tenant',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'required' => 'Please provide a :attribute.',
+            'string' => 'The :attribute must be a string.',
+            'max' => 'The :attribute may not be greater than :max characters.',
+            'array' => 'The :attribute must be an array.',
+            'exists' => 'The selected :attribute is invalid.',
+            'unique' => 'The :attribute has already been taken.',
+        ];
+    }
 }

--- a/backend/app/Http/Requests/StatusUpsertRequest.php
+++ b/backend/app/Http/Requests/StatusUpsertRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StatusUpsertRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'tenant_id' => ['sometimes', 'integer'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'name',
+            'tenant_id' => 'tenant',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'required' => 'Please provide a :attribute.',
+            'string' => 'The :attribute must be a string.',
+            'integer' => 'The :attribute must be an integer.',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/TeamUpsertRequest.php
+++ b/backend/app/Http/Requests/TeamUpsertRequest.php
@@ -30,4 +30,24 @@ class TeamUpsertRequest extends FormRequest
             'tenant_id' => ['nullable', 'exists:tenants,id'],
         ];
     }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'name',
+            'description' => 'description',
+            'tenant_id' => 'tenant',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'required' => 'Please provide a :attribute.',
+            'string' => 'The :attribute must be a string.',
+            'max' => 'The :attribute may not be greater than :max characters.',
+            'exists' => 'The selected :attribute is invalid.',
+            'unique' => 'The :attribute has already been taken.',
+        ];
+    }
 }

--- a/backend/app/Http/Requests/TypeUpsertRequest.php
+++ b/backend/app/Http/Requests/TypeUpsertRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TypeUpsertRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $isUpdate = (bool) $this->route('appointmentType');
+        $required = $isUpdate ? 'sometimes' : 'required';
+
+        return [
+            'name' => [$required, 'string', 'max:255'],
+            'form_schema' => ['nullable', 'json'],
+            'fields_summary' => ['nullable', 'json'],
+            'statuses' => [$required, 'json'],
+            'tenant_id' => ['sometimes', 'integer'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'name',
+            'form_schema' => 'form schema',
+            'fields_summary' => 'fields summary',
+            'statuses' => 'statuses',
+            'tenant_id' => 'tenant',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'required' => 'Please provide a :attribute.',
+            'json' => 'The :attribute must be valid JSON.',
+            'integer' => 'The :attribute must be an integer.',
+            'max' => 'The :attribute may not be greater than :max characters.',
+            'string' => 'The :attribute must be a string.',
+        ];
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $data = parent::validated($key, $default);
+        foreach (['form_schema', 'fields_summary', 'statuses'] as $field) {
+            if (isset($data[$field])) {
+                $data[$field] = json_decode($data[$field], true);
+            }
+        }
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize validation with new Laravel FormRequests and friendlier messages
- tighten controllers to use request validation directly
- surface server-side validation in SPA forms via vee-validate

## Testing
- `php artisan test` *(fails: response count mismatch)*
- `npm test` *(fails: expected API params in roles store)*

------
https://chatgpt.com/codex/tasks/task_e_68b044d7200c8323981b716cd00c5925