### PR TITLE
feat: auto seed per-feature roles for tenants

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -89,7 +89,7 @@ class TenantController extends Controller
             'address' => 'sometimes|nullable|string',
         ]);
         $tenant->update($data);
-        return $tenant;
+        return $tenant->load('roles');
     }
 
     public function destroy(Request $request, Tenant $tenant)

--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -35,14 +35,11 @@ class Tenant extends Model
 
     public function allowedAbilities(): array
     {
-        $features = is_array($this->features) ? $this->features : json_decode($this->features ?? '[]', true);
-        $map = config('feature_map');
+        $map = config('feature_map', []);
         $abilities = [];
 
-        foreach ($features as $feature) {
-            if (isset($map[$feature]['abilities'])) {
-                $abilities = array_merge($abilities, $map[$feature]['abilities']);
-            }
+        foreach ($this->features ?? [] as $feature) {
+            $abilities = array_merge($abilities, $map[$feature]['abilities'] ?? []);
         }
 
         return array_values(array_unique($abilities));

--- a/backend/app/Observers/TenantObserver.php
+++ b/backend/app/Observers/TenantObserver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Tenant;
+use Database\Seeders\DefaultFeatureRolesSeeder;
+
+class TenantObserver
+{
+    public function created(Tenant $tenant): void
+    {
+        DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant);
+    }
+
+    public function updated(Tenant $tenant): void
+    {
+        if ($tenant->wasChanged('features')) {
+            DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant);
+        }
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\Tenant;
+use App\Observers\TenantObserver;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Tenant::observe(TenantObserver::class);
     }
 }

--- a/backend/database/seeders/DefaultFeatureRolesSeeder.php
+++ b/backend/database/seeders/DefaultFeatureRolesSeeder.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tenant;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class DefaultFeatureRolesSeeder extends Seeder
+{
+    public static function syncDefaultRolesForFeatures(Tenant $tenant): void
+    {
+        $features = $tenant->features ?? [];
+        $map = config('feature_map', []);
+
+        $roles = [];
+
+        foreach ($features as $feature) {
+            switch ($feature) {
+                case 'appointments':
+                case 'types':
+                case 'teams':
+                case 'statuses':
+                case 'employees':
+                    $uc = ucfirst($feature);
+                    // viewer role
+                    $roles[] = [
+                        'slug' => "$feature\_viewer",
+                        'name' => "$uc Viewer",
+                        'abilities' => ["$feature.view"],
+                        'level' => 3,
+                    ];
+
+                    // editor role
+                    $abilities = ["$feature.view"];
+                    if (in_array("$feature.create", $map[$feature]['abilities'] ?? [])) {
+                        $abilities[] = "$feature.create";
+                    }
+                    if (in_array("$feature.update", $map[$feature]['abilities'] ?? [])) {
+                        $abilities[] = "$feature.update";
+                    }
+                    $roles[] = [
+                        'slug' => "$feature\_editor",
+                        'name' => "$uc Editor",
+                        'abilities' => $abilities,
+                        'level' => 3,
+                    ];
+
+                    // manager role
+                    $abilities = [];
+                    if (in_array("$feature.manage", $map[$feature]['abilities'] ?? [])) {
+                        $abilities[] = "$feature.manage";
+                    }
+                    if (in_array("$feature.delete", $map[$feature]['abilities'] ?? [])) {
+                        $abilities[] = "$feature.delete";
+                    }
+                    if (in_array("$feature.assign", $map[$feature]['abilities'] ?? [])) {
+                        $abilities[] = "$feature.assign";
+                    }
+                    $roles[] = [
+                        'slug' => "$feature\_manager",
+                        'name' => "$uc Manager",
+                        'abilities' => $abilities,
+                        'level' => 2,
+                    ];
+                    break;
+                case 'roles':
+                    $roles[] = [
+                        'slug' => 'roles_manager',
+                        'name' => 'Roles Manager',
+                        'abilities' => ['roles.view', 'roles.manage'],
+                        'level' => 2,
+                    ];
+                    break;
+            }
+        }
+
+        foreach ($roles as $role) {
+            $existing = DB::table('roles')
+                ->where('tenant_id', $tenant->id)
+                ->where('slug', $role['slug'])
+                ->first();
+
+            $abilities = $role['abilities'];
+            $level = $role['level'];
+
+            if ($existing) {
+                $existingAbilities = json_decode($existing->abilities, true) ?? [];
+                $abilities = array_values(array_unique(array_merge($existingAbilities, $abilities)));
+                $level = min($existing->level, $level);
+            }
+
+            DB::table('roles')->updateOrInsert(
+                ['tenant_id' => $tenant->id, 'slug' => $role['slug']],
+                [
+                    'name' => $role['name'],
+                    'abilities' => json_encode($abilities),
+                    'level' => $level,
+                    'created_at' => $existing->created_at ?? now(),
+                    'updated_at' => now(),
+                ]
+            );
+        }
+
+        // Update tenant role abilities
+        $tenantRole = DB::table('roles')
+            ->where('tenant_id', $tenant->id)
+            ->where('slug', 'tenant')
+            ->first();
+
+        if ($tenantRole) {
+            $abilities = array_values(array_unique(array_merge(
+                json_decode($tenantRole->abilities, true) ?? [],
+                $tenant->allowedAbilities()
+            )));
+
+            DB::table('roles')
+                ->where('id', $tenantRole->id)
+                ->update([
+                    'abilities' => json_encode($abilities),
+                    'updated_at' => now(),
+                ]);
+        }
+    }
+}

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -52,6 +52,8 @@ class TenantBootstrapSeeder extends Seeder
             ]
         );
 
+        DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures(\App\Models\Tenant::find($tenantId));
+
         $managerAbilities = array_intersect(
             ['appointments.manage', 'teams.manage', 'statuses.manage', 'types.manage'],
             $tenantAbilities


### PR DESCRIPTION
## Summary
- collect allowed abilities from tenant features
- seed default roles for each feature and sync on tenant updates
- return roles after tenant updates

## Testing
- `composer test` *(fails: Tests\Feature\StatusRoutesTest > crud routes work: Expected response status code [200] but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b095a7dae08323b81466e5d8951909