### PR TITLE
Add frontend redirect for password reset links

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Api\LookupController;
 use App\Http\Controllers\Api\CalendarController;
 use App\Http\Middleware\EnsureTenantScope;
 use App\Http\Middleware\Ability;
+use Illuminate\Http\Request;
 
 Route::middleware(['api','tenant'])->get('/health', function () {
     return response()->json(['status' => 'ok', 'tenant' => config('tenant.branding')]);
@@ -34,6 +35,15 @@ Route::prefix('auth')->group(function () {
     Route::post('refresh', [AuthController::class, 'refresh']);
     Route::post('password/email', [AuthController::class, 'sendResetLinkEmail']);
     Route::post('password/reset', [AuthController::class, 'reset']);
+    Route::get('password/reset/{token}', function (Request $request, string $token) {
+        $frontendUrl = explode(',', env('FRONTEND_URL', 'http://localhost:5173'))[0];
+        $frontendUrl = rtrim($frontendUrl, '/');
+        $query = http_build_query([
+            'token' => $token,
+            'email' => $request->email,
+        ]);
+        return redirect("{$frontendUrl}/reset-password?{$query}");
+    })->name('password.reset');
 });
 
 Route::middleware('auth:sanctum')->get('/me', [AuthController::class, 'me']);

--- a/backend/tests/Feature/PasswordResetRouteTest.php
+++ b/backend/tests/Feature/PasswordResetRouteTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PasswordResetRouteTest extends TestCase
+{
+    public function test_password_reset_route_redirects_to_frontend(): void
+    {
+        $response = $this->get('/api/auth/password/reset/test-token?email=user@example.com');
+
+        $response->assertRedirect('http://localhost:5173/reset-password?token=test-token&email=user%40example.com');
+    }
+}


### PR DESCRIPTION
## Summary
- define `password.reset` route to redirect to the frontend
- cover new route with a feature test

## Testing
- `composer test` *(fails: file_get_contents(/workspace/asbuild/backend/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b084dad8c48323881e8704bac70dcc