### PR TITLE
Backfill tenant feature roles with defaults

### DIFF
--- a/backend/database/migrations/2025_09_03_000000_backfill_tenant_roles.php
+++ b/backend/database/migrations/2025_09_03_000000_backfill_tenant_roles.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use App\Models\Tenant;
+use Database\Seeders\DefaultFeatureRolesSeeder;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $defaultFeatures = ['appointments','roles','types','teams','statuses'];
+
+        Tenant::query()->lazy()->each(function (Tenant $tenant) use ($defaultFeatures) {
+            if (empty($tenant->features)) {
+                $tenant->features = $defaultFeatures;
+                $tenant->save();
+            }
+
+            DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant);
+        });
+    }
+
+    public function down(): void
+    {
+        // no-op
+    }
+};

--- a/backend/database/seeders/TenantRolesBackfillSeeder.php
+++ b/backend/database/seeders/TenantRolesBackfillSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tenant;
+use Illuminate\Database\Seeder;
+
+class TenantRolesBackfillSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $defaultFeatures = ['appointments','roles','types','teams','statuses'];
+
+        Tenant::query()->lazy()->each(function (Tenant $tenant) use ($defaultFeatures) {
+            if (empty($tenant->features)) {
+                $tenant->features = $defaultFeatures;
+                $tenant->save();
+            }
+
+            DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- backfill tenant features with sensible defaults when empty
- sync default roles for each tenant during migration
- provide seeder to re-run tenant role sync

## Testing
- `composer test` *(fails: Tests\Feature\StatusRoutesTest > crud routes work)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a1eedf888323853e0008d0fa8e67