### PR TITLE
feat: add role level type

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -372,6 +372,8 @@ components:
         description:
           type: string
           nullable: true
+        level:
+          type: integer
     RoleAssignment:
       type: object
       required:

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -693,6 +693,7 @@ export interface components {
             id?: number;
             name?: string;
             description?: string | null;
+            level?: number;
         };
         RoleAssignment: {
             user_id: number;


### PR DESCRIPTION
## Summary
- add `level` integer property to Role in OpenAPI spec and generated types
- regenerate API type definitions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0541d52a8832388baade2684977b0