### PR TITLE
Guard brandings dark mode migration against existing columns

### DIFF
--- a/backend/database/migrations/2025_09_04_000000_add_branding_dark_mode_fields.php
+++ b/backend/database/migrations/2025_09_04_000000_add_branding_dark_mode_fields.php
@@ -9,22 +9,39 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('brandings', function (Blueprint $table) {
-            $table->string('secondary_color')->nullable()->after('color');
-            $table->string('color_dark')->nullable()->after('secondary_color');
-            $table->string('secondary_color_dark')->nullable()->after('color_dark');
-            $table->string('logo_dark')->nullable()->after('logo');
+            if (!Schema::hasColumn('brandings', 'secondary_color')) {
+                $table->string('secondary_color')->nullable()->after('color');
+            }
+
+            if (!Schema::hasColumn('brandings', 'color_dark')) {
+                $after = Schema::hasColumn('brandings', 'secondary_color') ? 'secondary_color' : 'color';
+                $table->string('color_dark')->nullable()->after($after);
+            }
+
+            if (!Schema::hasColumn('brandings', 'secondary_color_dark')) {
+                $table->string('secondary_color_dark')->nullable()->after('color_dark');
+            }
+
+            if (!Schema::hasColumn('brandings', 'logo_dark')) {
+                $table->string('logo_dark')->nullable()->after('logo');
+            }
         });
     }
 
     public function down(): void
     {
         Schema::table('brandings', function (Blueprint $table) {
-            $table->dropColumn([
-                'secondary_color',
-                'color_dark',
-                'secondary_color_dark',
-                'logo_dark',
-            ]);
+            $columns = [];
+
+            foreach (['secondary_color', 'color_dark', 'secondary_color_dark', 'logo_dark'] as $column) {
+                if (Schema::hasColumn('brandings', $column)) {
+                    $columns[] = $column;
+                }
+            }
+
+            if (!empty($columns)) {
+                $table->dropColumn($columns);
+            }
         });
     }
 };


### PR DESCRIPTION
## Summary
- prevent re-adding branding columns by checking for existing fields before adding or dropping

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b17b89bf5c8323aae8680370dd5d4d