### PR TITLE
fix: reorder component options and resolve template shadow

### DIFF
--- a/frontend/src/components/ui/Header/index.vue
+++ b/frontend/src/components/ui/Header/index.vue
@@ -78,6 +78,7 @@ import TenantSwitcher from "@/components/admin/TenantSwitcher.vue";
 import { useAuthStore } from "@/stores/auth";
 
 export default {
+  name: "Header",
   components: {
     Profile,
     Notification,

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="max-w-2xl mx-auto">
     <Tabs v-model="active" :tabs="tabs">
-      <template #default="{ active }">
-        <div v-if="active === 'profile'">
+      <template #default="{ active: slotActive }">
+        <div v-if="slotActive === 'profile'">
           <ProfileForm />
         </div>
-        <div v-else-if="active === 'branding'">
+        <div v-else-if="slotActive === 'branding'">
           <BrandingForm />
         </div>
-        <div v-else-if="active === 'footer'">
+        <div v-else-if="slotActive === 'footer'">
           <FooterForm />
         </div>
-        <div v-else-if="active === 'notifications'" class="space-y-4">
+        <div v-else-if="slotActive === 'notifications'" class="space-y-4">
           <div
             v-for="pref in prefs"
             :key="pref.category"
@@ -28,7 +28,7 @@
             >Save</Button
           >
         </div>
-        <div v-else-if="active === 'gdpr'" class="space-y-4">
+        <div v-else-if="slotActive === 'gdpr'" class="space-y-4">
           <router-link class="text-primary-500 underline" to="/gdpr"
             >Manage your data</router-link
           >


### PR DESCRIPTION
## Summary
- add explicit name and reorder options in Header component
- rename slot variable to avoid template shadow in SettingsView

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ac377dd08323956c90fbb4d6b019