### PR TITLE
feat: normalize input validation

### DIFF
--- a/frontend/src/components/ui/Checkbox/index.vue
+++ b/frontend/src/components/ui/Checkbox/index.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    class="relative"
+    :class="`${errorText ? 'has-error' : ''}  ${showSuccessIcon ? 'is-valid' : ''}`"
+  >
     <label
       :class="disabled ? ' cursor-not-allowed opacity-50' : 'cursor-pointer'"
       class="flex items-center"
@@ -37,47 +40,57 @@
         {{ label }}
       </span>
       <slot name="labelHtml"></slot>
+      <span v-if="showSuccessIcon" class="text-success-500 ltr:ml-2 rtl:mr-2">
+        <Icon icon="bi:check-lg" />
+      </span>
     </label>
+    <p
+      v-if="errorText"
+      class="mt-1 text-danger-500 text-sm whitespace-pre-line"
+    >
+      {{ errorText }}
+    </p>
+    <p v-if="successText" class="mt-1 text-success-500 text-sm">
+      {{ successText }}
+    </p>
+    <span
+      v-if="description"
+      class="block text-secondary-500 font-light leading-4 text-xs mt-2"
+      >{{ description }}</span
+    >
   </div>
 </template>
 <script>
+import Icon from "@/components/Icon";
 import { computed, defineComponent, ref } from "vue";
 export default defineComponent({
   name: "Checkbox",
+  components: { Icon },
   inheritAttrs: false,
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "checkbox",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
-    checked: {
-      type: Boolean,
-      default: false,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
+    // incoming error could be string or array from backend/lib
+    error: { type: [String, Array, Object, Boolean], default: "" },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
+    validate: { type: [Boolean, String, Array, Object], default: false },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    name: { type: String, default: "checkbox" },
+    id: { type: String, default: "" },
+    description: { type: String, default: "" },
+    checked: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
     activeClass: {
       type: String,
       default:
         " ring-black-500  bg-slate-900 dark:bg-slate-700 dark:ring-slate-700 ",
     },
-    value: {
-      type: null,
-    },
+    value: { type: null },
   },
   emits: ["update:modelValue", "input", "change"],
 
@@ -97,7 +110,40 @@ export default defineComponent({
       set: (newValue) => context.emit("update:modelValue", newValue),
     });
 
-    return { localValue, ck, onChange, inputId };
+    // normalize error to string
+    const errorText = computed(() => {
+      const e = props.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    });
+    // determine whether validation UI should show
+    const validationEnabled = computed(
+      () => props.showValidation || !!props.validate
+    );
+    // success text comes only from dedicated prop or legacy when string
+    const successText = computed(() => {
+      if (props.successMessage) return props.successMessage;
+      if (typeof props.validate === "string") return props.validate;
+      return "";
+    });
+    // success icon shows only if validation is enabled and there is no error
+    const showSuccessIcon = computed(
+      () => validationEnabled.value && !errorText.value
+    );
+
+    return {
+      localValue,
+      ck,
+      onChange,
+      inputId,
+      errorText,
+      successText,
+      showSuccessIcon,
+      description: props.description,
+    };
   },
 });
 </script>

--- a/frontend/src/components/ui/FromGroup/index.vue
+++ b/frontend/src/components/ui/FromGroup/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     class="fromGroup relative"
-    :class="`${error ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
-      validate ? 'is-valid' : ''
+    :class="`${errorText ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
+      showSuccessIcon ? 'is-valid' : ''
     } `"
   >
     <label
@@ -16,26 +16,28 @@
       <slot :input-id="inputId"></slot>
     </div>
 
-    <span
-      v-if="error"
+    <p
+      v-if="errorText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-danger-500 text-white text-[10px] px-2 py-1 rounded'
-          : ' text-danger-500 block text-sm'
+          : ' text-danger-500 block text-sm whitespace-pre-line'
       "
-      >{{ error }}</span
     >
-    <span
-      v-if="validate"
+      {{ errorText }}
+    </p>
+    <p
+      v-if="successText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-success-500 text-white text-[10px] px-2 py-1 rounded'
           : ' text-success-500 block text-sm'
       "
-      >{{ validate }}</span
     >
+      {{ successText }}
+    </p>
     <span
       v-if="description"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
@@ -47,49 +49,25 @@
 export default {
   components: {},
   props: {
-    label: {
-      type: String,
+    modelValue: {
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    classLabel: {
-      type: String,
-      default: " ",
-    },
-    classInput: {
-      type: String,
-      default: "classinput",
-    },
-
-    name: {
-      type: String,
-      default: "",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
-    error: {
-      type: [String, Boolean],
-      default: "",
-    },
-
-    horizontal: {
-      type: Boolean,
-      default: false,
-    },
-    validate: {
-      type: [Array, String, Function],
-      default: () => [],
-    },
-    msgTooltip: {
-      type: Boolean,
-      default: false,
-    },
-
-    description: {
-      type: String,
-      default: "",
-    },
+    // incoming error could be string or array from backend/lib
+    error: { type: [String, Array, Object, Boolean], default: "" },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
+    validate: { type: [Boolean, String, Array, Object], default: false },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    classLabel: { type: String, default: " " },
+    classInput: { type: String, default: "classinput" },
+    name: { type: String, default: "" },
+    id: { type: String, default: "" },
+    description: { type: String, default: "" },
+    horizontal: { type: Boolean, default: false },
+    msgTooltip: { type: Boolean, default: false },
   },
   data() {
     return {
@@ -99,6 +77,29 @@ export default {
   computed: {
     inputId() {
       return this.id || this.generatedId;
+    },
+    // normalize error to string
+    errorText() {
+      const e = this.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    },
+    // determine whether validation UI should show
+    validationEnabled() {
+      return this.showValidation || !!this.validate;
+    },
+    // success text comes only from dedicated prop or legacy when string
+    successText() {
+      if (this.successMessage) return this.successMessage;
+      if (typeof this.validate === "string") return this.validate;
+      return "";
+    },
+    // success icon shows only if validation is enabled and there is no error
+    showSuccessIcon() {
+      return this.validationEnabled && !this.errorText;
     },
   },
 };

--- a/frontend/src/components/ui/Radio/index.vue
+++ b/frontend/src/components/ui/Radio/index.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    class="relative"
+    :class="`${errorText ? 'has-error' : ''}  ${showSuccessIcon ? 'is-valid' : ''}`"
+  >
     <label
       :class="disabled ? ' cursor-not-allowed opacity-50' : 'cursor-pointer'"
       class="flex items-center"
@@ -31,46 +34,53 @@
       >
         {{ label }}
       </span>
+      <span v-if="showSuccessIcon" class="text-success-500 ltr:ml-2 rtl:mr-2">
+        <Icon icon="bi:check-lg" />
+      </span>
     </label>
+    <p
+      v-if="errorText"
+      class="mt-1 text-danger-500 text-sm whitespace-pre-line"
+    >
+      {{ errorText }}
+    </p>
+    <p v-if="successText" class="mt-1 text-success-500 text-sm">
+      {{ successText }}
+    </p>
+    <span
+      v-if="description"
+      class="block text-secondary-500 font-light leading-4 text-xs mt-2"
+      >{{ description }}</span
+    >
   </div>
 </template>
 <script>
+import Icon from "@/components/Icon";
 import { computed, defineComponent, ref } from "vue";
 export default defineComponent({
   name: "Radio",
+  components: { Icon },
   inheritAttrs: false,
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "checkbox",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
-    checked: {
-      type: Boolean,
-      default: false,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    activeClass: {
-      type: String,
-      default: "ring-slate-500 dark:ring-slate-400",
-    },
-    value: {
-      type: null,
-    },
+    // incoming error could be string or array from backend/lib
+    error: { type: [String, Array, Object, Boolean], default: "" },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
+    validate: { type: [Boolean, String, Array, Object], default: false },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    name: { type: String, default: "checkbox" },
+    id: { type: String, default: "" },
+    description: { type: String, default: "" },
+    checked: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    activeClass: { type: String, default: "ring-slate-500 dark:ring-slate-400" },
+    value: { type: null },
   },
   emits: ["update:modelValue", "input", "change"],
 
@@ -90,7 +100,40 @@ export default defineComponent({
       set: (newValue) => context.emit("update:modelValue", newValue),
     });
 
-    return { localValue, ck, onChange, inputId };
+    // normalize error to string
+    const errorText = computed(() => {
+      const e = props.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    });
+    // determine whether validation UI should show
+    const validationEnabled = computed(
+      () => props.showValidation || !!props.validate
+    );
+    // success text comes only from dedicated prop or legacy when string
+    const successText = computed(() => {
+      if (props.successMessage) return props.successMessage;
+      if (typeof props.validate === "string") return props.validate;
+      return "";
+    });
+    // success icon shows only if validation is enabled and there is no error
+    const showSuccessIcon = computed(
+      () => validationEnabled.value && !errorText.value
+    );
+
+    return {
+      localValue,
+      ck,
+      onChange,
+      inputId,
+      errorText,
+      successText,
+      showSuccessIcon,
+      description: props.description,
+    };
   },
 });
 </script>

--- a/frontend/src/components/ui/Select/VueSelect.vue
+++ b/frontend/src/components/ui/Select/VueSelect.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     class="fromGroup relative"
-    :class="`${error ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
-      validate ? 'is-valid' : ''
+    :class="`${errorText ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
+      showSuccessIcon ? 'is-valid' : ''
     } `"
   >
     <label
@@ -18,10 +18,8 @@
           :id="inputId"
           :name="name"
           :modelValue="modelValue"
-          :error="error"
           :readonly="isReadonly"
           :disabled="disabled"
-          :validate="validate"
           :multiple="multiple"
           :options="options"
           @update:model-value="$emit('update:modelValue', $event)"
@@ -32,36 +30,36 @@
       </div>
       <slot :input-id="inputId"></slot>
       <div class="flex text-xl absolute right-[14px] top-1/2 -translate-y-1/2">
-        <span v-if="error" class="text-danger-500">
+        <span v-if="errorText" class="text-danger-500">
           <Icon icon="heroicons-outline:information-circle" />
         </span>
-
-        <span v-if="validate" class="text-success-500">
+        <span v-if="showSuccessIcon" class="text-success-500">
           <Icon icon="bi:check-lg" />
         </span>
       </div>
     </div>
-
-    <span
-      v-if="error"
+    <p
+      v-if="errorText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-danger-500 text-white text-[10px] px-2 py-1 rounded'
-          : ' text-danger-500 block text-sm'
+          : ' text-danger-500 block text-sm whitespace-pre-line'
       "
-      >{{ error }}</span
     >
-    <span
-      v-if="validate"
+      {{ errorText }}
+    </p>
+    <p
+      v-if="successText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-success-500 text-white text-[10px] px-2 py-1 rounded'
           : ' text-success-500 block text-sm'
       "
-      >{{ validate }}</span
     >
+      {{ successText }}
+    </p>
     <span
       v-if="description"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
@@ -80,71 +78,35 @@ export default {
   },
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
+    // incoming error could be string or array from backend/lib
     error: {
-      type: [String, Boolean],
+      type: [String, Array, Object, Boolean],
       default: "",
     },
-    description: {
-      type: String,
-      default: "",
-    },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
     validate: {
-      type: [Array, String, Function],
-      default: () => [],
-    },
-    placeholder: {
-      type: String,
-      default: "Select Option",
-    },
-    classLabel: {
-      type: String,
-      default: " ",
-    },
-    classInput: {
-      type: String,
-      default: "classinput",
-    },
-
-    isReadonly: {
-      type: Boolean,
+      type: [Boolean, String, Array, Object],
       default: false,
     },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    horizontal: {
-      type: Boolean,
-      default: false,
-    },
-    msgTooltip: {
-      type: Boolean,
-      default: false,
-    },
-
-    multiple: {
-      type: Boolean,
-      default: false,
-    },
-    options: {
-      type: Array,
-      default: () => [],
-    },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    name: { type: String, default: "" },
+    id: { type: String, default: "" },
+    description: { type: String, default: "" },
+    placeholder: { type: String, default: "Select Option" },
+    classLabel: { type: String, default: " " },
+    classInput: { type: String, default: "classinput" },
+    isReadonly: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    horizontal: { type: Boolean, default: false },
+    msgTooltip: { type: Boolean, default: false },
+    multiple: { type: Boolean, default: false },
+    options: { type: Array, default: () => [] },
   },
   emits: ["update:modelValue", "input", "change"],
   data() {
@@ -155,6 +117,29 @@ export default {
   computed: {
     inputId() {
       return this.id || this.generatedId;
+    },
+    // normalize error to string
+    errorText() {
+      const e = this.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    },
+    // determine whether validation UI should show
+    validationEnabled() {
+      return this.showValidation || !!this.validate;
+    },
+    // success text comes only from dedicated prop or legacy when string
+    successText() {
+      if (this.successMessage) return this.successMessage;
+      if (typeof this.validate === "string") return this.validate;
+      return "";
+    },
+    // success icon shows only if validation is enabled and there is no error
+    showSuccessIcon() {
+      return this.validationEnabled && !this.errorText;
     },
   },
 };

--- a/frontend/src/components/ui/Select/index.vue
+++ b/frontend/src/components/ui/Select/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     class="fromGroup relative"
-    :class="`${error ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
-      validate ? 'is-valid' : ''
+    :class="`${errorText ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
+      showSuccessIcon ? 'is-valid' : ''
     } `"
   >
     <label
@@ -18,10 +18,8 @@
         :name="name"
         :class="`${classInput} input-control block w-full focus:outline-none min-h-[40px] `"
         :value="modelValue"
-        :error="error"
         :readonly="isReadonly"
         :disabled="disabled"
-        :validate="validate"
         :formatter="formatter"
         :size="size"
         :multiple="multiple"
@@ -47,26 +45,28 @@
       </select>
     </div>
 
-    <span
-      v-if="error"
+    <p
+      v-if="errorText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-danger-500 text-white text-[10px] px-2 py-1 rounded'
-          : ' text-danger-500 block text-sm'
+          : ' text-danger-500 block text-sm whitespace-pre-line'
       "
-      >{{ error }}</span
     >
-    <span
-      v-if="validate"
+      {{ errorText }}
+    </p>
+    <p
+      v-if="successText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-success-500 text-white text-[10px] px-2 py-1 rounded'
           : ' text-success-500 block text-sm'
       "
-      >{{ validate }}</span
     >
+      {{ successText }}
+    </p>
     <span
       v-if="description"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
@@ -78,33 +78,26 @@
 export default {
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
+    // incoming error could be string or array from backend/lib
     error: {
-      type: [String, Boolean],
+      type: [String, Array, Object, Boolean],
       default: "",
     },
-    description: {
-      type: String,
-      default: "",
-    },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
     validate: {
-      type: [Array, String, Function],
-      default: () => [],
+      type: [Boolean, String, Array, Object],
+      default: false,
     },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    id: { type: String, default: "" },
+    name: { type: String, default: "" },
+    description: { type: String, default: "" },
     placeholder: {
       type: String,
       default: "Select Option",
@@ -168,6 +161,29 @@ export default {
   computed: {
     inputId() {
       return this.id || this.generatedId;
+    },
+    // normalize error to string
+    errorText() {
+      const e = this.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    },
+    // determine whether validation UI should show
+    validationEnabled() {
+      return this.showValidation || !!this.validate;
+    },
+    // success text comes only from dedicated prop or legacy when string
+    successText() {
+      if (this.successMessage) return this.successMessage;
+      if (typeof this.validate === "string") return this.validate;
+      return "";
+    },
+    // success icon shows only if validation is enabled and there is no error
+    showSuccessIcon() {
+      return this.validationEnabled && !this.errorText;
     },
   },
 };

--- a/frontend/src/components/ui/Switch/index.vue
+++ b/frontend/src/components/ui/Switch/index.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    class="relative"
+    :class="`${errorText ? 'has-error' : ''}  ${showSuccessIcon ? 'is-valid' : ''}`"
+  >
     <label
       class="flex items-start"
       :class="disabled ? ' cursor-not-allowed opacity-40' : 'cursor-pointer'"
@@ -57,7 +60,24 @@
       >
         {{ label }}
       </span>
+      <span v-if="showSuccessIcon" class="text-success-500 ltr:ml-2 rtl:mr-2">
+        <Icon icon="bi:check-lg" />
+      </span>
     </label>
+    <p
+      v-if="errorText"
+      class="mt-1 text-danger-500 text-sm whitespace-pre-line"
+    >
+      {{ errorText }}
+    </p>
+    <p v-if="successText" class="mt-1 text-success-500 text-sm">
+      {{ successText }}
+    </p>
+    <span
+      v-if="description"
+      class="block text-secondary-500 font-light leading-4 text-xs mt-2"
+      >{{ description }}</span
+    >
   </div>
 </template>
 <script>
@@ -71,52 +91,28 @@ export default defineComponent({
   inheritAttrs: false,
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "checkbox",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
-    active: {
-      type: Boolean,
-      default: false,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    activeClass: {
-      type: String,
-      default: "bg-slate-900 dark:bg-slate-900 ",
-    },
-    value: {
-      type: null,
-    },
-    badge: {
-      type: Boolean,
-      default: false,
-    },
-    icon: {
-      type: Boolean,
-      default: false,
-    },
-    prevIcon: {
-      type: String,
-      default: "heroicons-outline:volume-up",
-    },
-    nextIcon: {
-      type: String,
-      default: "heroicons-outline:volume-off",
-    },
+    // incoming error could be string or array from backend/lib
+    error: { type: [String, Array, Object, Boolean], default: "" },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
+    validate: { type: [Boolean, String, Array, Object], default: false },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    name: { type: String, default: "checkbox" },
+    id: { type: String, default: "" },
+    description: { type: String, default: "" },
+    active: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    activeClass: { type: String, default: "bg-slate-900 dark:bg-slate-900 " },
+    value: { type: null },
+    badge: { type: Boolean, default: false },
+    icon: { type: Boolean, default: false },
+    prevIcon: { type: String, default: "heroicons-outline:volume-up" },
+    nextIcon: { type: String, default: "heroicons-outline:volume-off" },
   },
   emits: ["update:modelValue", "input", "change"],
 
@@ -136,7 +132,40 @@ export default defineComponent({
       set: (newValue) => context.emit("update:modelValue", newValue),
     });
 
-    return { localValue, ck, onChange, inputId };
+    // normalize error to string
+    const errorText = computed(() => {
+      const e = props.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    });
+    // determine whether validation UI should show
+    const validationEnabled = computed(
+      () => props.showValidation || !!props.validate
+    );
+    // success text comes only from dedicated prop or legacy when string
+    const successText = computed(() => {
+      if (props.successMessage) return props.successMessage;
+      if (typeof props.validate === "string") return props.validate;
+      return "";
+    });
+    // success icon shows only if validation is enabled and there is no error
+    const showSuccessIcon = computed(
+      () => validationEnabled.value && !errorText.value
+    );
+
+    return {
+      localValue,
+      ck,
+      onChange,
+      inputId,
+      errorText,
+      successText,
+      showSuccessIcon,
+      description: props.description,
+    };
   },
 });
 </script>

--- a/frontend/src/components/ui/Textarea/index.vue
+++ b/frontend/src/components/ui/Textarea/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     class="fromGroup relative"
-    :class="`${error ? 'has-error' : ''}  ${horizontal ? 'flex' : ''} ${
-      validate ? 'is-valid' : ''
+    :class="`${errorText ? 'has-error' : ''}  ${horizontal ? 'flex' : ''} ${
+      showSuccessIcon ? 'is-valid' : ''
     } `"
   >
     <label
@@ -21,11 +21,9 @@
         :placeholder="placeholder"
         :class="`${classInput} input-control block w-full focus:outline-none pt-3 `"
         :value="modelValue"
-        :error="error"
         :readonly="isReadonly"
         :disabled="disabled"
         :rows="rows"
-        :validate="validate"
         @input="
           ($event) => {
             $emit('update:modelValue', $event.target.value);
@@ -38,36 +36,36 @@
       <div
         class="flex text-xl absolute ltr:right-[14px] rtl:left-[14px] top-1/2 -translate-y-1/2"
       >
-        <span v-if="error" class="text-danger-500">
+        <span v-if="errorText" class="text-danger-500">
           <Icon icon="heroicons-outline:information-circle" />
         </span>
-
-        <span v-if="validate" class="text-success-500">
+        <span v-if="showSuccessIcon" class="text-success-500">
           <Icon icon="bi:check-lg" />
         </span>
       </div>
     </div>
-
-    <span
-      v-if="error"
+    <p
+      v-if="errorText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-danger-500 text-white text-[10px] px-2 py-1 rounded'
-          : ' text-danger-500 block text-sm'
+          : ' text-danger-500 block text-sm whitespace-pre-line'
       "
-      >{{ error }}</span
     >
-    <span
-      v-if="validate"
+      {{ errorText }}
+    </p>
+    <p
+      v-if="successText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-success-500 text-white text-[10px] px-2 py-1 rounded'
           : ' text-success-500 block text-sm'
       "
-      >{{ validate }}</span
     >
+      {{ successText }}
+    </p>
     <span
       v-if="description"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
@@ -83,33 +81,26 @@ export default {
   },
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
+    // incoming error could be string or array from backend/lib
     error: {
-      type: [String, Boolean],
+      type: [String, Array, Object, Boolean],
       default: "",
     },
-    description: {
-      type: String,
-      default: "",
-    },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
     validate: {
-      type: [Array, String, Function],
-      default: () => [],
+      type: [Boolean, String, Array, Object],
+      default: false,
     },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    name: { type: String, default: "" },
+    id: { type: String, default: "" },
+    description: { type: String, default: "" },
     placeholder: {
       type: String,
       default: "message",
@@ -152,6 +143,29 @@ export default {
   computed: {
     inputId() {
       return this.id || this.generatedId;
+    },
+    // normalize error to string
+    errorText() {
+      const e = this.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    },
+    // determine whether validation UI should show
+    validationEnabled() {
+      return this.showValidation || !!this.validate;
+    },
+    // success text comes only from dedicated prop or legacy when string
+    successText() {
+      if (this.successMessage) return this.successMessage;
+      if (typeof this.validate === "string") return this.validate;
+      return "";
+    },
+    // success icon shows only if validation is enabled and there is no error
+    showSuccessIcon() {
+      return this.validationEnabled && !this.errorText;
     },
   },
 };

--- a/frontend/src/components/ui/Textinput/index.vue
+++ b/frontend/src/components/ui/Textinput/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     class="fromGroup relative"
-    :class="`${error ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
-      validate ? 'is-valid' : ''
+    :class="`${errorText ? 'has-error' : ''}  ${horizontal ? 'flex' : ''}  ${
+      showSuccessIcon ? 'is-valid' : ''
     } `"
   >
     <label
@@ -25,10 +25,8 @@
           hasicon ? 'ltr:pr-10 rtl:pl-10' : ''
         } `"
         :value="modelValue"
-        :error="error"
         :readonly="isReadonly"
         :disabled="disabled"
-        :validate="validate"
         @input="
           ($event) => {
             $emit('update:modelValue', $event.target.value);
@@ -44,10 +42,8 @@
         :name="name"
         :placeholder="placeholder"
         :value="modelValue"
-        :error="error"
         :readonly="isReadonly"
         :disabled="disabled"
-        :validate="validate"
         :options="options"
         modelValue="modelValue"
         @input="
@@ -71,36 +67,36 @@
           <Icon v-else icon="heroicons-outline:eye-off" />
         </span>
 
-        <span v-if="error" class="text-danger-500">
+        <span v-if="errorText" class="text-danger-500">
           <Icon icon="heroicons-outline:information-circle" />
         </span>
-
-        <span v-if="validate" class="text-success-500">
+        <span v-if="showSuccessIcon" class="text-success-500">
           <Icon icon="bi:check-lg" />
         </span>
       </div>
     </div>
-
-    <span
-      v-if="error"
+    <p
+      v-if="errorText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-danger-500 text-white text-[10px] px-2 py-1 rounded'
-          : ' text-danger-500 block text-sm'
+          : ' text-danger-500 block text-sm whitespace-pre-line'
       "
-      >{{ error }}</span
     >
-    <span
-      v-if="validate"
+      {{ errorText }}
+    </p>
+    <p
+      v-if="successText"
       class="mt-2"
       :class="
         msgTooltip
           ? ' inline-block bg-success-500 text-white text-[10px] px-2 py-1 rounded'
           : ' text-success-500 block text-sm'
       "
-      >{{ validate }}</span
     >
+      {{ successText }}
+    </p>
     <span
       v-if="description"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
@@ -115,33 +111,26 @@ export default {
   components: { Icon, Cleave },
   props: {
     modelValue: {
-      type: [String, Number, Boolean, Object, Array],
+      type: [String, Number, Boolean, Object, Array, Date],
       default: "",
     },
-    label: {
-      type: String,
-      default: "",
-    },
-    name: {
-      type: String,
-      default: "",
-    },
-    id: {
-      type: String,
-      default: "",
-    },
+    // incoming error could be string or array from backend/lib
     error: {
-      type: [String, Boolean],
+      type: [String, Array, Object, Boolean],
       default: "",
     },
-    description: {
-      type: String,
-      default: "",
-    },
+    // legacy: sometimes boolean, sometimes string/array -> normalize
     validate: {
-      type: [Array, String, Function],
-      default: () => [],
+      type: [Boolean, String, Array, Object],
+      default: false,
     },
+    // NEW (preferred): explicit flags/messages
+    showValidation: { type: Boolean, default: false },
+    successMessage: { type: String, default: "" },
+    label: { type: String, default: "" },
+    id: { type: String, default: "" },
+    name: { type: String, default: "" },
+    description: { type: String, default: "" },
     placeholder: {
       type: String,
       default: "Search",
@@ -200,6 +189,29 @@ export default {
   computed: {
     inputId() {
       return this.id || this.generatedId;
+    },
+    // normalize error to string
+    errorText() {
+      const e = this.error;
+      if (!e) return "";
+      if (Array.isArray(e)) return e.filter(Boolean).join("\n");
+      if (typeof e === "object")
+        return Object.values(e).flat().filter(Boolean).join("\n");
+      return String(e);
+    },
+    // determine whether validation UI should show
+    validationEnabled() {
+      return this.showValidation || !!this.validate;
+    },
+    // success text comes only from dedicated prop or legacy when string
+    successText() {
+      if (this.successMessage) return this.successMessage;
+      if (typeof this.validate === "string") return this.validate;
+      return "";
+    },
+    // success icon shows only if validation is enabled and there is no error
+    showSuccessIcon() {
+      return this.validationEnabled && !this.errorText;
     },
   },
   methods: {


### PR DESCRIPTION
## Summary
- normalize validation props across form inputs
- gate success icon & messaging behind validation checks
- ensure error arrays & objects render cleanly

## Testing
- `npm test`
- `npm run lint` *(fails: Form label must have an associated control)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b262fed883239682dbaa94d86225