### PR TITLE
Seed super admin tenant and roles

### DIFF
--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -9,7 +9,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
-            TenantBootstrapSeeder::class,
+            TenantSeeder::class,
+            RoleSeeder::class,
             SuperAdminSeeder::class,
             RoleUserSeeder::class,
             TenantSettingsSeeder::class,

--- a/backend/database/seeders/RoleSeeder.php
+++ b/backend/database/seeders/RoleSeeder.php
@@ -9,17 +9,19 @@ class RoleSeeder extends Seeder
 {
     public function run(): void
     {
-        DB::table('roles')->insert([
-            'id' => 1,
-            'tenant_id' => null,
-            'name' => 'SuperAdmin',
-            'slug' => 'super_admin',
-            // SuperAdmin is the root role; use level 0 so other roles can build from it
-            'level' => 0,
-            // Grant full system access via wildcard ability
-            'abilities' => json_encode(['*']),
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        DB::table('roles')->updateOrInsert(
+            ['id' => 1],
+            [
+                'tenant_id' => 1,
+                'name' => 'SuperAdmin',
+                'slug' => 'super_admin',
+                // SuperAdmin is the root role; use level 0 so other roles can build from it
+                'level' => 0,
+                // Grant full system access via wildcard ability
+                'abilities' => json_encode(['*']),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 }

--- a/backend/database/seeders/RoleUserSeeder.php
+++ b/backend/database/seeders/RoleUserSeeder.php
@@ -10,7 +10,7 @@ class RoleUserSeeder extends Seeder
     public function run(): void
     {
         $roleId = DB::table('roles')
-            ->whereNull('tenant_id')
+            ->where('tenant_id', 1)
             ->where('slug', 'super_admin')
             ->value('id');
 

--- a/backend/database/seeders/TenantSeeder.php
+++ b/backend/database/seeders/TenantSeeder.php
@@ -9,15 +9,17 @@ class TenantSeeder extends Seeder
 {
     public function run(): void
     {
-        DB::table('tenants')->insert([
-            'id' => 1,
-            'name' => 'Default Tenant',
-            'quota_storage_mb' => 0,
-            'features' => json_encode([]),
-            'phone' => '123-456-7890',
-            'address' => '123 Main St',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        DB::table('tenants')->updateOrInsert(
+            ['id' => 1],
+            [
+                'name' => 'Super Admin Tenant',
+                'quota_storage_mb' => 0,
+                'features' => json_encode([]),
+                'phone' => '123-456-7890',
+                'address' => '123 Main St',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- introduce a seeded Super Admin tenant
- scope seeded roles to Super Admin tenant
- update default seeder pipeline to seed tenant/role/user linkage

## Testing
- `composer test` *(fails: Tests\Feature\SuperAdminRoleVisibilityTest > super admin can view roles from all tenants without header)*

------
https://chatgpt.com/codex/tasks/task_e_68b068050d248323b65e50536bfdcd91