### PR TITLE
feat: gate reports navigation by ability

### DIFF
--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -53,6 +53,7 @@ export const menuItems = [
     title: "Reports",
     icon: "heroicons-outline:chart-bar",
     link: "reports.kpis",
+    requiredAbilities: ["reports.view"],
     admin: true,
   },
   {
@@ -143,6 +144,7 @@ export const topMenu = [
     title: "Reports",
     icon: "heroicons-outline:chart-bar",
     link: "reports.kpis",
+    requiredAbilities: ["reports.view"],
     admin: true,
   },
   {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -337,6 +337,7 @@ export const routes = [
       breadcrumb: 'routes.reports',
       title: 'Reports',
       layout: 'app',
+      requiredAbilities: ['reports.view'],
     },
   },
   {
@@ -350,6 +351,7 @@ export const routes = [
       title: 'Reports - KPIs',
       layout: 'app',
       groupParent: 'reports',
+      requiredAbilities: ['reports.view'],
     },
   },
   {


### PR DESCRIPTION
## Summary
- require `reports.view` to see Reports in main and top menus
- gate Reports routes using the same ability

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1808ba6648323b87d676ca5f4b433