### PR TITLE
Fix impersonation to respect tenant permissions

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -44,11 +44,6 @@ class User extends Authenticatable
 
     public function isSuperAdmin(): bool
     {
-        $token = $this->currentAccessToken();
-        if ($token && str_starts_with($token->name, 'impersonation')) {
-            return true;
-        }
-
         return $this->roles()
             ->where(function ($q) {
                 $q->where('slug', 'super_admin')
@@ -59,11 +54,6 @@ class User extends Authenticatable
 
     public function hasRole(string $role): bool
     {
-        $token = $this->currentAccessToken();
-        if ($token && str_starts_with($token->name, 'impersonation')) {
-            return true;
-        }
-
         $slug = Str::snake($role);
 
         return $this->roles()


### PR DESCRIPTION
## Summary
- remove impersonation token bypass from `User::isSuperAdmin` and `User::hasRole`

## Testing
- `composer test` *(fails: EmployeeTest, AppointmentRoutesTest, AppointmentsAssigneeTest)*
- `./vendor/bin/phpunit tests/Feature/ImpersonationTokenTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae77e98c8323a72fcbce40969d1a