### PR TITLE
feat: sanitize rich HTML with DOMPurify

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "frontend",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@fullcalendar/core": "6.0.3",
         "@fullcalendar/daygrid": "6.0.3",
@@ -34,6 +34,7 @@
         "vue": "^3.5.20",
         "vue-chartjs": "5.3.1",
         "vue-cleave-component": "^3.0.2",
+        "vue-dompurify-html": "^3.1.2",
         "vue-flatpickr-component": "^9",
         "vue-good-table-next": "^0.2.2",
         "vue-i18n": "11.1.10",
@@ -2099,32 +2100,6 @@
         }
       }
     },
-    "node_modules/@tanstack/vue-query/node_modules/vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@tanstack/vue-virtual": {
       "version": "3.13.12",
       "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.12.tgz",
@@ -3662,6 +3637,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -6664,32 +6645,6 @@
         "vue": ">=2.5.17"
       }
     },
-    "node_modules/simplebar-vue/node_modules/vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7710,6 +7665,45 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-dompurify-html": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vue-dompurify-html/-/vue-dompurify-html-3.1.2.tgz",
+      "integrity": "sha512-2xCnSuog5+OPUtmeAwPZY/6oV9YKuLhjgcl5EUw3jKbmhnyPo8YyCczCeRNGBorVcz1fCGm6PEOIUSXNS8I0ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^2.3.4",
+        "vue-demi": "^0.13.2"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
       }
     },
     "node_modules/vue-eslint-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "vue": "^3.5.20",
     "vue-chartjs": "5.3.1",
     "vue-cleave-component": "^3.0.2",
+    "vue-dompurify-html": "^3.1.2",
     "vue-flatpickr-component": "^9",
     "vue-good-table-next": "^0.2.2",
     "vue-i18n": "11.1.10",

--- a/frontend/src/components/datatable/DashcodeServerTable.vue
+++ b/frontend/src/components/datatable/DashcodeServerTable.vue
@@ -65,7 +65,7 @@
                 :key="col.field"
                 class="table-td"
               >
-                <span v-if="col.html" v-html="row[col.field]" />
+                <span v-if="col.html" v-dompurify-html="row[col.field]" />
                 <span v-else>{{ row[col.field] }}</span>
               </td>
               <td v-if="hasActions" class="table-td">

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,6 +24,7 @@ import "v-calendar/dist/style.css";
 import { VueQueryPlugin } from "@tanstack/vue-query";
 import { useThemeSettingsStore } from "./stores/themeSettings";
 import { useBrandingStore } from "./stores/branding";
+import VueDOMPurifyHTML from "vue-dompurify-html";
 
 const app = createApp(App)
   .use(stores)
@@ -39,7 +40,8 @@ const app = createApp(App)
   .use(VueGoodTablePlugin)
   .use(VueApexCharts)
   .use(PerfectScrollbar)
-  .use(VCalendar);
+  .use(VCalendar)
+  .use(VueDOMPurifyHTML);
 
 app.use(VueQueryPlugin);
 


### PR DESCRIPTION
## Summary
- register vue-dompurify-html plugin and use sanitized directive
- replace v-html usage with v-dompurify-html
- add vue-dompurify-html dependency

## Testing
- `npm test`
- `npm run lint` *(fails: 88 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab069a688323a4d3239235b60076