### PR TITLE
feat: assign default role to new tenants

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -38,7 +38,7 @@ class TenantController extends Controller
             'address' => 'nullable|string',
         ]);
         $tenant = Tenant::create($data);
-        return response()->json($tenant, 201);
+        return response()->json($tenant->load('roles'), 201);
     }
 
     public function show(Request $request, Tenant $tenant)

--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -21,9 +21,26 @@ class Tenant extends Model
         'features' => 'array',
     ];
 
+    protected static function booted(): void
+    {
+        static::created(function (self $tenant): void {
+            $tenant->roles()->create([
+                'name' => 'Tenant',
+                'slug' => 'tenant',
+                'level' => 1,
+                'abilities' => [],
+            ]);
+        });
+    }
+
     public function appointments(): HasMany
     {
         return $this->hasMany(Appointment::class);
+    }
+
+    public function roles(): HasMany
+    {
+        return $this->hasMany(Role::class);
     }
 
     public static function current(): ?Tenant

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -39,6 +39,17 @@ class TenantBootstrapSeeder extends Seeder
         $tenantId = DB::table('tenants')->where('id', 1)->value('id');
 
         // Tenant roles
+        DB::table('roles')->updateOrInsert(
+            ['tenant_id' => $tenantId, 'slug' => 'tenant'],
+            [
+                'name' => 'Tenant',
+                'level' => 1,
+                'abilities' => json_encode([]),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
         $managerAbilities = ['appointments.manage', 'teams.manage', 'statuses.manage'];
         $agentAbilities = ['appointments.view', 'appointments.update'];
 


### PR DESCRIPTION
## Summary
- create a level-1 `Tenant` role whenever a new tenant is created
- return tenant roles from the tenant creation endpoint
- seed default tenant role in bootstrap seeder

## Testing
- `composer test` *(fails: AppointmentRoutesTest, AppointmentTypeRoutesTest, AppointmentsAssigneeTest, StatusRoutesTest, SuperAdminRoleVisibilityTest)*
- `npm test` *(skipped: 16 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b05cf289cc8323a8927222fc6339df