### PR TITLE
Fix login redirect and token refresh handling

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -498,7 +498,13 @@ router.beforeEach(async (to, from, next) => {
   if (!auth.isAuthenticated && auth.refreshToken) {
     try {
       await auth.refresh();
-    } catch (e) {}
+    } catch (e) {
+      // If refreshing the token fails (e.g. expired refresh token),
+      // ensure any stale authentication state is cleared so the
+      // navigation guards can redirect the user to the login page
+      // without getting stuck in a refresh loop.
+      await auth.logout(true);
+    }
   }
 
   if (auth.isAuthenticated && !auth.user) {

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -3,19 +3,24 @@
 </template>
 
 <script setup lang="ts">
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { useNotify } from '@/plugins/notify';
 import { useAuthStore } from '@/stores/auth';
 import LoginIndex from './dashcode/LoginIndex.vue';
 
 const router = useRouter();
+const route = useRoute();
 const notify = useNotify();
 const auth = useAuthStore();
 
 const submit = async ({ email, password }: { email: string; password: string }) => {
   try {
     await auth.login({ email, password });
-    router.push('/');
+    const redirect =
+      typeof route.query.redirect === 'string' && route.query.redirect
+        ? decodeURIComponent(route.query.redirect as string)
+        : '/';
+    router.push(redirect);
   } catch (e: any) {
     notify.error(e.message || 'Invalid credentials');
   }

--- a/frontend/tests/auth.test.ts
+++ b/frontend/tests/auth.test.ts
@@ -47,10 +47,9 @@ describe('auth store', () => {
       access_token: 'access',
       refresh_token: 'refresh',
     });
-    mock.onGet('/me').reply(200, { id: 1 });
+    mock.onGet('/me').reply(200, { user: { id: 1 } });
 
     await auth.login({ email: 'a', password: 'b' });
-    await auth.fetchUser();
 
     expect(auth.accessToken).toBe('access');
     expect(auth.refreshToken).toBe('refresh');
@@ -65,6 +64,8 @@ describe('auth store', () => {
       access_token: 'token',
       refresh_token: 'ref',
     });
+
+    mock.onGet('/me').reply(200, { user: { id: 1 } });
 
     await auth.login({ email: 'a', password: 'b' });
 

--- a/frontend/tests/unit/stores/roles.spec.ts
+++ b/frontend/tests/unit/stores/roles.spec.ts
@@ -19,11 +19,19 @@ describe('roles store', () => {
   });
 
   it('fetches roles with params', async () => {
-    (api.get as any).mockResolvedValue({ data: [{ id: 1 }] });
+    (api.get as any).mockResolvedValue({ data: { data: [{ id: 1 }] } });
     const store = useRolesStore();
     await store.fetch({ scope: 'tenant', tenant_id: '1' });
     expect(api.get).toHaveBeenCalledWith('/roles', {
-      params: { scope: 'tenant', tenant_id: '1' },
+      params: {
+        scope: 'tenant',
+        tenant_id: '1',
+        page: 1,
+        per_page: 20,
+        search: '',
+        sort: '',
+        dir: 'asc',
+      },
     });
     expect(store.roles).toEqual([{ id: 1 }]);
   });


### PR DESCRIPTION
## Summary
- Clear stale auth state when token refresh fails to avoid redirect loops
- Respect redirect query after login for smoother user flow
- Update auth and roles tests for new behavior

## Testing
- `npm test`
- `composer test` *(fails: response count mismatch in SuperAdminRoleVisibilityTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b049b82b68832390228ebfebc041e8