### PR TITLE
Respect custom tenant headers in API requests

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -49,7 +49,7 @@ api.interceptors.request.use(async (config) => {
   }
   const tenant = useTenantStore();
   config.headers = config.headers || {};
-  if (tenant.currentTenantId) {
+  if (tenant.currentTenantId && !config.headers[TENANT_HEADER]) {
     config.headers[TENANT_HEADER] = tenant.currentTenantId;
   }
   if (authGetter) {


### PR DESCRIPTION
## Summary
- prevent axios interceptor from overwriting an explicit X-Tenant-ID header
- ensures super admins can fetch abilities for other tenants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a7788e9c8323859eaa1bc81eab24