### PR TITLE
refactor: use show-validation api in demo forms

### DIFF
--- a/dashcode-full-source-code/src/views/forms/input/State.vue
+++ b/dashcode-full-source-code/src/views/forms/input/State.vue
@@ -5,7 +5,8 @@
       name="ValidState"
       type="text"
       placeholder="Valid"
-      validate="This is valid state."
+      show-validation
+      success-message="This is valid state."
     />
     <Textinput
       label="Invalid State"

--- a/dashcode-full-source-code/src/views/forms/input/StateTooltip.vue
+++ b/dashcode-full-source-code/src/views/forms/input/StateTooltip.vue
@@ -5,7 +5,8 @@
       name="ValidState"
       type="text"
       placeholder="Valid"
-      validate="This is valid state."
+      show-validation
+      success-message="This is valid state."
       msgTooltip
     />
     <Textinput

--- a/dashcode-full-source-code/src/views/forms/textarea/State.vue
+++ b/dashcode-full-source-code/src/views/forms/textarea/State.vue
@@ -4,7 +4,8 @@
       label="Valid State"
       name="ValidState"
       placeholder="Valid"
-      validate="This is valid state."
+      show-validation
+      success-message="This is valid state."
     />
     <Textarea
       label="Invalid State"

--- a/dashcode-full-source-code/src/views/forms/textarea/StateTooltip.vue
+++ b/dashcode-full-source-code/src/views/forms/textarea/StateTooltip.vue
@@ -4,7 +4,8 @@
       label="Valid State"
       name="ValidState"
       placeholder="Valid"
-      validate="This is valid state."
+      show-validation
+      success-message="This is valid state."
       msgTooltip
     />
     <Textarea


### PR DESCRIPTION
## Summary
- replace legacy `validate` prop with `show-validation` and `success-message` in demo input/textarea state examples

## Testing
- `npm run lint` *(fails: Cannot use 'import.meta' outside a module)*
- `npm run lint` *(fails: 93 problems (83 errors, 10 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68b1b4428ffc832381b1b9ef6476af8c