### PR TITLE
Fix role list to include all roles

### DIFF
--- a/backend/app/Http/Controllers/Api/RoleController.php
+++ b/backend/app/Http/Controllers/Api/RoleController.php
@@ -28,9 +28,11 @@ class RoleController extends Controller
         $scope = $request->query('scope');
         $tenantId = $request->query('tenant_id');
 
-        if (! $request->user()->hasRole('SuperAdmin')) {
+        if (! $request->user()->isSuperAdmin()) {
             $tenantId = $request->user()->tenant_id;
-            $base = Role::where('tenant_id', $tenantId);
+            $base = Role::where(function ($query) use ($tenantId) {
+                $query->where('tenant_id', $tenantId)->orWhereNull('tenant_id');
+            });
             $result = $this->listQuery($base, $request, ['name'], ['name']);
             return RoleResource::collection($result['data'])->additional([
                 'meta' => $result['meta'],

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -25,7 +25,7 @@ class Role extends Model
     {
         static::creating(function (self $role): void {
             if (empty($role->slug)) {
-                $role->slug = Str::slug($role->name, '_');
+                $role->slug = Str::snake($role->name);
             }
         });
     }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -56,6 +56,10 @@ class User extends Authenticatable
     {
         $slug = Str::snake($role);
 
-        return $this->roles->contains(fn ($r) => $r->name === $role || $r->slug === $slug);
+        return $this->roles()
+            ->where(function ($q) use ($role, $slug) {
+                $q->where('name', $role)->orWhere('slug', $slug);
+            })
+            ->exists();
     }
 }


### PR DESCRIPTION
## Summary
- ensure role slugs use snake case for consistent lookups
- query user roles to correctly detect super admins
- show tenant and global roles for non-super admins

## Testing
- `composer test` *(fails: Failed asserting that actual size 2 matches expected size 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b06b78b31883239f546fc5054ad9c8