### PR TITLE
chore: output frontend build to public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ backend/.phpunit.result.cache
 frontend/test-results/
 laravelForReference/
 .env
+public/build/

--- a/backend/app/Providers/RouteServiceProvider.php
+++ b/backend/app/Providers/RouteServiceProvider.php
@@ -24,7 +24,7 @@ class RouteServiceProvider extends ServiceProvider
 
         Route::fallback(function () {
             $candidates = [
-                public_path('index.html'),
+                public_path('build/index.html'),
                 base_path('frontend/index.html'),
             ];
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(({ command }) => ({
     }
   },
   build: {
-    outDir: '../public',
+    outDir: '../public/build',
     emptyOutDir: true,
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- direct Vite build output to `public/build` and clean the directory before building
- serve built index from new location
- ignore compiled frontend assets

## Testing
- `npm test`
- `composer test` *(fails: require(/workspace/asbuild/backend/vendor/autoload.php) failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b19773f384832392cc6bfc760f2a09