### PR TITLE
Add granular feature abilities and employees feature mapping

### DIFF
--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -1,13 +1,47 @@
 <?php
 
 return [
+    // Appointments
+    'appointments.view',
+    'appointments.create',
+    'appointments.update',
+    'appointments.delete',
     'appointments.assign',
     'appointments.manage',
-    'appointments.view',
-    'appointments.update',
+
+    // Roles & Permissions
+    'roles.view',
+    'roles.create',
+    'roles.update',
+    'roles.delete',
     'roles.manage',
-    'teams.manage',
-    'statuses.manage',
+
+    // Appointment Types
+    'types.view',
+    'types.create',
+    'types.update',
+    'types.delete',
     'types.manage',
+
+    // Teams
+    'teams.view',
+    'teams.create',
+    'teams.update',
+    'teams.delete',
+    'teams.manage',
+
+    // Statuses
+    'statuses.view',
+    'statuses.create',
+    'statuses.update',
+    'statuses.delete',
+    'statuses.manage',
+
+    // Employees
+    'employees.view',
+    'employees.create',
+    'employees.update',
+    'employees.delete',
+    'employees.manage',
 ];
 

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -5,26 +5,59 @@ return [
         'label' => 'Appointments',
         'abilities' => [
             'appointments.view',
+            'appointments.create',
             'appointments.update',
-            'appointments.manage',
+            'appointments.delete',
             'appointments.assign',
+            'appointments.manage',
         ],
     ],
     'roles' => [
         'label' => 'Roles & Permissions',
-        'abilities' => ['roles.manage'],
+        'abilities' => [
+            'roles.view',
+            'roles.manage',
+        ],
     ],
     'types' => [
         'label' => 'Appointment Types',
-        'abilities' => ['types.manage'],
+        'abilities' => [
+            'types.view',
+            'types.create',
+            'types.update',
+            'types.delete',
+            'types.manage',
+        ],
     ],
     'teams' => [
         'label' => 'Teams',
-        'abilities' => ['teams.manage'],
+        'abilities' => [
+            'teams.view',
+            'teams.create',
+            'teams.update',
+            'teams.delete',
+            'teams.manage',
+        ],
     ],
     'statuses' => [
         'label' => 'Statuses',
-        'abilities' => ['statuses.manage'],
+        'abilities' => [
+            'statuses.view',
+            'statuses.create',
+            'statuses.update',
+            'statuses.delete',
+            'statuses.manage',
+        ],
+    ],
+    'employees' => [
+        'label' => 'Employees',
+        'abilities' => [
+            'employees.view',
+            'employees.create',
+            'employees.update',
+            'employees.delete',
+            'employees.manage',
+        ],
     ],
     // Additional features can be listed here as needed, e.g. 'reports', 'billing', 'employees', …
 ];

--- a/backend/tests/Feature/LookupRoutesTest.php
+++ b/backend/tests/Feature/LookupRoutesTest.php
@@ -51,14 +51,27 @@ class LookupRoutesTest extends TestCase
 
     public function test_abilities_lookup_scopes_for_tenant_features(): void
     {
-        $this->tenant->update(['features' => ['roles', 'teams']]);
+        $this->tenant->update(['features' => ['roles', 'teams', 'employees']]);
 
         $abilities = $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->getJson('/api/lookups/abilities?forTenant=1')
             ->assertStatus(200)
             ->json();
 
-        $this->assertEqualsCanonicalizing(['roles.manage', 'teams.manage'], $abilities);
+        $this->assertEqualsCanonicalizing([
+            'roles.view',
+            'roles.manage',
+            'teams.view',
+            'teams.create',
+            'teams.update',
+            'teams.delete',
+            'teams.manage',
+            'employees.view',
+            'employees.create',
+            'employees.update',
+            'employees.delete',
+            'employees.manage',
+        ], $abilities);
     }
 
     public function test_super_admin_abilities_lookup_scopes_for_tenant_features(): void
@@ -102,6 +115,7 @@ class LookupRoutesTest extends TestCase
         $this->assertContains(['slug' => 'types', 'label' => 'Appointment Types'], $features);
         $this->assertContains(['slug' => 'teams', 'label' => 'Teams'], $features);
         $this->assertContains(['slug' => 'statuses', 'label' => 'Statuses'], $features);
+        $this->assertContains(['slug' => 'employees', 'label' => 'Employees'], $features);
     }
 }
 


### PR DESCRIPTION
## Summary
- define CRUD ability codes for appointments, roles, types, teams, statuses, and employees
- map each feature to its granular abilities and add new employees feature
- test lookups for new abilities and employees feature

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b093feb1548323bbb88ba1a735f330