### PR TITLE
chore: add frontend lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Install pnpm
+        run: npm install -g pnpm
       - name: Install dependencies
         run: npm ci
+      - name: Run lint
+        run: pnpm run ci:lint
       - name: Run tests
         run: npm test

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "test": "vitest run tests/unit tests/*.test.ts && playwright test tests/e2e",
     "lint": "eslint --ext .vue,.js,.ts src",
     "lint:fix": "eslint --ext .vue,.js,.ts src --fix",
+    "precommit": "pnpm run lint",
+    "ci:lint": "pnpm run lint",
     "format": "prettier --write .",
     "gen:api:types": "openapi-typescript ../backend/docs/openapi.yaml -o src/types/api.d.ts"
   },


### PR DESCRIPTION
## Summary
- ensure frontend lint runs in CI to catch a11y issues
- wire up precommit/ci scripts for pnpm linting

## Testing
- `pnpm run ci:lint` *(fails: numerous existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b1bb7b14832391b8f00e14ea8790