### PR TITLE
Add abilities lookup and selection for roles

### DIFF
--- a/backend/app/Http/Controllers/Api/LookupController.php
+++ b/backend/app/Http/Controllers/Api/LookupController.php
@@ -55,4 +55,9 @@ class LookupController extends Controller
 
         return $results->sortBy('label')->values();
     }
+
+    public function abilities()
+    {
+        return collect(config('abilities'))->values();
+    }
 }

--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'appointments.assign',
+    'appointments.manage',
+    'appointments.view',
+    'appointments.update',
+    'roles.manage',
+    'teams.manage',
+    'statuses.manage',
+    'types.manage',
+];
+

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -119,5 +119,6 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     });
 
     Route::get('lookups/assignees', [LookupController::class, 'assignees']);
+    Route::get('lookups/abilities', [LookupController::class, 'abilities']);
     Route::get('calendar/events', [CalendarController::class, 'events']);
 });

--- a/backend/tests/Feature/LookupRoutesTest.php
+++ b/backend/tests/Feature/LookupRoutesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class LookupRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $tenant = Tenant::create(['name' => 'Test Tenant']);
+        $role = Role::create(['name' => 'ClientAdmin', 'slug' => 'client_admin', 'tenant_id' => $tenant->id]);
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+        $this->tenant = $tenant;
+    }
+
+    public function test_abilities_lookup_returns_list(): void
+    {
+        $abilities = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->getJson('/api/lookups/abilities')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains('roles.manage', $abilities);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose abilities list via new lookup endpoint
- allow selecting abilities in role form

## Testing
- `composer test` *(fails: 5 failed, 14 warnings)*
- `npm test` *(passes unit tests, skips e2e)*

------
https://chatgpt.com/codex/tasks/task_e_68b058bd4b88832390d54cc2b36d00a0