### PR TITLE
Fix tenant header for role ability lookup

### DIFF
--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -61,6 +61,7 @@ import { useTenantStore } from '@/stores/tenant';
 import { useRolesStore } from '@/stores/roles';
 import VueSelect from '@/components/ui/Select/VueSelect.vue';
 import vSelect from 'vue-select';
+import { TENANT_HEADER } from '@/config/app';
 import { useForm } from 'vee-validate';
 
 const route = useRoute();
@@ -113,7 +114,10 @@ onMounted(async () => {
 async function loadAbilityOptions() {
   try {
     const params = tenantId.value ? { forTenant: 1 } : undefined;
-    const { data } = await api.get('/lookups/abilities', { params });
+    const headers = tenantId.value
+      ? { [TENANT_HEADER]: tenantId.value }
+      : undefined;
+    const { data } = await api.get('/lookups/abilities', { params, headers });
     abilityOptions.value = (data || []).map((a: string) => ({
       label: a,
       value: a,


### PR DESCRIPTION
## Summary
- include X-Tenant-ID header when super admins fetch ability options for tenant roles

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0836a7a908323b8c3b6bfd61e99f7