### PR TITLE
Fix login page branding load and service worker caching

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -28,6 +28,8 @@ Route::middleware(['api','tenant'])->get('/health', function () {
     return response()->json(['status' => 'ok', 'tenant' => config('tenant.branding')]);
 });
 
+Route::middleware(['api','tenant'])->get('branding', [BrandingController::class, 'show']);
+
 Route::prefix('auth')->group(function () {
     Route::post('login', [AuthController::class, 'login'])
         ->middleware('throttle:auth')
@@ -168,7 +170,6 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     Route::post('employees/{employee}', [EmployeeController::class, 'update'])
         ->middleware(Ability::class . ':employees.manage');
 
-    Route::get('branding', [BrandingController::class, 'show']);
     Route::put('branding', [BrandingController::class, 'update'])
         ->middleware(Ability::class . ':branding.manage');
     Route::put('settings/profile', [SettingsController::class, 'updateProfile']);

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -22,7 +22,12 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') return;
+  if (
+    event.request.method !== 'GET' ||
+    !event.request.url.startsWith(self.location.origin)
+  ) {
+    return;
+  }
   event.respondWith(
     fetch(event.request)
       .then((response) => {

--- a/frontend/src/stores/branding.ts
+++ b/frontend/src/stores/branding.ts
@@ -10,8 +10,12 @@ export const useBrandingStore = defineStore('branding', {
   }),
   actions: {
     async load() {
-      const { data } = await api.get('/branding');
-      this.branding = data;
+      try {
+        const { data } = await api.get('/branding');
+        this.branding = data;
+      } catch (_) {
+        // Ignore errors so the app can still load without branding info
+      }
       this.applyTheme();
     },
     async update(payload: Record<string, any>) {


### PR DESCRIPTION
## Summary
- Expose `/api/branding` without auth so login can load branding data
- Skip non-origin requests in service worker to avoid unsupported cache schemes
- Handle branding load errors gracefully in Pinia store

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15056b3248323a1667616b8d21293