### PR TITLE
fix: improve accessibility labels and focus

### DIFF
--- a/frontend/src/components/layout/CommandPalette.vue
+++ b/frontend/src/components/layout/CommandPalette.vue
@@ -15,7 +15,13 @@
       ref="panel"
       class="relative z-10 w-full max-w-md rounded-2xl bg-background p-4 shadow-lg"
     >
+      <label
+        for="command-palette-search"
+        class="sr-only"
+        >{{ t('commandPalette.placeholder') }}</label
+      >
       <input
+        id="command-palette-search"
         ref="input"
         v-model="query"
         type="text"
@@ -34,7 +40,9 @@
               i === index ? 'bg-foreground/10' : '',
             ]"
             @mouseenter="index = i"
+            @mouseleave="index = -1"
             @focusin="index = i"
+            @focusout="index = -1"
             @click="select(a)"
           >
             {{ a.label }}

--- a/frontend/src/components/ui/Checkbox/index.vue
+++ b/frontend/src/components/ui/Checkbox/index.vue
@@ -1,21 +1,20 @@
 <template>
   <div>
-    <input
-      :id="inputId"
-      v-model="localValue"
-      type="checkbox"
-      class="hidden"
-      :disabled="disabled"
-      :name="name"
-      :value="value"
-      v-bind="$attrs"
-      @change="onChange"
-    />
     <label
-      class="flex items-center"
-      :for="inputId"
       :class="disabled ? ' cursor-not-allowed opacity-50' : 'cursor-pointer'"
+      class="flex items-center"
     >
+      <input
+        :id="inputId"
+        v-model="localValue"
+        type="checkbox"
+        class="hidden"
+        :disabled="disabled"
+        :name="name"
+        :value="value"
+        v-bind="$attrs"
+        @change="onChange"
+      />
       <span
         class="h-4 w-4 border flex-none border-slate-100 dark:border-slate-800 rounded inline-flex ltr:mr-3 rtl:ml-3 relative transition-all duration-150"
         :class="

--- a/frontend/src/components/ui/Pagination/index.vue
+++ b/frontend/src/components/ui/Pagination/index.vue
@@ -27,15 +27,15 @@
       </div>
 
       <div v-if="enableSearch && enableSelect" class="flex items-center">
+        <label :for="ids.select" class="text-sm">Page</label>
         <Select
+          :id="ids.select"
           v-model.number="input2"
           placeholder="Go"
-          label="Page"
           classInput=" w-[60px] h-9 "
           :options="options"
           @change="changePage(input2)"
-        >
-        </Select>
+        />
 
         <span class="text-sm text-slate-500 inline-block ltr:ml-2 rtl:mr-2">
           of {{ perPage }} entries</span
@@ -188,6 +188,7 @@ export default defineComponent({
       input2: null,
       ids: {
         page: 'pagination-page',
+        select: 'pagination-select',
       },
     };
   },

--- a/frontend/src/components/ui/Radio/index.vue
+++ b/frontend/src/components/ui/Radio/index.vue
@@ -1,21 +1,20 @@
 <template>
   <div>
-    <input
-      :id="inputId"
-      v-model="localValue"
-      type="radio"
-      class="hidden"
-      :disabled="disabled"
-      :name="name"
-      :value="value"
-      v-bind="$attrs"
-      @change="onChange"
-    />
     <label
-      class="flex items-center"
-      :for="inputId"
       :class="disabled ? ' cursor-not-allowed opacity-50' : 'cursor-pointer'"
+      class="flex items-center"
     >
+      <input
+        :id="inputId"
+        v-model="localValue"
+        type="radio"
+        class="hidden"
+        :disabled="disabled"
+        :name="name"
+        :value="value"
+        v-bind="$attrs"
+        @change="onChange"
+      />
       <span
         :class="
           localValue === value

--- a/frontend/src/components/ui/Sidebar/index.vue
+++ b/frontend/src/components/ui/Sidebar/index.vue
@@ -9,6 +9,7 @@
       ${$store.themeSettingsStore.isMouseHovered ? 'sidebar-hovered' : ''}
 
       `"
+      tabindex="0"
       @mouseenter="$store.themeSettingsStore.isMouseHovered = true"
       @mouseleave="$store.themeSettingsStore.isMouseHovered = false"
       @focusin="$store.themeSettingsStore.isMouseHovered = true"

--- a/frontend/src/components/ui/Switch/index.vue
+++ b/frontend/src/components/ui/Switch/index.vue
@@ -1,21 +1,20 @@
 <template>
   <div>
-    <input
-      :id="inputId"
-      v-model="localValue"
-      type="checkbox"
-      class="hidden"
-      :disabled="disabled"
-      :name="name"
-      :value="value"
-      v-bind="$attrs"
-      @change="onChange"
-    />
     <label
       class="flex items-start"
-      :for="inputId"
       :class="disabled ? ' cursor-not-allowed opacity-40' : 'cursor-pointer'"
     >
+      <input
+        :id="inputId"
+        v-model="localValue"
+        type="checkbox"
+        class="hidden"
+        :disabled="disabled"
+        :name="name"
+        :value="value"
+        v-bind="$attrs"
+        @change="onChange"
+      />
       <div
         :class="ck ? activeClass : 'bg-secondary-500'"
         class="relative inline-flex h-6 w-[46px] ltr:mr-3 rtl:ml-3 items-center rounded-full transition-all duration-150"

--- a/frontend/src/views/appointments/AppointmentsList.vue
+++ b/frontend/src/views/appointments/AppointmentsList.vue
@@ -12,25 +12,25 @@
       </div>
     <div class="flex gap-4 mb-4">
       <div class="flex flex-col">
-        <label :for="ids.status" class="mb-1 text-sm">Status</label>
-        <select :id="ids.status" v-model="statusFilter" class="border rounded p-2">
+        <label for="appointments-status" class="mb-1 text-sm">Status</label>
+        <select id="appointments-status" v-model="statusFilter" class="border rounded p-2">
           <option value="">All Statuses</option>
           <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
         </select>
       </div>
       <div class="flex flex-col">
-        <label :for="ids.start" class="mb-1 text-sm">Start Date</label>
+        <label for="appointments-start" class="mb-1 text-sm">Start Date</label>
         <input
-          :id="ids.start"
+          id="appointments-start"
           v-model="startDate"
           type="date"
           class="border rounded p-2"
         />
       </div>
       <div class="flex flex-col">
-        <label :for="ids.end" class="mb-1 text-sm">End Date</label>
+        <label for="appointments-end" class="mb-1 text-sm">End Date</label>
         <input
-          :id="ids.end"
+          id="appointments-end"
           v-model="endDate"
           type="date"
           class="border rounded p-2"
@@ -98,11 +98,6 @@ const statusFilter = ref('');
 const startDate = ref('');
 const endDate = ref('');
 const tableKey = ref(0);
-const ids = {
-  status: 'appointments-status',
-  start: 'appointments-start',
-  end: 'appointments-end',
-};
 
 const statusOptions = ref<string[]>([]);
 

--- a/frontend/src/views/appointments/AttachmentPanel.vue
+++ b/frontend/src/views/appointments/AttachmentPanel.vue
@@ -1,8 +1,8 @@
 <template>
   <Card>
     <div class="mb-4">
-      <label :for="ids.file" class="block mb-1">Attachment</label>
-      <input :id="ids.file" type="file" @change="onFileChange" />
+      <label for="attachment-file" class="block mb-1">Attachment</label>
+      <input id="attachment-file" type="file" @change="onFileChange" />
     </div>
     <ul class="text-sm">
       <li v-for="att in attachments" :key="att.id">
@@ -20,7 +20,6 @@ import Card from '@/components/ui/Card/index.vue';
 
 const props = defineProps<{ appointmentId: number }>();
 const attachments = ref<any[]>([]);
-const ids = { file: 'attachment-file' };
 
 async function load() {
   const { data } = await api.get(`/appointments/${props.appointmentId}`);

--- a/frontend/src/views/appointments/CalendarView.vue
+++ b/frontend/src/views/appointments/CalendarView.vue
@@ -2,29 +2,29 @@
   <div>
     <div class="flex gap-4 mb-4">
       <div class="flex flex-col">
-        <label :for="ids.status" class="mb-1 text-sm">Status</label>
-        <select :id="ids.status" v-model="statusId" class="border rounded p-2">
+        <label for="calendar-status" class="mb-1 text-sm">Status</label>
+        <select id="calendar-status" v-model="statusId" class="border rounded p-2">
           <option value="">All Statuses</option>
           <option v-for="s in statusOptions" :key="s.id" :value="s.id">{{ s.name }}</option>
         </select>
       </div>
       <div class="flex flex-col">
-        <label :for="ids.type" class="mb-1 text-sm">Type</label>
-        <select :id="ids.type" v-model="typeId" class="border rounded p-2">
+        <label for="calendar-type" class="mb-1 text-sm">Type</label>
+        <select id="calendar-type" v-model="typeId" class="border rounded p-2">
           <option value="">All Types</option>
           <option v-for="t in typeOptions" :key="t.id" :value="t.id">{{ t.name }}</option>
         </select>
       </div>
       <div class="flex flex-col">
-        <label :for="ids.team" class="mb-1 text-sm">Team</label>
-        <select :id="ids.team" v-model="teamId" class="border rounded p-2">
+        <label for="calendar-team" class="mb-1 text-sm">Team</label>
+        <select id="calendar-team" v-model="teamId" class="border rounded p-2">
           <option value="">All Teams</option>
           <option v-for="t in teamOptions" :key="t.id" :value="t.id">{{ t.label || t.name }}</option>
         </select>
       </div>
       <div class="flex flex-col">
-        <label :for="ids.employee" class="mb-1 text-sm">Employee</label>
-        <select :id="ids.employee" v-model="employeeId" class="border rounded p-2">
+        <label for="calendar-employee" class="mb-1 text-sm">Employee</label>
+        <select id="calendar-employee" v-model="employeeId" class="border rounded p-2">
           <option value="">All Employees</option>
           <option v-for="e in employeeOptions" :key="e.id" :value="e.id">{{ e.label || e.name }}</option>
         </select>
@@ -84,12 +84,6 @@ const statusId = ref('');
 const typeId = ref('');
 const teamId = ref('');
 const employeeId = ref('');
-const ids = {
-  status: 'calendar-status',
-  type: 'calendar-type',
-  team: 'calendar-team',
-  employee: 'calendar-employee',
-};
 
 onMounted(async () => {
   statusOptions.value = await statusStore.fetch('tenant');

--- a/frontend/src/views/appointments/StatusChanger.vue
+++ b/frontend/src/views/appointments/StatusChanger.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="flex items-center gap-2">
+    <label for="status-changer-select" class="sr-only">Status</label>
     <Select
+      id="status-changer-select"
       v-model="selected"
       :options="options"
       placeholder="Change status"
-      label="Status"
       classInput="min-w-[160px]"
     />
     <Button

--- a/frontend/src/views/auth/dashcode/common/Signin.vue
+++ b/frontend/src/views/auth/dashcode/common/Signin.vue
@@ -21,12 +21,16 @@
     />
 
     <div class="flex justify-between">
-      <label class="cursor-pointer flex items-start">
-        <input
-          type="checkbox"
-          class="hidden"
-          @change="() => (checkbox = !checkbox)"
-        />
+      <input
+        id="signin-remember"
+        type="checkbox"
+        class="hidden"
+        @change="() => (checkbox = !checkbox)"
+      />
+      <label
+        for="signin-remember"
+        class="cursor-pointer flex items-start"
+      >
         <span
           class="h-4 w-4 border rounded flex-none inline-flex mr-3 relative top-1 transition-all duration-150"
           :class="

--- a/frontend/src/views/auth/dashcode/common/Signup.vue
+++ b/frontend/src/views/auth/dashcode/common/Signup.vue
@@ -29,12 +29,13 @@
       classInput="h-[48px]"
     />
 
-    <label class="cursor-pointer flex items-start">
-      <input
-        type="checkbox"
-        class="hidden"
-        @change="() => (checkbox = !checkbox)"
-      />
+    <input
+      id="signup-accept"
+      type="checkbox"
+      class="hidden"
+      @change="() => (checkbox = !checkbox)"
+    />
+    <label for="signup-accept" class="cursor-pointer flex items-start">
       <span
         class="h-4 w-4 border rounded inline-flex mr-3 relative flex-none top-1 transition-all duration-150"
         :class="

--- a/frontend/src/views/auth/dashcode/common/Social.vue
+++ b/frontend/src/views/auth/dashcode/common/Social.vue
@@ -3,33 +3,37 @@
     <li class="flex-1">
       <a
         href="#"
+        aria-label="Twitter"
         class="inline-flex h-10 w-10 bg-[#1C9CEB] text-white text-2xl flex-col items-center justify-center rounded-full"
       >
-        <img src="@/assets/images/icon/tw.svg" alt="" />
+        <img src="@/assets/images/icon/tw.svg" alt="Twitter" />
       </a>
     </li>
     <li class="flex-1">
       <a
         href="#"
+        aria-label="Facebook"
         class="inline-flex h-10 w-10 bg-[#395599] text-white text-2xl flex-col items-center justify-center rounded-full"
       >
-        <img src="@/assets/images/icon/fb.svg" alt="" />
+        <img src="@/assets/images/icon/fb.svg" alt="Facebook" />
       </a>
     </li>
     <li class="flex-1">
       <a
         href="#"
+        aria-label="LinkedIn"
         class="inline-flex h-10 w-10 bg-[#0A63BC] text-white text-2xl flex-col items-center justify-center rounded-full"
       >
-        <img src="@/assets/images/icon/in.svg" alt="" />
+        <img src="@/assets/images/icon/in.svg" alt="LinkedIn" />
       </a>
     </li>
     <li class="flex-1">
       <a
         href="#"
+        aria-label="Google"
         class="inline-flex h-10 w-10 bg-[#EA4335] text-white text-2xl flex-col items-center justify-center rounded-full"
       >
-        <img src="@/assets/images/icon/gp.svg" alt="" />
+        <img src="@/assets/images/icon/gp.svg" alt="Google" />
       </a>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- add search field label and keyboard hover handling for CommandPalette
- expose sidebar wrapper to keyboard focus
- wire explicit labels and ids for pagination and appointment filters
- ensure auth checkboxes and social links have accessible labels

## Testing
- `pnpm run lint` *(fails: 90 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b1af3fb9e08323b31ea18955a3b739