### PR TITLE
Use explicit array in RoleResource

### DIFF
--- a/backend/app/Http/Resources/RoleResource.php
+++ b/backend/app/Http/Resources/RoleResource.php
@@ -11,6 +11,13 @@ class RoleResource extends JsonResource
 
     public function toArray($request): array
     {
-        return $this->formatDates(parent::toArray($request));
+        return $this->formatDates([
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'abilities' => $this->abilities,
+            'tenant_id' => $this->tenant_id,
+            'level' => $this->level,
+        ]);
     }
 }

--- a/backend/tests/Feature/RoleRoutesTest.php
+++ b/backend/tests/Feature/RoleRoutesTest.php
@@ -44,20 +44,36 @@ class RoleRoutesTest extends TestCase
         $roleId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'slug', 'abilities', 'tenant_id', 'level'],
+            ])
             ->assertJsonPath('data.level', 1)
+            ->assertJsonPath('data.tenant_id', $this->tenant->id)
+            ->assertJsonMissingPath('data.created_at')
+            ->assertJsonMissingPath('data.updated_at')
             ->json('data.id');
 
         $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->getJson("/api/roles/{$roleId}")
-            ->assertStatus(200);
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'slug', 'abilities', 'tenant_id', 'level'],
+            ])
+            ->assertJsonMissingPath('data.created_at')
+            ->assertJsonMissingPath('data.updated_at');
 
         $update = ['name' => 'Updated', 'slug' => 'updated', 'level' => 2];
         $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->putJson("/api/roles/{$roleId}", $update)
             ->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'slug', 'abilities', 'tenant_id', 'level'],
+            ])
             ->assertJsonPath('data.name', 'Updated')
             ->assertJsonPath('data.slug', 'updated')
-            ->assertJsonPath('data.level', 2);
+            ->assertJsonPath('data.level', 2)
+            ->assertJsonMissingPath('data.created_at')
+            ->assertJsonMissingPath('data.updated_at');
 
         $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->deleteJson("/api/roles/{$roleId}")


### PR DESCRIPTION
## Summary
- Return explicit fields from `RoleResource`
- Verify role responses include only expected fields in tests

## Testing
- `composer test` *(fails: AppointmentRoutesTest > crud routes work, AppointmentTypeRoutesTest > crud routes work, AppointmentsAssigneeTest > assignee persisted when creating appointment, StatusRoutesTest > crud routes work, SuperAdminRoleVisibilityTest > super admin can view roles from all tenants without header)*

------
https://chatgpt.com/codex/tasks/task_e_68b05660f1588323afcc36c451a66b95