### PR TITLE
feat: add branding colors for dark mode

### DIFF
--- a/backend/app/Http/Controllers/Api/BrandingController.php
+++ b/backend/app/Http/Controllers/Api/BrandingController.php
@@ -24,6 +24,8 @@ class BrandingController extends Controller
             'name' => 'nullable|string',
             'color' => 'nullable|string',
             'secondary_color' => 'nullable|string',
+            'color_dark' => 'nullable|string',
+            'secondary_color_dark' => 'nullable|string',
             'logo' => 'nullable|string',
             'logo_dark' => 'nullable|string',
             'email_from' => 'nullable|email',

--- a/backend/app/Models/Branding.php
+++ b/backend/app/Models/Branding.php
@@ -14,6 +14,8 @@ class Branding extends Model
         'name',
         'color',
         'secondary_color',
+        'color_dark',
+        'secondary_color_dark',
         'logo',
         'logo_dark',
         'email_from',

--- a/backend/database/migrations/2025_09_02_000000_create_brandings_table.php
+++ b/backend/database/migrations/2025_09_02_000000_create_brandings_table.php
@@ -14,6 +14,8 @@ return new class extends Migration
             $table->string('name')->nullable();
             $table->string('color')->nullable();
             $table->string('secondary_color')->nullable();
+            $table->string('color_dark')->nullable();
+            $table->string('secondary_color_dark')->nullable();
             $table->string('logo')->nullable();
             $table->string('logo_dark')->nullable();
             $table->string('email_from')->nullable();

--- a/backend/database/seeders/BrandingSeeder.php
+++ b/backend/database/seeders/BrandingSeeder.php
@@ -15,6 +15,8 @@ class BrandingSeeder extends Seeder
                 'name' => 'Default Brand',
                 'color' => '#4669fa',
                 'secondary_color' => '#A0AEC0',
+                'color_dark' => '#4669fa',
+                'secondary_color_dark' => '#A0AEC0',
                 'logo' => null,
                 'logo_dark' => null,
                 'email_from' => null,

--- a/backend/tests/Feature/BrandingRoutesTest.php
+++ b/backend/tests/Feature/BrandingRoutesTest.php
@@ -44,6 +44,8 @@ class BrandingRoutesTest extends TestCase
             'name' => 'Brand',
             'color' => '#ffffff',
             'secondary_color' => '#000000',
+            'color_dark' => '#111111',
+            'secondary_color_dark' => '#222222',
             'logo' => 'logo.png',
             'logo_dark' => 'logo-dark.png',
             'footer_left' => 'Left',
@@ -61,6 +63,8 @@ class BrandingRoutesTest extends TestCase
             ->assertJsonPath('footer_left', 'Left')
             ->assertJsonPath('footer_right', 'Right')
             ->assertJsonPath('secondary_color', '#000000')
+            ->assertJsonPath('color_dark', '#111111')
+            ->assertJsonPath('secondary_color_dark', '#222222')
             ->assertJsonPath('logo_dark', 'logo-dark.png');
     }
 

--- a/frontend/src/components/settings/BrandingForm.vue
+++ b/frontend/src/components/settings/BrandingForm.vue
@@ -41,6 +41,22 @@
         class="h-10 w-20 rounded border border-slate-200"
       />
     </div>
+    <div>
+      <label class="form-label">Primary Color (Dark)</label>
+      <input
+        type="color"
+        v-model="form.color_dark"
+        class="h-10 w-20 rounded border border-slate-200"
+      />
+    </div>
+    <div>
+      <label class="form-label">Secondary Color (Dark)</label>
+      <input
+        type="color"
+        v-model="form.secondary_color_dark"
+        class="h-10 w-20 rounded border border-slate-200"
+      />
+    </div>
     <Textinput label="Email From" type="email" v-model="form.email_from" />
     <Button type="submit" :isDisabled="!dirty" btnClass="btn-dark"
       >Save Branding</Button

--- a/frontend/src/stores/branding.ts
+++ b/frontend/src/stores/branding.ts
@@ -7,6 +7,8 @@ export const useBrandingStore = defineStore('branding', {
       name: 'Asbuild SPA',
       color: '#4669fa',
       secondary_color: '#A0AEC0',
+      color_dark: '#4669fa',
+      secondary_color_dark: '#A0AEC0',
       logo: '',
       logo_dark: '',
       email_from: '',
@@ -36,8 +38,13 @@ export const useBrandingStore = defineStore('branding', {
         const b = parseInt(clean.slice(4, 6), 16);
         document.documentElement.style.setProperty(name, `${r} ${g} ${b}`);
       };
-      setVar('--color-primary', this.branding.color);
-      setVar('--color-secondary', this.branding.secondary_color);
+      const isDark = document.body.classList.contains('dark');
+      const primary = isDark ? this.branding.color_dark : this.branding.color;
+      const secondary = isDark
+        ? this.branding.secondary_color_dark
+        : this.branding.secondary_color;
+      setVar('--color-primary', primary);
+      setVar('--color-secondary', secondary);
       if (this.branding.name) {
         document.title = this.branding.name;
       }

--- a/frontend/src/stores/themeSettings.js
+++ b/frontend/src/stores/themeSettings.js
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import api from "@/services/api";
 import { useAuthStore } from "./auth";
+import { useBrandingStore } from "./branding";
 
 const safeSetItem = (key, value) => {
   try {
@@ -96,6 +97,8 @@ export const useThemeSettingsStore = defineStore("themeSettings", {
       this.theme = this.theme === "dark" ? "light" : "dark";
       document.body.classList.add(this.theme);
       safeSetItem("theme", this.theme);
+      const branding = useBrandingStore();
+      branding.applyTheme();
     },
 
     toggleSettings() {


### PR DESCRIPTION
## Summary
- support storing dark theme colors for branding
- apply branding colors dynamically based on current theme

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b177ed32248323bb590eb96e40fae0