### PR TITLE
Gate employees feature by abilities

### DIFF
--- a/backend/app/Http/Controllers/Api/EmployeeController.php
+++ b/backend/app/Http/Controllers/Api/EmployeeController.php
@@ -17,13 +17,6 @@ class EmployeeController extends Controller
 {
     use ListQuery;
 
-    protected function ensureAdmin(Request $request): void
-    {
-        if (! $request->user()->hasRole('ClientAdmin') && ! $request->user()->hasRole('SuperAdmin')) {
-            abort(403);
-        }
-    }
-
     protected function getTenantId(Request $request): int
     {
         if ($request->user()->hasRole('SuperAdmin')) {
@@ -39,8 +32,6 @@ class EmployeeController extends Controller
 
     public function index(Request $request)
     {
-        $this->ensureAdmin($request);
-
         $tenantId = $this->getTenantId($request);
 
         $base = User::where('tenant_id', $tenantId)
@@ -54,8 +45,6 @@ class EmployeeController extends Controller
 
     public function store(Request $request)
     {
-        $this->ensureAdmin($request);
-
         $data = $request->validate([
             'name' => 'required|string',
             'email' => 'required|email',
@@ -97,8 +86,6 @@ class EmployeeController extends Controller
 
     public function show(Request $request, User $employee)
     {
-        $this->ensureAdmin($request);
-
         $tenantId = $this->getTenantId($request);
         if ($employee->tenant_id !== $tenantId) {
             abort(404);
@@ -109,8 +96,6 @@ class EmployeeController extends Controller
 
     public function update(Request $request, User $employee)
     {
-        $this->ensureAdmin($request);
-
         $tenantId = $this->getTenantId($request);
         if ($employee->tenant_id !== $tenantId) {
             abort(404);
@@ -154,8 +139,6 @@ class EmployeeController extends Controller
 
     public function destroy(Request $request, User $employee)
     {
-        $this->ensureAdmin($request);
-
         $tenantId = $this->getTenantId($request);
         if ($employee->tenant_id !== $tenantId) {
             abort(404);

--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -48,7 +48,6 @@ export const menuItems = [
     icon: "heroicons-outline:users",
     link: "employees.list",
     requiredAbilities: ["employees.view", "employees.manage"],
-    admin: true,
   },
   {
     title: "Reports",
@@ -118,7 +117,6 @@ export const topMenu = [
     icon: "heroicons-outline:users",
     link: "employees.list",
     requiredAbilities: ["employees.view", "employees.manage"],
-    admin: true,
   },
   {
     title: "Reports",
@@ -180,7 +178,6 @@ export const addNewOptions = [
     icon: 'heroicons-outline:users',
     link: 'employees.create',
     requiredAbilities: ['employees.manage'],
-    admin: true,
   },
   {
     label: 'Status',


### PR DESCRIPTION
## Summary
- Remove role-based guards from EmployeeController to rely on ability middleware while keeping tenant scoping and SuperAdmin restrictions
- Expose Employees menu and quick actions to users with employees abilities without requiring admin role

## Testing
- `npm test`
- `composer test` *(fails: Failed to open vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b09c532c9c8323b1897d05224368f2