### PR TITLE
Enable request logging for artisan server

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -20,6 +20,10 @@ return Application::configure(
             \App\Http\Middleware\ETag::class,
         ]);
 
+        $middleware->append([
+            \App\Http\Middleware\LogRequests::class,
+        ]);
+
         $middleware->alias([
             'tenant' => \App\Http\Middleware\ResolveTenant::class,
             'signed.url' => \App\Http\Middleware\SignedUrl::class,


### PR DESCRIPTION
## Summary
- append custom request logging middleware so each request logs method, URL, and status

## Testing
- `php -l backend/bootstrap/app.php`
- `composer test` *(fails: Warning: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b04b8985ec8323804c1979fc2f1422