### PR TITLE
Add a11y labels and default props for UI elements

### DIFF
--- a/frontend/src/components/ui/Alert/index.vue
+++ b/frontend/src/components/ui/Alert/index.vue
@@ -29,11 +29,10 @@ export default {
   components: {
     Icon,
   },
-  type: "primary-500",
-
   props: {
     type: {
       type: String,
+      default: "",
     },
     dismissible: {
       type: Boolean,
@@ -41,6 +40,7 @@ export default {
     },
     icon: {
       type: String,
+      default: "",
     },
     class: {
       type: String,

--- a/frontend/src/components/ui/Checkbox/index.vue
+++ b/frontend/src/components/ui/Checkbox/index.vue
@@ -4,6 +4,7 @@
     :class="`${errorText ? 'has-error' : ''}  ${showSuccessIcon ? 'is-valid' : ''}`"
   >
     <label
+      :for="inputId"
       :class="disabled ? ' cursor-not-allowed opacity-50' : 'cursor-pointer'"
       class="flex items-center"
     >
@@ -90,7 +91,7 @@ export default defineComponent({
       default:
         " ring-black-500  bg-slate-900 dark:bg-slate-700 dark:ring-slate-700 ",
     },
-    value: { type: null },
+    value: { type: null, default: "" },
   },
   emits: ["update:modelValue", "input", "change"],
 

--- a/frontend/src/components/ui/Header/Cart/cart-item.vue
+++ b/frontend/src/components/ui/Header/Cart/cart-item.vue
@@ -39,7 +39,10 @@ import { cartStore } from "@/store/cart";
 
 const cart = cartStore();
 const props = defineProps({
-  item: Object,
+  item: {
+    type: Object,
+    default: () => ({}),
+  },
 });
 </script>
 

--- a/frontend/src/components/ui/InputGroup/index.vue
+++ b/frontend/src/components/ui/InputGroup/index.vue
@@ -164,9 +164,11 @@ export default {
     },
     prepend: {
       type: String,
+      default: "",
     },
     append: {
       type: String,
+      default: "",
     },
     classLabel: {
       type: String,
@@ -202,9 +204,11 @@ export default {
     },
     prependIcon: {
       type: String,
+      default: "",
     },
     appendIcon: {
       type: String,
+      default: "",
     },
     merged: {
       type: Boolean,

--- a/frontend/src/components/ui/Radio/index.vue
+++ b/frontend/src/components/ui/Radio/index.vue
@@ -4,6 +4,7 @@
     :class="`${errorText ? 'has-error' : ''}  ${showSuccessIcon ? 'is-valid' : ''}`"
   >
     <label
+      :for="inputId"
       :class="disabled ? ' cursor-not-allowed opacity-50' : 'cursor-pointer'"
       class="flex items-center"
     >
@@ -80,7 +81,7 @@ export default defineComponent({
     checked: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     activeClass: { type: String, default: "ring-slate-500 dark:ring-slate-400" },
-    value: { type: null },
+    value: { type: null, default: "" },
   },
   emits: ["update:modelValue", "input", "change"],
 

--- a/frontend/src/components/ui/Switch/index.vue
+++ b/frontend/src/components/ui/Switch/index.vue
@@ -4,6 +4,7 @@
     :class="`${errorText ? 'has-error' : ''}  ${showSuccessIcon ? 'is-valid' : ''}`"
   >
     <label
+      :for="inputId"
       class="flex items-start"
       :class="disabled ? ' cursor-not-allowed opacity-40' : 'cursor-pointer'"
     >
@@ -108,7 +109,7 @@ export default defineComponent({
     active: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     activeClass: { type: String, default: "bg-slate-900 dark:bg-slate-900 " },
-    value: { type: null },
+    value: { type: null, default: "" },
     badge: { type: Boolean, default: false },
     icon: { type: Boolean, default: false },
     prevIcon: { type: String, default: "heroicons-outline:volume-up" },


### PR DESCRIPTION
## Summary
- wire Checkbox, Radio, and Switch labels to their controls
- add default prop values for Alert, InputGroup, and cart item components

## Testing
- `pnpm run lint` *(fails: Form label must have an associated control)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ba8625e883239d5a78e093efbb4c