### PR TITLE
Hide branding and footer without branding feature

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/AddNew.vue
+++ b/frontend/src/components/ui/Header/Navtools/AddNew.vue
@@ -40,7 +40,8 @@ const items = computed(() =>
   addNewOptions.filter((i) => {
     if (i.admin && !auth.isSuperAdmin) return false;
     const req = i.requiredAbilities || [];
-    return auth.hasAny(req);
+    const features = i.requiredFeatures || [];
+    return auth.hasAny(req) && features.every((f) => auth.features.includes(f));
   })
 );
 

--- a/frontend/src/components/ui/Header/Navtools/DesktopMenu.vue
+++ b/frontend/src/components/ui/Header/Navtools/DesktopMenu.vue
@@ -112,12 +112,20 @@ export default {
   computed: {
     newMenulist() {
       const auth = useAuthStore();
-      return topMenu.filter((item) => {
-        if (item.isHeadr) return false;
-        if (item.admin && !auth.isSuperAdmin) return false;
-        const req = item.requiredAbilities || [];
-        return auth.hasAny(req);
-      });
+      const filterItems = (items = []) =>
+        items.filter((item) => {
+          if (item.isHeadr) return false;
+          if (item.admin && !auth.isSuperAdmin) return false;
+          const req = item.requiredAbilities || [];
+          const features = item.requiredFeatures || [];
+          return (
+            auth.hasAny(req) && features.every((f) => auth.features.includes(f))
+          );
+        });
+      return filterItems(topMenu).map((item) => ({
+        ...item,
+        child: filterItems(item.child || []),
+      }));
     },
   },
 };

--- a/frontend/src/components/ui/Sidebar/Navmenu.vue
+++ b/frontend/src/components/ui/Sidebar/Navmenu.vue
@@ -137,12 +137,20 @@ export default {
 
   setup(props) {
     const auth = useAuthStore();
-    const visibleItems = computed(() =>
-      props.items.filter((it) => {
+    const filterItems = (items = []) =>
+      items.filter((it) => {
         if (it.admin && !auth.isSuperAdmin) return false;
         const req = it.requiredAbilities || [];
-        return auth.hasAny(req);
-      }),
+        const features = it.requiredFeatures || [];
+        return (
+          auth.hasAny(req) && features.every((f) => auth.features.includes(f))
+        );
+      });
+    const visibleItems = computed(() =>
+      filterItems(props.items).map((it) => ({
+        ...it,
+        child: filterItems(it.child || []),
+      })),
     );
     return { visibleItems };
   },

--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -75,11 +75,13 @@ export const menuItems = [
         childtitle: "Branding",
         childlink: "settings.branding",
         requiredAbilities: ["branding.manage"],
+        requiredFeatures: ["branding"],
       },
       {
         childtitle: "Footer",
         childlink: "settings.footer",
         requiredAbilities: ["branding.manage"],
+        requiredFeatures: ["branding"],
       },
       {
         childtitle: "GDPR",
@@ -153,6 +155,7 @@ export const topMenu = [
     link: "settings.branding",
     admin: true,
     requiredAbilities: ["branding.manage"],
+    requiredFeatures: ["branding"],
   },
   {
     title: "Footer",
@@ -160,6 +163,7 @@ export const topMenu = [
     link: "settings.footer",
     admin: true,
     requiredAbilities: ["branding.manage"],
+    requiredFeatures: ["branding"],
   },
   {
     title: "GDPR",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -277,6 +277,7 @@ export const routes = [
     meta: {
       requiresAuth: true,
       requiredAbilities: ['branding.manage'],
+      requiredFeatures: ['branding'],
       breadcrumb: 'routes.branding',
       title: 'Branding',
       layout: 'app',
@@ -290,6 +291,7 @@ export const routes = [
     meta: {
       requiresAuth: true,
       requiredAbilities: ['branding.manage'],
+      requiredFeatures: ['branding'],
       breadcrumb: 'routes.footer',
       title: 'Footer',
       layout: 'app',
@@ -582,6 +584,13 @@ router.beforeEach(async (to, from, next) => {
   }
 
   if (to.meta.requiredAbilities?.length && !auth.hasAny(to.meta.requiredAbilities)) {
+    return next('/');
+  }
+
+  if (
+    to.meta.requiredFeatures?.length &&
+    !to.meta.requiredFeatures.every((f) => auth.features.includes(f))
+  ) {
     return next('/');
   }
 

--- a/frontend/src/views/settings/Branding.vue
+++ b/frontend/src/views/settings/Branding.vue
@@ -21,7 +21,7 @@ const route = useRoute();
 
 const tabs = computed(() => {
   const t = [{ id: '/settings/profile', label: 'Profile' }];
-  if (auth.can('branding.manage')) {
+  if (auth.can('branding.manage') && auth.features.includes('branding')) {
     t.push({ id: '/settings/branding', label: 'Branding' });
     t.push({ id: '/settings/footer', label: 'Footer' });
   }

--- a/frontend/src/views/settings/Footer.vue
+++ b/frontend/src/views/settings/Footer.vue
@@ -21,7 +21,7 @@ const route = useRoute();
 
 const tabs = computed(() => {
   const t = [{ id: '/settings/profile', label: 'Profile' }];
-  if (auth.can('branding.manage')) {
+  if (auth.can('branding.manage') && auth.features.includes('branding')) {
     t.push({ id: '/settings/branding', label: 'Branding' });
     t.push({ id: '/settings/footer', label: 'Footer' });
   }

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -21,7 +21,7 @@ const route = useRoute();
 
 const tabs = computed(() => {
   const t = [{ id: '/settings/profile', label: 'Profile' }];
-  if (auth.can('branding.manage')) {
+  if (auth.can('branding.manage') && auth.features.includes('branding')) {
     t.push({ id: '/settings/branding', label: 'Branding' });
     t.push({ id: '/settings/footer', label: 'Footer' });
   }


### PR DESCRIPTION
## Summary
- filter sidebar child items by required features so branding/footer submenus only show with `branding`
- apply same feature-based filtering to header desktop menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b152e3d9488323a96d2204045f1506