### PR TITLE
docs: explain role levels and feature mapping

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,49 @@ Run the tenant bootstrap seeder to populate a sample tenant with roles, a team, 
 php artisan migrate:fresh --seed --seeder=TenantBootstrapSeeder
 ```
 
+## Role Levels
+
+Roles carry a numeric `level` used to scope what other roles they can manage. Lower numbers are more privileged: the `SuperAdmin` role is level 0, tenant administrators default to level 1, and additional roles can use higher numbers as needed. Users may not manage roles above their own lowest level.
+
+## Features & Abilities
+
+Features are enumerated in `config/features.php` and mapped to ability strings via `config/feature_map.php`. Each feature lists the abilities that gate access to parts of the system. When introducing a new feature:
+
+1. Define any new ability strings in `config/abilities.php`.
+2. Map the feature to its abilities in `config/feature_map.php`.
+3. Optionally register the feature slug in `config/features.php` if it should be toggled.
+
+Example for a `reports` feature:
+
+```php
+// config/feature_map.php
+return [
+    // ...
+    'reports' => [
+        'label' => 'Reports',
+        'abilities' => [
+            'reports.view',
+            'reports.manage',
+        ],
+    ],
+];
+```
+
+```php
+// config/abilities.php
+return [
+    // ...
+    'reports.view',
+    'reports.manage',
+];
+```
+
+Remember to safeguard new resources. When adding a manage-able resource:
+
+- Guard routes with the ability middleware, e.g. `Ability::class . ':reports.manage'`.
+- Add any necessary policy checks.
+- Expose a menu item (or similar frontend entry point) with `requiredAbilities` matching the new ability.
+
 ## Development
 
 Use the bundled composer script to run the backend with detailed request logs:


### PR DESCRIPTION
## Summary
- document role levels and how they restrict role management
- outline feature map usage and steps to add new features and abilities, with a reports example
- note required middleware, policy, and menu updates for new manageable resources

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b07fce8c9c83238112f9bc9c4479e4