### PR TITLE
Ensure super admins see full feature set

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -125,8 +125,12 @@ class AuthController extends Controller
         $tenant = Tenant::current() ?? Tenant::find($user->tenant_id);
 
         $features = $tenant?->features ?? [];
-        if ($user->isSuperAdmin() && ! in_array('notifications', $features)) {
-            $features[] = 'notifications';
+        if ($user->isSuperAdmin()) {
+            $features = collect($features)
+                ->merge(config('features', []))
+                ->unique()
+                ->values()
+                ->all();
         }
 
         return response()->json([

--- a/backend/tests/Feature/SuperAdminFeaturesTest.php
+++ b/backend/tests/Feature/SuperAdminFeaturesTest.php
@@ -10,11 +10,11 @@ use Illuminate\Support\Facades\Hash;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
-class SuperAdminNotificationsFeatureTest extends TestCase
+class SuperAdminFeaturesTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_super_admin_has_notifications_feature_even_when_tenant_does_not(): void
+    public function test_super_admin_has_all_features_even_when_tenant_does_not(): void
     {
         $tenant = Tenant::create(['name' => 'Tenant', 'features' => []]);
 
@@ -40,7 +40,10 @@ class SuperAdminNotificationsFeatureTest extends TestCase
 
         $data = $this->getJson('/api/me')->assertStatus(200)->json();
 
+        $this->assertEqualsCanonicalizing(config('features'), $data['features']);
         $this->assertContains('notifications', $data['features']);
+        $this->assertContains('branding', $data['features']);
+        $this->assertContains('themes', $data['features']);
     }
 }
 


### PR DESCRIPTION
## Summary
- Merge tenant features with global feature list in /me for super admins
- Assert notifications, branding, and themes are always returned to super admins

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b16785d480832396aca166d22853cb