### PR TITLE
Seed default abilities for core roles

### DIFF
--- a/backend/database/seeders/RoleSeeder.php
+++ b/backend/database/seeders/RoleSeeder.php
@@ -16,7 +16,8 @@ class RoleSeeder extends Seeder
             'slug' => 'super_admin',
             // SuperAdmin is the root role; use level 0 so other roles can build from it
             'level' => 0,
-            'abilities' => json_encode([]),
+            // Grant full system access via wildcard ability
+            'abilities' => json_encode(['*']),
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -39,12 +39,14 @@ class TenantBootstrapSeeder extends Seeder
         $tenantId = DB::table('tenants')->where('id', 1)->value('id');
 
         // Tenant roles
+        $tenantAbilities = config('abilities');
         DB::table('roles')->updateOrInsert(
             ['tenant_id' => $tenantId, 'slug' => 'tenant'],
             [
                 'name' => 'Tenant',
                 'level' => 1,
-                'abilities' => json_encode([]),
+                // Grant core abilities for tenant-level administration
+                'abilities' => json_encode($tenantAbilities),
                 'created_at' => now(),
                 'updated_at' => now(),
             ]


### PR DESCRIPTION
## Summary
- Give super admin role wildcard ability
- Provide tenants with full ability set for internal management

## Testing
- `composer test` *(fails: missing .env, unimplemented tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b06382c6708323a325c07129ac7b04