### PR TITLE
Seed tenants and attach super admin to tenant

### DIFF
--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -9,9 +9,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
-            TenantSeeder::class,
+            TenantBootstrapSeeder::class,
             SuperAdminSeeder::class,
-            RoleSeeder::class,
             RoleUserSeeder::class,
             TenantSettingsSeeder::class,
         ]);

--- a/backend/database/seeders/RoleUserSeeder.php
+++ b/backend/database/seeders/RoleUserSeeder.php
@@ -9,12 +9,18 @@ class RoleUserSeeder extends Seeder
 {
     public function run(): void
     {
-        DB::table('role_user')->insert([
-            'role_id' => 1,
-            'user_id' => 1,
-            'tenant_id' => 1,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        $roleId = DB::table('roles')
+            ->whereNull('tenant_id')
+            ->where('slug', 'super_admin')
+            ->value('id');
+
+        $userId = DB::table('users')
+            ->where('email', 'anastasiou.ks@gmail.com')
+            ->value('id');
+
+        DB::table('role_user')->updateOrInsert(
+            ['role_id' => $roleId, 'user_id' => $userId, 'tenant_id' => 1],
+            ['created_at' => now(), 'updated_at' => now()]
+        );
     }
 }

--- a/backend/database/seeders/SuperAdminSeeder.php
+++ b/backend/database/seeders/SuperAdminSeeder.php
@@ -10,16 +10,17 @@ class SuperAdminSeeder extends Seeder
 {
     public function run(): void
     {
-        DB::table('users')->insert([
-            'id' => 1,
-            'name' => 'Super Admin',
-            'email' => 'anastasiou.ks@gmail.com',
-            'password' => Hash::make('Swordfish01!@#'),
-            'tenant_id' => 1,
-            'phone' => '123-456-7890',
-            'address' => '456 Admin St',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        DB::table('users')->updateOrInsert(
+            ['email' => 'anastasiou.ks@gmail.com'],
+            [
+                'name' => 'Super Admin',
+                'password' => Hash::make('Swordfish01!@#'),
+                'tenant_id' => 1,
+                'phone' => '123-456-7890',
+                'address' => '456 Admin St',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- seed tenant-specific roles and data during migrations
- ensure super admin belongs to tenant 1
- dynamically link super admin to global role

## Testing
- `php artisan migrate:fresh --seed --force`
- `./vendor/bin/phpunit` *(fails: Failed asserting that 405 is identical to 200; response count mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b060c3d088832390c9fe40e008f5cc