### PR TITLE
Log exceptions to stderr

### DIFF
--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -1,6 +1,6 @@
 <?php
 
-use Monolog\Formatter\JsonFormatter;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 
 return [
@@ -19,7 +19,10 @@ return [
             'with' => [
                 'stream' => 'php://stderr',
             ],
-            'formatter' => JsonFormatter::class,
+            'formatter' => LineFormatter::class,
+            'formatter_with' => [
+                'includeStacktraces' => true,
+            ],
             'level' => env('LOG_LEVEL', 'debug'),
         ],
 


### PR DESCRIPTION
## Summary
- output backend logs to `stderr` with stack traces so exceptions show in terminal

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b194c01bf483239059d4d7f76b7714