### PR TITLE
Expose tenant features via /me endpoint

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\Tenant;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -121,9 +122,12 @@ class AuthController extends Controller
     {
         $user = $request->user()->load('roles');
 
+        $tenant = Tenant::current() ?? Tenant::find($user->tenant_id);
+
         return response()->json([
             'user' => $user,
             'abilities' => $this->abilitiesFor($user),
+            'features' => $tenant?->features ?? [],
         ]);
     }
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -27,6 +27,7 @@ export const useAuthStore = defineStore('auth', {
     refreshToken: initialRefresh as string | null,
     impersonatedTenant: localStorage.getItem('impersonatingTenant') || '',
     abilities: [] as string[],
+    features: [] as string[],
   }),
   getters: {
     isAuthenticated: (state) => !!state.accessToken,
@@ -60,6 +61,7 @@ export const useAuthStore = defineStore('auth', {
       const { data } = await api.get('/me');
       this.user = data.user;
       this.abilities = data.abilities || [];
+      this.features = data.features || [];
       useTenantStore().setTenant(data.user?.tenant_id || '');
     },
     async logout(skipServer = false) {


### PR DESCRIPTION
## Summary
- Include current tenant feature flags in `/me` API response
- Track feature list in auth store for frontend hints

## Testing
- `composer test` *(fails: 7 failed, 22 warnings, 6 incomplete, 6 passed)*
- `npm test` *(skipped: 19)*

------
https://chatgpt.com/codex/tasks/task_e_68b09d88d3f08323a52a3132ad5d221e