### PR TITLE
chore: ensure alt text for images

### DIFF
--- a/frontend/src/components/comments/CommentsThread.vue
+++ b/frontend/src/components/comments/CommentsThread.vue
@@ -18,6 +18,7 @@
           <img
             v-if="hasThumb(file)"
             :src="file.variants.thumb"
+            :alt="file.filename || ''"
             class="w-16 h-16 object-cover rounded"
           />
           <div

--- a/frontend/src/components/settings/BrandingForm.vue
+++ b/frontend/src/components/settings/BrandingForm.vue
@@ -10,7 +10,7 @@
         <input :id="ids.logo" v-bind="getLogoInputProps()" class="hidden" />
         <p v-if="!logoFile && !form.logo">Drop logo here or click to upload</p>
         <p v-else-if="logoFile">{{ logoFile.name }}</p>
-        <img v-else :src="form.logo" class="mx-auto h-24" />
+        <img v-else :src="form.logo" alt="" class="mx-auto h-24" />
       </div>
     </div>
     <div>
@@ -26,7 +26,7 @@
         />
         <p v-if="!logoDarkFile && !form.logo_dark">Drop logo here or click to upload</p>
         <p v-else-if="logoDarkFile">{{ logoDarkFile.name }}</p>
-        <img v-else :src="form.logo_dark" class="mx-auto h-24" />
+        <img v-else :src="form.logo_dark" alt="" class="mx-auto h-24" />
       </div>
     </div>
     <div>

--- a/frontend/src/components/ui/Ecommerce/product-box.vue
+++ b/frontend/src/components/ui/Ecommerce/product-box.vue
@@ -9,6 +9,7 @@
             <img
               class="h-full w-full object-contain transition-all duration-300 group-hover:scale-105"
               :src="product.img"
+              :alt="product?.title || ''"
             />
 
             <Badge

--- a/frontend/src/components/ui/Ecommerce/product-list.vue
+++ b/frontend/src/components/ui/Ecommerce/product-list.vue
@@ -11,6 +11,7 @@
             <img
               class="h-full w-full object-contain transition-all duration-300 group-hover:scale-105"
               :src="product.img"
+              :alt="product?.title || ''"
             />
 
             <Badge

--- a/frontend/src/components/ui/Ecommerce/product-wish.vue
+++ b/frontend/src/components/ui/Ecommerce/product-wish.vue
@@ -11,6 +11,7 @@
             <img
               class="h-full w-full object-contain transition-all duration-300 group-hover:scale-105"
               :src="product.img"
+              :alt="product?.title || ''"
             />
 
             <Badge

--- a/frontend/src/components/ui/Ecommerce/step/cart-step.vue
+++ b/frontend/src/components/ui/Ecommerce/step/cart-step.vue
@@ -39,7 +39,7 @@
                   <div
                     class="md:p-4 p-2 flex-none bg-slate-200 rounded md:h-20 md:w-20 w-16 h-16 rtl:ml-3"
                   >
-                    <img class="w-full h-full object-contain" :src="item.img" />
+                    <img class="w-full h-full object-contain" :src="item.img" :alt="item?.title || ''" />
                   </div>
                   <div>
                     <p

--- a/frontend/src/components/ui/Ecommerce/step/delivery-info.vue
+++ b/frontend/src/components/ui/Ecommerce/step/delivery-info.vue
@@ -13,7 +13,7 @@
               <div
                 class="md:p-4 p-2 flex-none bg-slate-200 rounded md:h-20 md:w-20 w-16 h-16 rtl:ml-3"
               >
-                <img class="w-full h-full object-contain" :src="item.img" />
+                <img class="w-full h-full object-contain" :src="item.img" :alt="item?.title || ''" />
               </div>
               <div class="md:text-base text-sm">
                 <p

--- a/frontend/src/components/ui/Ecommerce/step/invoice-cart.vue
+++ b/frontend/src/components/ui/Ecommerce/step/invoice-cart.vue
@@ -126,6 +126,7 @@
                         <img
                           class="w-full h-full object-contain"
                           :src="item.img"
+                          :alt="item?.title || ''"
                         />
                       </div>
                       <div>

--- a/frontend/src/components/ui/Ecommerce/step/payment.vue
+++ b/frontend/src/components/ui/Ecommerce/step/payment.vue
@@ -34,7 +34,7 @@
                       <img
                         class="h-full w-full object-cover"
                         :src="item.img"
-                        alt=""
+                        :alt="item.value || ''"
                       />
                     </div>
                     <p class="pt-2 uppercase text-sm md:text-base">

--- a/frontend/src/components/ui/Ecommerce/thumb-slider.vue
+++ b/frontend/src/components/ui/Ecommerce/thumb-slider.vue
@@ -19,7 +19,7 @@
       <img
         class="h-full w-full object-contain transition-all duration-300 group-hover:scale-105"
         :src="image"
-        alt="."
+        :alt="product?.title || ''"
       />
     </SwiperSlide>
   </Swiper>
@@ -40,7 +40,7 @@
         :key="i"
         class="h-[90px] w-[90px] py-[14px] px-[17px] bg-secondary-200 rounded"
       >
-        <img class="h-full w-full object-contain" :src="image" alt="." />
+        <img class="h-full w-full object-contain" :src="image" :alt="product?.title || ''" />
       </SwiperSlide>
     </Swiper>
   </div>

--- a/frontend/src/components/ui/Fileinput/index.vue
+++ b/frontend/src/components/ui/Fileinput/index.vue
@@ -68,7 +68,7 @@
           <img
             :src="url"
             class="w-full object-cover h-full block rounded"
-            :alt="selectedFile?.name"
+            :alt="selectedFile?.name || ''"
           />
         </div>
 
@@ -84,7 +84,7 @@
             <img
               :src="url"
               class="object-cover w-full h-full rounded"
-              :alt="selectedFile?.name"
+              :alt="selectedFile?.name || ''"
             />
           </div>
         </div>

--- a/frontend/src/components/ui/Header/Cart/cart-item.vue
+++ b/frontend/src/components/ui/Header/Cart/cart-item.vue
@@ -2,7 +2,7 @@
   <div class="flex space-x-4 rtl:space-x-reverse pt-4">
     <div class="flex-none">
       <div class="md:w-20 md:h-20 w-14 h-14 bg-slate-200 rounded">
-        <img :src="props.item.img" class="w-full h-full object-cover p-3" />
+        <img :src="props.item.img" :alt="props.item?.title || ''" class="w-full h-full object-cover p-3" />
       </div>
     </div>
     <div class="flex-1 space-y-1 truncate">

--- a/frontend/src/components/ui/Header/Navtools/Logo.vue
+++ b/frontend/src/components/ui/Header/Navtools/Logo.vue
@@ -3,12 +3,12 @@
     <img
       v-if="!themeSettingsStore.isDark"
       :src="branding.branding.logo || logoLight"
-      alt=""
+      :alt="alt || ''"
     />
     <img
       v-else
       :src="branding.branding.logo_dark || logoDark"
-      alt=""
+      :alt="alt || ''"
     />
   </router-link>
 </template>
@@ -20,4 +20,11 @@ import logoDark from '@/assets/images/logo/logo-white.svg';
 
 const themeSettingsStore = useThemeSettingsStore();
 const branding = useBrandingStore();
+const props = defineProps({
+  alt: {
+    type: String,
+    default: '',
+  },
+});
+const { alt } = props;
 </script>

--- a/frontend/src/components/ui/Header/Navtools/Message.vue
+++ b/frontend/src/components/ui/Header/Navtools/Message.vue
@@ -53,7 +53,7 @@
                   ></span>
                   <img
                     :src="item.image"
-                    alt=""
+                    :alt="item.title || ''"
                     class="block w-full h-full object-cover rounded-full border hover:border-white border-transparent"
                   />
                 </div>

--- a/frontend/src/components/ui/Header/Navtools/MobileLogo.vue
+++ b/frontend/src/components/ui/Header/Navtools/MobileLogo.vue
@@ -3,13 +3,13 @@
     <img
       v-if="!themeSettingsStore.isDark"
       :src="branding.branding.logo || logoLight"
-      alt=""
+      :alt="alt || ''"
       class="h-8"
     />
     <img
       v-else
       :src="branding.branding.logo_dark || logoDark"
-      alt=""
+      :alt="alt || ''"
       class="h-8"
     />
   </router-link>
@@ -22,4 +22,11 @@ import logoDark from '@/assets/images/logo/logo-c-white.svg';
 
 const themeSettingsStore = useThemeSettingsStore();
 const branding = useBrandingStore();
+const props = defineProps({
+  alt: {
+    type: String,
+    default: '',
+  },
+});
+const { alt } = props;
 </script>

--- a/frontend/src/components/ui/Header/Navtools/Notification.vue
+++ b/frontend/src/components/ui/Header/Navtools/Notification.vue
@@ -45,7 +45,7 @@
                 <div class="h-8 w-8 bg-white rounded-full">
                   <img
                     :src="item.image"
-                    alt=""
+                    :alt="item.title || ''"
                     :class="`${
                       active ? ' border-white' : ' border-transparent'
                     } block w-full h-full object-cover rounded-full border`"

--- a/frontend/src/components/ui/Image/index.vue
+++ b/frontend/src/components/ui/Image/index.vue
@@ -27,7 +27,7 @@ export default {
     },
     alt: {
       type: String,
-      default: 'image title',
+      default: '',
     },
     imageClass: {
       type: String,

--- a/frontend/src/views/appointments/AppointmentDetails.vue
+++ b/frontend/src/views/appointments/AppointmentDetails.vue
@@ -47,6 +47,7 @@
                 <img
                   v-if="hasThumb(photo.file)"
                   :src="photo.file.variants.thumb"
+                  :alt="photo.file?.filename || ''"
                   class="w-24 h-24 object-cover rounded"
                 />
                 <div


### PR DESCRIPTION
## Summary
- add configurable alt props to header logos
- supply meaningful alt text across ecommerce components
- set default empty alt in base Image component

## Testing
- `npm test`
- `npm run lint` *(fails: Form label must have an associated control)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a6d8c2948323880d00c3df2454cd