### PR TITLE
Handle empty branding values and add migration for dark theme fields

### DIFF
--- a/backend/database/migrations/2025_09_02_000000_create_brandings_table.php
+++ b/backend/database/migrations/2025_09_02_000000_create_brandings_table.php
@@ -13,11 +13,7 @@ return new class extends Migration
             $table->foreignId('tenant_id')->nullable()->constrained()->cascadeOnDelete();
             $table->string('name')->nullable();
             $table->string('color')->nullable();
-            $table->string('secondary_color')->nullable();
-            $table->string('color_dark')->nullable();
-            $table->string('secondary_color_dark')->nullable();
             $table->string('logo')->nullable();
-            $table->string('logo_dark')->nullable();
             $table->string('email_from')->nullable();
             $table->string('footer_left')->nullable();
             $table->string('footer_right')->nullable();

--- a/backend/database/migrations/2025_09_04_000000_add_branding_dark_mode_fields.php
+++ b/backend/database/migrations/2025_09_04_000000_add_branding_dark_mode_fields.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('brandings', function (Blueprint $table) {
+            $table->string('secondary_color')->nullable()->after('color');
+            $table->string('color_dark')->nullable()->after('secondary_color');
+            $table->string('secondary_color_dark')->nullable()->after('color_dark');
+            $table->string('logo_dark')->nullable()->after('logo');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('brandings', function (Blueprint $table) {
+            $table->dropColumn([
+                'secondary_color',
+                'color_dark',
+                'secondary_color_dark',
+                'logo_dark',
+            ]);
+        });
+    }
+};

--- a/frontend/src/stores/branding.ts
+++ b/frontend/src/stores/branding.ts
@@ -18,7 +18,10 @@ export const useBrandingStore = defineStore('branding', {
     async load() {
       try {
         const { data } = await api.get('/branding');
-        this.branding = { ...this.branding, ...data };
+        const clean = Object.fromEntries(
+          Object.entries(data || {}).filter(([, v]) => v != null && v !== '')
+        );
+        this.branding = { ...this.branding, ...clean };
       } catch (_) {
         // Ignore errors so the app can still load without branding info
       }
@@ -26,7 +29,10 @@ export const useBrandingStore = defineStore('branding', {
     },
     async update(payload: Record<string, any>) {
       const { data } = await api.put('/branding', payload);
-      this.branding = data;
+      const clean = Object.fromEntries(
+        Object.entries(data || {}).filter(([, v]) => v != null && v !== '')
+      );
+      this.branding = { ...this.branding, ...clean };
       this.applyTheme();
     },
     applyTheme() {


### PR DESCRIPTION
## Summary
- preserve default branding colors when API returns empty values
- restore original branding table and add migration for dark mode fields

## Testing
- `composer test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b179bd5aac8323939bae72dfe47439