### PR TITLE
Hide branding/footer menus without feature flag

### DIFF
--- a/frontend/src/components/ui/Sidebar/Navmenu.vue
+++ b/frontend/src/components/ui/Sidebar/Navmenu.vue
@@ -138,12 +138,32 @@ export default {
   setup(props) {
     const auth = useAuthStore();
     const visibleItems = computed(() =>
-      props.items.filter((it) => {
-        if (it.admin && !auth.isSuperAdmin) return false;
-        const req = it.requiredAbilities || [];
-        const features = it.requiredFeatures || [];
-        return auth.hasAny(req) && features.every((f) => auth.features.includes(f));
-      }),
+      props.items
+        .map((it) => {
+          const child = it.child
+            ? it.child.filter((ci) => {
+                const req = ci.requiredAbilities || [];
+                const features = ci.requiredFeatures || [];
+                return (
+                  auth.hasAny(req) &&
+                  features.every((f) => auth.features.includes(f))
+                );
+              })
+            : null;
+          return { ...it, child };
+        })
+        .filter((it) => {
+          if (it.admin && !auth.isSuperAdmin) return false;
+          const req = it.requiredAbilities || [];
+          const features = it.requiredFeatures || [];
+          const allowed =
+            auth.hasAny(req) &&
+            features.every((f) => auth.features.includes(f));
+          if (it.child) {
+            return allowed && it.child.length > 0;
+          }
+          return allowed;
+        }),
     );
     return { visibleItems };
   },


### PR DESCRIPTION
## Summary
- filter sidebar submenu items by abilities and feature flags

## Testing
- `npm test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b1554b27248323a9e84502aa1bf37b