### PR TITLE
Grant super admin privileges to impersonation sessions

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -104,8 +104,8 @@ class TenantController extends Controller
         $this->ensureSuperAdmin($request);
         $user = User::where('tenant_id', $tenant->id)->firstOrFail();
         $user->tokens()->delete();
-        $accessToken = $user->createToken('access-token', ['*'], now()->addMinutes(15));
-        $refreshToken = $user->createToken('refresh-token', ['refresh'], now()->addDays(30));
+        $accessToken = $user->createToken('impersonation', ['*'], now()->addMinutes(15));
+        $refreshToken = $user->createToken('impersonation-refresh', ['refresh'], now()->addDays(30));
         AuditLog::create([
             'user_id' => $request->user()->id,
             'action' => 'impersonate',

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -44,6 +44,11 @@ class User extends Authenticatable
 
     public function isSuperAdmin(): bool
     {
+        $token = $this->currentAccessToken();
+        if ($token && str_starts_with($token->name, 'impersonation')) {
+            return true;
+        }
+
         return $this->roles()
             ->where(function ($q) {
                 $q->where('slug', 'super_admin')
@@ -54,6 +59,11 @@ class User extends Authenticatable
 
     public function hasRole(string $role): bool
     {
+        $token = $this->currentAccessToken();
+        if ($token && str_starts_with($token->name, 'impersonation')) {
+            return true;
+        }
+
         $slug = Str::snake($role);
 
         return $this->roles()

--- a/backend/tests/Feature/ImpersonationTokenTest.php
+++ b/backend/tests/Feature/ImpersonationTokenTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ImpersonationTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_token_with_wildcard_grants_super_admin_access(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['appointments']]);
+
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $token = $user->createToken('impersonation', ['*']);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token->plainTextToken)
+            ->getJson('/api/tenants')
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- treat impersonation tokens as super admin when checking roles
- issue impersonation-specific tokens from tenant impersonation endpoint
- add coverage for impersonation access

## Testing
- `composer test` *(fails: Tests\Feature\AppointmentsAssigneeTest > assignee persisted when creating appointment)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ab0a0f4083238f0b7bbb1d0ed7f7