### PR TITLE
test: cover ability constraints

### DIFF
--- a/backend/tests/Feature/SuperAdminBypassTest.php
+++ b/backend/tests/Feature/SuperAdminBypassTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SuperAdminBypassTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_assign_any_ability(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['appointments']]);
+        $superRole = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'tenant_id' => null,
+            'level' => 0,
+            'abilities' => ['roles.manage'],
+        ]);
+
+        $user = User::create([
+            'name' => 'Root',
+            'email' => 'root@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($superRole->id, ['tenant_id' => $tenant->id]);
+
+        Sanctum::actingAs($user);
+
+        $payload = [
+            'name' => 'Types Manager',
+            'slug' => 'types_manager',
+            'abilities' => ['types.manage'],
+            'tenant_id' => $tenant->id,
+            'level' => 1,
+        ];
+
+        $this->postJson('/api/roles', $payload)
+            ->assertStatus(201)
+            ->assertJsonFragment(['abilities' => ['types.manage']]);
+    }
+}
+

--- a/backend/tests/Feature/TenantRoleAbilityRestrictionTest.php
+++ b/backend/tests/Feature/TenantRoleAbilityRestrictionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TenantRoleAbilityRestrictionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tenant_features_limit_role_creation(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['appointments']]);
+
+        $adminRole = Role::create([
+            'name' => 'Manager',
+            'slug' => 'manager',
+            'tenant_id' => $tenant->id,
+            'level' => 1,
+            'abilities' => ['roles.manage'],
+        ]);
+
+        $user = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($adminRole->id, ['tenant_id' => $tenant->id]);
+
+        Sanctum::actingAs($user);
+
+        $payload = [
+            'name' => 'Type Manager',
+            'slug' => 'type_manager',
+            'abilities' => ['types.manage'],
+            'level' => 1,
+        ];
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/roles', $payload)
+            ->assertStatus(422);
+
+        $tenant->update(['features' => ['appointments', 'types']]);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/roles', $payload)
+            ->assertStatus(201)
+            ->assertJsonFragment(['abilities' => ['types.manage']]);
+    }
+}
+

--- a/frontend/tests/e2e/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation.spec.ts
@@ -12,3 +12,10 @@ test.skip('sidebar keyboard navigation', async ({ page }) => {
   await page.keyboard.press('Escape');
   await expect(page.getByRole('menuitem', { name: 'Appointments' })).not.toBeVisible();
 });
+
+test.skip('non-admin sidebar hides unauthorized items', async ({ page }) => {
+  await page.goto('/');
+  // In a real scenario, user would be authenticated with limited abilities.
+  await expect(page.getByRole('link', { name: 'Appointment Types' })).not.toBeVisible();
+});
+

--- a/frontend/tests/e2e/roles.spec.ts
+++ b/frontend/tests/e2e/roles.spec.ts
@@ -11,3 +11,11 @@ test.skip('creates a role and assigns it to a user', async ({ page }) => {
   await page.getByRole('option', { name: /John Doe/ }).click();
   await page.getByRole('button', { name: 'Assign' }).click();
 });
+
+test.skip('role form shows only allowed abilities', async ({ page }) => {
+  await page.goto('/roles');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await page.getByRole('combobox', { name: 'Abilities' }).click();
+  await expect(page.getByRole('option', { name: 'types.manage' })).not.toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- add tenant ability restriction test
- add super admin bypass test
- document sidebar and role form ability filtering in e2e specs

## Testing
- `php artisan test`
- `pnpm test:e2e` *(fails: Command "test:e2e" not found)*
- `pnpm playwright test tests/e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b07eec683c83238c8c533b999f97d5