### PR TITLE
Scope abilities lookup by tenant features

### DIFF
--- a/backend/app/Http/Controllers/Api/LookupController.php
+++ b/backend/app/Http/Controllers/Api/LookupController.php
@@ -59,8 +59,9 @@ class LookupController extends Controller
 
     public function abilities(Request $request)
     {
-        if ($request->boolean('forTenant') && ! $request->user()->hasRole('SuperAdmin')) {
-            $tenant = $request->user()->tenant ?? Tenant::find($request->user()->tenant_id);
+        if ($request->boolean('forTenant')) {
+            $tenantId = $this->getTenantId($request);
+            $tenant = Tenant::find($tenantId);
 
             return $tenant?->allowedAbilities() ?? [];
         }


### PR DESCRIPTION
## Summary
- ensure ability lookups always respect tenant feature sets
- update tests to cover super admin tenant-scoped abilities

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b0818f69d08323a5d0df23d97bd017