### PR TITLE
Add GDPR feature with roles and ability gating

### DIFF
--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -57,5 +57,11 @@ return [
 
     // Branding
     'branding.manage',
+
+    // GDPR
+    'gdpr.view',
+    'gdpr.manage',
+    'gdpr.export',
+    'gdpr.delete',
 ];
 

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -82,5 +82,14 @@ return [
             'branding.manage',
         ],
     ],
+    'gdpr' => [
+        'label' => 'GDPR',
+        'abilities' => [
+            'gdpr.view',
+            'gdpr.manage',
+            'gdpr.export',
+            'gdpr.delete',
+        ],
+    ],
     // Additional features can be listed here as needed, e.g. 'reports', 'billing', 'employees', …
 ];

--- a/backend/config/features.php
+++ b/backend/config/features.php
@@ -10,6 +10,7 @@ return [
     'employees',
     'themes',
     'tenants',
+    'gdpr',
     'branding',
 ];
 

--- a/backend/database/seeders/DefaultFeatureRolesSeeder.php
+++ b/backend/database/seeders/DefaultFeatureRolesSeeder.php
@@ -66,6 +66,20 @@ class DefaultFeatureRolesSeeder extends Seeder
                         'level' => 2,
                     ];
                     break;
+                case 'gdpr':
+                    $roles[] = [
+                        'slug' => 'gdpr_viewer',
+                        'name' => 'GDPR Viewer',
+                        'abilities' => ['gdpr.view'],
+                        'level' => 3,
+                    ];
+                    $roles[] = [
+                        'slug' => 'gdpr_manager',
+                        'name' => 'GDPR Manager',
+                        'abilities' => ['gdpr.view', 'gdpr.manage', 'gdpr.export', 'gdpr.delete'],
+                        'level' => 2,
+                    ];
+                    break;
                 case 'roles':
                     $roles[] = [
                         'slug' => 'roles_manager',

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -178,10 +178,14 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         ->middleware(Ability::class . ':themes.manage');
 
     Route::prefix('gdpr')->group(function () {
-        Route::get('export', [GdprController::class, 'export']);
-        Route::get('consents', [GdprController::class, 'consents']);
-        Route::put('consents', [GdprController::class, 'updateConsents']);
-        Route::post('delete', [GdprController::class, 'requestDelete']);
+        Route::get('export', [GdprController::class, 'export'])
+            ->middleware(Ability::class . ':gdpr.export');
+        Route::get('consents', [GdprController::class, 'consents'])
+            ->middleware(Ability::class . ':gdpr.view');
+        Route::put('consents', [GdprController::class, 'updateConsents'])
+            ->middleware(Ability::class . ':gdpr.manage');
+        Route::post('delete', [GdprController::class, 'requestDelete'])
+            ->middleware(Ability::class . ':gdpr.delete');
     });
 
     Route::prefix('reports')->group(function () {

--- a/backend/tests/Feature/FeatureAbilitiesTest.php
+++ b/backend/tests/Feature/FeatureAbilitiesTest.php
@@ -65,7 +65,8 @@ class FeatureAbilitiesTest extends TestCase
     public static function featureAbilityProvider(): array
     {
         return [
-                        'roles' => ['roles', '/api/roles', 'roles.manage'],
+            'gdpr' => ['gdpr', '/api/gdpr/consents', 'gdpr.view'],
+            'roles' => ['roles', '/api/roles', 'roles.manage'],
             'types' => ['types', '/api/appointment-types', 'types.view'],
             'teams' => ['teams', '/api/teams', 'teams.view'],
             'statuses' => ['statuses', '/api/statuses', 'statuses.view'],

--- a/backend/tests/Feature/LookupRoutesTest.php
+++ b/backend/tests/Feature/LookupRoutesTest.php
@@ -118,6 +118,7 @@ class LookupRoutesTest extends TestCase
         $this->assertContains(['slug' => 'employees', 'label' => 'Employees'], $features);
         $this->assertContains(['slug' => 'themes', 'label' => 'Theme Customizer'], $features);
         $this->assertContains(['slug' => 'tenants', 'label' => 'Tenants'], $features);
+        $this->assertContains(['slug' => 'gdpr', 'label' => 'GDPR'], $features);
     }
 }
 

--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -81,7 +81,11 @@ export const menuItems = [
         childlink: "settings.footer",
         requiredAbilities: ["branding.manage"],
       },
-      { childtitle: "GDPR", childlink: "gdpr.index" },
+      {
+        childtitle: "GDPR",
+        childlink: "gdpr.index",
+        requiredAbilities: ["gdpr.view", "gdpr.manage"],
+      },
     ],
   },
 ];
@@ -157,7 +161,12 @@ export const topMenu = [
     admin: true,
     requiredAbilities: ["branding.manage"],
   },
-  { title: "GDPR", icon: "heroicons-outline:shield-check", link: "gdpr.index" },
+  {
+    title: "GDPR",
+    icon: "heroicons-outline:shield-check",
+    link: "gdpr.index",
+    requiredAbilities: ["gdpr.view", "gdpr.manage"],
+  },
   {
     title: "Tenants",
     icon: "heroicons-outline:building-office",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -318,6 +318,7 @@ export const routes = [
       title: 'GDPR',
       layout: 'app',
       groupParent: 'settings',
+      requiredAbilities: ['gdpr.view', 'gdpr.manage'],
     },
   },
   {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -49,6 +49,7 @@ import Button from '@/components/ui/Button/index.vue';
 import Switch from '@/components/ui/Switch/index.vue';
 import { RouterLink } from 'vue-router';
 import { useNotify } from '@/plugins/notify';
+import { useAuthStore } from '@/stores/auth';
 
 interface Pref {
   category: string;
@@ -56,13 +57,20 @@ interface Pref {
   email: boolean;
 }
 
-const tabs = [
-  { id: 'profile', label: 'Profile' },
-  { id: 'branding', label: 'Branding' },
-  { id: 'footer', label: 'Footer' },
-  { id: 'notifications', label: 'Notifications' },
-  { id: 'gdpr', label: 'GDPR' },
-];
+const auth = useAuthStore();
+
+const tabs = computed(() => {
+  const t = [
+    { id: 'profile', label: 'Profile' },
+    { id: 'branding', label: 'Branding' },
+    { id: 'footer', label: 'Footer' },
+    { id: 'notifications', label: 'Notifications' },
+  ];
+  if (auth.hasAny(['gdpr.view', 'gdpr.manage'])) {
+    t.push({ id: 'gdpr', label: 'GDPR' });
+  }
+  return t;
+});
 
 const active = ref('profile');
 const prefs = ref<Pref[]>([]);


### PR DESCRIPTION
## Summary
- add GDPR feature configuration and abilities
- seed default GDPR roles and secure API routes
- gate GDPR UI routes and menu items by ability

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0d706e00c83239eff9d567fb2a508