### PR TITLE
T2: sync VueSelect label and id handling

### DIFF
--- a/frontend/src/components/ui/Select/VueSelect.vue
+++ b/frontend/src/components/ui/Select/VueSelect.vue
@@ -8,20 +8,20 @@
     <label
       v-if="label"
       :class="`${classLabel} inline-block input-label `"
-      :for="inputId"
+      :id="inputId"
     >
       {{ label }}</label
     >
     <div class="relative">
       <div v-if="!$slots.default">
         <vSelect
-          :id="inputId"
           :name="name"
           :modelValue="modelValue"
           :readonly="isReadonly"
           :disabled="disabled"
           :multiple="multiple"
           :options="options"
+          :aria-labelledby="inputId"
           @update:model-value="$emit('update:modelValue', $event)"
           @input="$emit('input', $event)"
           @change="$emit('change', $event)"


### PR DESCRIPTION
## Summary
- ensure VueSelect labels use a generated ID and connect via `aria-labelledby`

## Testing
- `npm test`
- `npm run lint` *(fails: Form label must have an associated control and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bc6eef8483239ea80f13327dbfe9