### PR TITLE
feat: gate UI actions by ability

### DIFF
--- a/frontend/src/views/appointments/AppointmentDetails.vue
+++ b/frontend/src/views/appointments/AppointmentDetails.vue
@@ -20,7 +20,10 @@
       </ul>
       <div class="mt-2">
         <StatusChanger
-          v-if="currentStatusId"
+          v-if="
+            currentStatusId &&
+            (can('appointments.update') || can('appointments.manage'))
+          "
           :appointment-id="appointment.id"
           :status-id="currentStatusId"
           @updated="onStatusChanged"
@@ -60,7 +63,11 @@
         <div v-else-if="active === 'comments'">
           <Card>
             <CommentsThread :comments="appointment.comments" class="mb-4" />
-            <CommentEditor :appointment-id="appointment.id" @added="onCommentAdded" />
+            <CommentEditor
+              v-if="can('appointments.update') || can('appointments.manage')"
+              :appointment-id="appointment.id"
+              @added="onCommentAdded"
+            />
           </Card>
         </div>
       </template>
@@ -80,6 +87,7 @@ import CommentEditor from '@/components/comments/CommentEditor.vue';
 import StatusChanger from './StatusChanger.vue';
 import { useStatusesStore } from '@/stores/statuses';
 import { formatDisplay, parseISO, toISO } from '@/utils/datetime';
+import { can } from '@/stores/auth';
 
 const route = useRoute();
 

--- a/frontend/src/views/appointments/AppointmentForm.vue
+++ b/frontend/src/views/appointments/AppointmentForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if="canAccess">
       <form @submit.prevent="submitForm" class="max-w-lg space-y-4">
       <VueSelect label="Type" :error="appointmentTypeError">
         <vSelect
@@ -91,6 +91,11 @@ const { value: appointmentTypeId, errorMessage: appointmentTypeError } = useFiel
 >('appointment_type_id');
 
 const isEdit = computed(() => route.name === 'appointments.edit');
+const canAccess = computed(() =>
+  isEdit.value
+    ? can('appointments.update') || can('appointments.manage')
+    : can('appointments.create') || can('appointments.manage'),
+);
 
 onMounted(async () => {
   const [typesRes, statusesRes] = await Promise.all([

--- a/frontend/src/views/appointments/AppointmentsList.vue
+++ b/frontend/src/views/appointments/AppointmentsList.vue
@@ -2,6 +2,7 @@
     <div>
       <div class="flex items-center justify-end mb-4">
         <RouterLink
+          v-if="can('appointments.create') || can('appointments.manage')"
           class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
           :to="{ name: 'appointments.create' }"
         >
@@ -27,21 +28,33 @@
           <button class="text-blue-600" title="View" @click="view(row.id)">
             <Icon icon="heroicons-outline:eye" class="w-5 h-5" />
           </button>
-          <button class="text-blue-600" title="Edit" @click="edit(row.id)">
+          <button
+            v-if="can('appointments.update') || can('appointments.manage')"
+            class="text-blue-600"
+            title="Edit"
+            @click="edit(row.id)"
+          >
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
-          <button class="text-red-600" title="Delete" @click="remove(row.id)">
+          <button
+            v-if="can('appointments.delete') || can('appointments.manage')"
+            class="text-red-600"
+            title="Delete"
+            @click="remove(row.id)"
+          >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
-          <button
-            v-for="s in getChangeActions(row)"
-            :key="s"
-            class="text-blue-600"
-            :title="`Mark ${s.replace(/_/g, ' ')}`"
-            @click="updateStatus(row, s)"
-          >
-            <Icon :icon="statusIcons[s] || 'heroicons-outline:arrow-right'" class="w-5 h-5" />
-          </button>
+          <template v-if="can('appointments.update') || can('appointments.manage')">
+            <button
+              v-for="s in getChangeActions(row)"
+              :key="s"
+              class="text-blue-600"
+              :title="`Mark ${s.replace(/_/g, ' ')}`"
+              @click="updateStatus(row, s)"
+            >
+              <Icon :icon="statusIcons[s] || 'heroicons-outline:arrow-right'" class="w-5 h-5" />
+            </button>
+          </template>
         </div>
       </template>
     </DashcodeServerTable>
@@ -57,6 +70,7 @@ import { useNotify } from '@/plugins/notify';
 import Icon from '@/components/ui/Icon';
 import Swal from 'sweetalert2';
 import { parseISO, formatDisplay } from '@/utils/datetime';
+import { can } from '@/stores/auth';
 
 const router = useRouter();
 const notify = useNotify();

--- a/frontend/src/views/employees/EmployeeForm.vue
+++ b/frontend/src/views/employees/EmployeeForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="canAccess">
     <form @submit.prevent="submit" class="grid gap-4 max-w-lg">
       <Textinput label="Name" v-model="form.name" />
       <Textinput label="Email" type="email" v-model="form.email" />
@@ -25,11 +25,17 @@ import Textinput from '@/components/ui/Textinput/index.vue';
 import VueSelect from '@/components/ui/Select/VueSelect.vue';
 import Button from '@/components/ui/Button/index.vue';
 import vSelect from 'vue-select';
+import { can } from '@/stores/auth';
 
 const route = useRoute();
 const router = useRouter();
 
 const isEdit = computed(() => route.name === 'employees.edit');
+const canAccess = computed(() =>
+  isEdit.value
+    ? can('employees.update') || can('employees.manage')
+    : can('employees.create') || can('employees.manage'),
+);
 
 const roleOptions = ref<string[]>([]);
 const form = ref({

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -2,6 +2,7 @@
     <div>
       <div class="mb-4">
       <Button
+        v-if="can('employees.create') || can('employees.manage')"
         btnClass="btn-primary"
         text="Invite Employee"
         link="/employees/create"
@@ -12,14 +13,19 @@
       :columns="columns"
       :fetcher="fetchEmployees"
     >
-      <template #actions="{ row }">
+      <template
+        v-if="can('employees.update') || can('employees.delete') || can('employees.manage')"
+        #actions="{ row }"
+      >
         <div class="flex gap-2">
           <Button
+            v-if="can('employees.update') || can('employees.manage')"
             :link="`/employees/${row.id}/edit`"
             btnClass="btn-outline-primary btn-sm"
             text="Edit"
           />
           <Button
+            v-if="can('employees.delete') || can('employees.manage')"
             btnClass="btn-outline-danger btn-sm"
             text="Delete"
             @click="remove(row.id)"
@@ -37,6 +43,7 @@ import Button from '@/components/ui/Button/index.vue';
 import api from '@/services/api';
 import { useNotify } from '@/plugins/notify';
 import Swal from 'sweetalert2';
+import { can } from '@/stores/auth';
 
 const notify = useNotify();
 const tableKey = ref(0);

--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="can('roles.manage')">
+  <div v-if="canAccess">
     <form @submit.prevent="onSubmit" class="max-w-md grid gap-4">
       <div>
         <label class="block font-medium mb-1" for="name">Name<span class="text-red-600">*</span></label>
@@ -91,6 +91,11 @@ const tenantOptions = computed(() => [
 ]);
 
 const isEdit = computed(() => route.name === 'roles.edit');
+const canAccess = computed(() =>
+  isEdit.value
+    ? can('roles.update') || can('roles.manage')
+    : can('roles.create') || can('roles.manage'),
+);
 
 async function loadRole() {
   const { data } = await api.get(`/roles/${route.params.id}`);

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -12,7 +12,7 @@
         </select>
       </div>
       <RouterLink
-        v-if="can('roles.manage')"
+        v-if="can('roles.create') || can('roles.manage')"
         class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
         :to="{ name: 'roles.create' }"
       >
@@ -25,18 +25,33 @@
       :columns="columns"
       :fetcher="fetchRoles"
     >
-      <template #actions="{ row }">
-        <div
-          v-if="row.name !== 'SuperAdmin' && can('roles.manage')"
-          class="flex gap-2"
-        >
-          <button class="text-blue-600" title="Edit" @click="edit(row.id)">
+      <template
+        v-if="can('roles.update') || can('roles.delete') || can('roles.manage')"
+        #actions="{ row }"
+      >
+        <div v-if="row.name !== 'SuperAdmin'" class="flex gap-2">
+          <button
+            v-if="can('roles.update') || can('roles.manage')"
+            class="text-blue-600"
+            title="Edit"
+            @click="edit(row.id)"
+          >
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
-          <button class="text-red-600" title="Delete" @click="remove(row.id)">
+          <button
+            v-if="can('roles.delete') || can('roles.manage')"
+            class="text-red-600"
+            title="Delete"
+            @click="remove(row.id)"
+          >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
-          <button class="text-green-600" title="Assign" @click="openAssign(row.id)">
+          <button
+            v-if="can('roles.manage')"
+            class="text-green-600"
+            title="Assign"
+            @click="openAssign(row.id)"
+          >
             <Icon icon="heroicons-outline:user-plus" class="w-5 h-5" />
           </button>
         </div>

--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="can('statuses.manage')">
+  <div v-if="canAccess">
     <form @submit.prevent="onSubmit" class="max-w-md grid gap-4">
       <div v-if="auth.isSuperAdmin">
         <label class="block font-medium mb-1" for="tenant">Tenant</label>
@@ -42,6 +42,11 @@ const serverError = ref('');
 const tenantId = ref<string | number | ''>('');
 
 const isEdit = computed(() => route.name === 'statuses.edit');
+const canAccess = computed(() =>
+  isEdit.value
+    ? can('statuses.update') || can('statuses.manage')
+    : can('statuses.create') || can('statuses.manage'),
+);
 
 onMounted(async () => {
   if (auth.isSuperAdmin) {

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -11,7 +11,7 @@
         </option>
       </select>
       <RouterLink
-        v-if="can('statuses.manage')"
+        v-if="can('statuses.create') || can('statuses.manage')"
         class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
         :to="{ name: 'statuses.create' }"
       >
@@ -24,16 +24,37 @@
       :columns="columns"
       :fetcher="fetchStatuses"
     >
-      <template #actions="{ row }">
-        <div v-if="can('statuses.manage')" class="flex gap-2">
-          <button class="text-blue-600" title="Edit" @click="edit(row.id)">
+      <template
+        v-if="
+          can('statuses.update') ||
+          can('statuses.delete') ||
+          can('statuses.create') ||
+          can('statuses.manage')
+        "
+        #actions="{ row }"
+      >
+        <div class="flex gap-2">
+          <button
+            v-if="can('statuses.update') || can('statuses.manage')"
+            class="text-blue-600"
+            title="Edit"
+            @click="edit(row.id)"
+          >
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
-          <button class="text-red-600" title="Delete" @click="remove(row.id)">
+          <button
+            v-if="can('statuses.delete') || can('statuses.manage')"
+            class="text-red-600"
+            title="Delete"
+            @click="remove(row.id)"
+          >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
           <button
-            v-if="auth.isSuperAdmin || !row.tenant_id"
+            v-if="
+              (can('statuses.create') || can('statuses.manage')) &&
+              (auth.isSuperAdmin || !row.tenant_id)
+            "
             class="text-green-600"
             title="Copy to Tenant"
             @click="copy(row.id)"

--- a/frontend/src/views/teams/TeamForm.vue
+++ b/frontend/src/views/teams/TeamForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="can('teams.manage')">
+  <div v-if="canAccess">
     <form @submit.prevent="submit" class="grid gap-4 max-w-lg">
       <Textinput label="Name" v-model="form.name" :error="errors.name" />
       <Textinput label="Description" v-model="form.description" :error="errors.description" />
@@ -38,6 +38,11 @@ const router = useRouter();
 const teamsStore = useTeamsStore();
 
 const isEdit = computed(() => route.name === 'teams.edit');
+const canAccess = computed(() =>
+  isEdit.value
+    ? can('teams.update') || can('teams.manage')
+    : can('teams.create') || can('teams.manage'),
+);
 
 const form = ref({
   name: '',

--- a/frontend/src/views/teams/TeamsList.vue
+++ b/frontend/src/views/teams/TeamsList.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="mb-4">
       <RouterLink
-        v-if="can('teams.manage')"
+        v-if="can('teams.create') || can('teams.manage')"
         class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
         :to="{ name: 'teams.create' }"
       >
@@ -15,12 +15,25 @@
       :columns="columns"
       :fetcher="fetchTeams"
     >
-      <template #actions="{ row }">
-        <div v-if="can('teams.manage')" class="flex gap-2">
-          <button class="text-blue-600" title="Edit" @click="edit(row.id)">
+      <template
+        v-if="can('teams.update') || can('teams.delete') || can('teams.manage')"
+        #actions="{ row }"
+      >
+        <div class="flex gap-2">
+          <button
+            v-if="can('teams.update') || can('teams.manage')"
+            class="text-blue-600"
+            title="Edit"
+            @click="edit(row.id)"
+          >
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
-          <button class="text-red-600" title="Delete" @click="remove(row.id)">
+          <button
+            v-if="can('teams.delete') || can('teams.manage')"
+            class="text-red-600"
+            title="Delete"
+            @click="remove(row.id)"
+          >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
         </div>

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="can('types.manage')">
+    <div v-if="canAccess">
       <form @submit.prevent="onSubmit" class="grid grid-cols-2 gap-8">
       <div>
         <div v-if="auth.isSuperAdmin" class="mb-4">
@@ -160,6 +160,11 @@ const fieldTypes = [
 ];
 
 const isEdit = computed(() => route.name === 'types.edit');
+const canAccess = computed(() =>
+  isEdit.value
+    ? can('types.update') || can('types.manage')
+    : can('types.create') || can('types.manage'),
+);
 
 const availableStatuses = computed(() =>
   allStatuses.value.filter(

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -11,7 +11,7 @@
           </option>
         </select>
         <RouterLink
-          v-if="can('types.manage')"
+          v-if="can('types.create') || can('types.manage')"
           class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
           :to="{ name: 'types.create' }"
         >
@@ -24,16 +24,37 @@
       :columns="columns"
       :fetcher="fetchTypes"
     >
-      <template #actions="{ row }">
-        <div v-if="can('types.manage')" class="flex gap-2">
-          <button class="text-blue-600" title="Edit" @click="edit(row.id)">
+      <template
+        v-if="
+          can('types.update') ||
+          can('types.delete') ||
+          can('types.create') ||
+          can('types.manage')
+        "
+        #actions="{ row }"
+      >
+        <div class="flex gap-2">
+          <button
+            v-if="can('types.update') || can('types.manage')"
+            class="text-blue-600"
+            title="Edit"
+            @click="edit(row.id)"
+          >
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
-          <button class="text-red-600" title="Delete" @click="remove(row.id)">
+          <button
+            v-if="can('types.delete') || can('types.manage')"
+            class="text-red-600"
+            title="Delete"
+            @click="remove(row.id)"
+          >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
           <button
-            v-if="auth.isSuperAdmin || !row.tenant_id"
+            v-if="
+              (can('types.create') || can('types.manage')) &&
+              (auth.isSuperAdmin || !row.tenant_id)
+            "
             class="text-green-600"
             title="Copy to Tenant"
             @click="copy(row.id)"


### PR DESCRIPTION
## Summary
- show create and row actions only when permitted
- restrict form pages by create/update abilities
- hide status change and comments for unauthorized users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09ab45d208323be66ab223ad45b97