### PR TITLE
chore: add ids and labels to form inputs

### DIFF
--- a/frontend/src/components/comments/CommentEditor.vue
+++ b/frontend/src/components/comments/CommentEditor.vue
@@ -2,25 +2,30 @@
   <div class="flex flex-col gap-2">
     <Textarea
       v-model="body"
+      :id="ids.body"
       :rows="3"
       label="Comment"
       placeholder="Add a comment"
     />
-    <VueSelect class="w-full" label="Mentions">
-      <template #default="{ inputId }">
-        <vSelect
-          :id="inputId"
-          v-model="selectedMentions"
-          :options="employees"
-          label="name"
-          multiple
-          placeholder="Mention users"
-        />
-      </template>
-    </VueSelect>
+    <div>
+      <label :for="ids.mentions" class="sr-only">Mentions</label>
+      <VueSelect class="w-full">
+        <template #default>
+          <vSelect
+            :id="ids.mentions"
+            v-model="selectedMentions"
+            :options="employees"
+            label="name"
+            multiple
+            placeholder="Mention users"
+          />
+        </template>
+      </VueSelect>
+    </div>
     <Textinput
       v-if="allowFiles"
       v-model="fileIds"
+      :id="ids.fileIds"
       label="File IDs"
       placeholder="File IDs comma separated"
     />
@@ -45,6 +50,11 @@ const selectedMentions = ref<any[]>([]);
 const fileIds = ref('');
 const employees = ref<any[]>([]);
 const allowFiles = props.allowFiles ?? false;
+const ids = {
+  body: 'comment-body',
+  mentions: 'comment-mentions',
+  fileIds: 'comment-file-ids',
+};
 
 onMounted(async () => {
   const { data } = await api.get('/employees');

--- a/frontend/src/components/settings/BrandingForm.vue
+++ b/frontend/src/components/settings/BrandingForm.vue
@@ -1,6 +1,6 @@
 <template>
   <form class="space-y-4" @submit.prevent="save">
-    <Textinput v-model="form.name" label="Name" />
+    <Textinput v-model="form.name" :id="ids.name" label="Name" />
     <div>
       <label class="form-label" :for="ids.logo">Logo</label>
       <div
@@ -65,7 +65,12 @@
         class="h-10 w-20 rounded border border-slate-200"
       />
     </div>
-    <Textinput v-model="form.email_from" label="Email From" type="email" />
+    <Textinput
+      v-model="form.email_from"
+      :id="ids.emailFrom"
+      label="Email From"
+      type="email"
+    />
     <Button type="submit" :isDisabled="!dirty" btnClass="btn-dark"
       >Save Branding</Button
     >
@@ -87,12 +92,14 @@ const form = reactive({ ...initial });
 const logoFile = ref<File | null>(null);
 const logoDarkFile = ref<File | null>(null);
 const ids = {
+  name: 'branding-name',
   logo: 'branding-logo',
   logoDark: 'branding-logo-dark',
   color: 'branding-color',
   secondaryColor: 'branding-secondary-color',
   colorDark: 'branding-color-dark',
   secondaryColorDark: 'branding-secondary-color-dark',
+  emailFrom: 'branding-email-from',
 };
 
 function onDrop(files: File[]) {

--- a/frontend/src/components/ui/Ecommerce/step/delivery-info.vue
+++ b/frontend/src/components/ui/Ecommerce/step/delivery-info.vue
@@ -51,17 +51,31 @@
           class="space-x-0 sm:space-x-2 md:space-x-5 md:space-y-0 space-y-3 rtl:space-x-reverse md:flex justify-start lg:justify-end flex-1 md:text-base text-sm"
         >
           <label
+            :for="ids.home"
             class="inline-flex items-center border border-slate-900 dark:border-slate-700 rounded py-3 lg:px-10 px-5 md:w-auto w-[200px]"
           >
-            <Radio v-model="picked1" name="x" value="A" checked />
+            <Radio
+              :id="ids.home"
+              v-model="picked1"
+              name="x"
+              value="A"
+              checked
+            />
             <span class="text-slate-900 dark:text-slate-300">
               Home Delivery
             </span>
           </label>
           <label
+            :for="ids.pickup"
             class="inline-flex items-center border border-slate-900 dark:border-slate-700 rounded py-3 lg:px-10 px-5 md:w-auto w-[200px]"
           >
-            <Radio v-model="picked1" name="x" value="B" @click="toggleModal" />
+            <Radio
+              :id="ids.pickup"
+              v-model="picked1"
+              name="x"
+              value="B"
+              @click="toggleModal"
+            />
             <span class="text-slate-900 dark:text-slate-300">
               Local Pickup
             </span>
@@ -81,6 +95,11 @@ import { cartStore } from "@/store/cart";
 
 const cart = cartStore();
 const activeModal = ref(false);
+
+const ids = {
+  home: 'delivery-home',
+  pickup: 'delivery-pickup',
+};
 
 const toggleModal = () => {
   activeModal.value = !activeModal.value;

--- a/frontend/src/components/ui/Ecommerce/step/note-modal.vue
+++ b/frontend/src/components/ui/Ecommerce/step/note-modal.vue
@@ -13,18 +13,21 @@
     >
       <Textarea
         label="Address"
+        :id="ids.address"
         name="pn4"
         placeholder="Your Address"
         horizontal
       />
       <div class="flex">
-        <p
+        <label
+          :for="ids.country"
           class="flex-none flex-0 mr-6 md:w-[100px] break-words ltr:inline-block rtl:block input-label"
         >
           Country
-        </p>
+        </label>
         <div class="flex-1 w-full">
           <Select
+            :id="ids.country"
             :options="options"
             placeholder="Select Your Country"
             classLabel="!w-[150px]"
@@ -32,13 +35,15 @@
         </div>
       </div>
       <div class="flex">
-        <p
+        <label
+          :for="ids.state"
           class="flex-none flex-0 mr-6 md:w-[100px] break-words ltr:inline-block rtl:block input-label"
         >
           State
-        </p>
+        </label>
         <div class="flex-1 w-full">
           <Select
+            :id="ids.state"
             :options="options"
             placeholder="Select Your State"
             classLabel="!w-[150px]"
@@ -46,13 +51,15 @@
         </div>
       </div>
       <div class="flex">
-        <p
+        <label
+          :for="ids.city"
           class="flex-none flex-0 mr-6 md:w-[100px] break-words ltr:inline-block rtl:block input-label"
         >
           City
-        </p>
+        </label>
         <div class="flex-1 w-full">
           <Select
+            :id="ids.city"
             :options="options"
             placeholder="Select Your City"
             classLabel="!w-[150px]"
@@ -62,6 +69,7 @@
 
       <InputGroup
         type="text"
+        :id="ids.postalCode"
         label="Postal Code"
         name="ps-1"
         placeholder="Your Postal Code"
@@ -69,6 +77,7 @@
       />
       <InputGroup
         type="text"
+        :id="ids.phone"
         label="Phone No"
         name="ps-1"
         placeholder="+880"
@@ -106,6 +115,14 @@ const props = defineProps({
   },
 });
 const emit = defineEmits(["close"]);
+const ids = {
+  address: 'address-input',
+  country: 'country-select',
+  state: 'state-select',
+  city: 'city-select',
+  postalCode: 'postal-code',
+  phone: 'phone-number',
+};
 </script>
 
 <style lang="scss" scoped></style>

--- a/frontend/src/components/ui/Ecommerce/step/pickup-modal.vue
+++ b/frontend/src/components/ui/Ecommerce/step/pickup-modal.vue
@@ -10,14 +10,19 @@
     <form class="space-y-5" @submit.prevent="submit">
       <InputGroup
         type="text"
+        :id="ids.address"
         name="ps-1"
+        label="Pickup Address"
         placeholder="Enter Pickup Address"
         horizontal
       />
       <div class="space-y-3">
         <div class="card border dark:border-slate-700 rounded-lg p-5">
-          <label class="flex gap-1 items-center cursor-pointer">
-            <Radio v-model="picked1" name="x" value="A" />
+          <label
+            :for="ids.optionA"
+            class="flex gap-1 items-center cursor-pointer"
+          >
+            <Radio :id="ids.optionA" v-model="picked1" name="x" value="A" />
             <div class="space-y-1">
               <p class="font-medium text-base rtl:text-right">Mohakhali DOHS</p>
               <p class="font-normal text-sm text-slate-500 flex items-center">
@@ -32,8 +37,11 @@
           </label>
         </div>
         <div class="card border dark:border-slate-700 rounded-lg p-5">
-          <label class="flex gap-1 items-center cursor-pointer">
-            <Radio v-model="picked1" name="x" value="B" />
+          <label
+            :for="ids.optionB"
+            class="flex gap-1 items-center cursor-pointer"
+          >
+            <Radio :id="ids.optionB" v-model="picked1" name="x" value="B" />
             <div class="space-y-1">
               <p class="font-medium text-base rtl:text-right">Mohakhali DOHS</p>
               <p class="font-normal text-sm text-slate-500 flex items-center">
@@ -48,8 +56,11 @@
           </label>
         </div>
         <div class="card border dark:border-slate-700 rounded-lg p-5">
-          <label class="flex gap-1 items-center cursor-pointer">
-            <Radio v-model="picked1" name="x" value="C" />
+          <label
+            :for="ids.optionC"
+            class="flex gap-1 items-center cursor-pointer"
+          >
+            <Radio :id="ids.optionC" v-model="picked1" name="x" value="C" />
             <div class="space-y-1">
               <p class="font-medium text-base rtl:text-right">Mohakhali DOHS</p>
               <p class="font-normal text-sm text-slate-500 flex items-center">
@@ -92,6 +103,12 @@ const props = defineProps({
 const emit = defineEmits(["close"]);
 
 const picked1 = ref("A");
+const ids = {
+  address: 'pickup-address',
+  optionA: 'pickup-option-a',
+  optionB: 'pickup-option-b',
+  optionC: 'pickup-option-c',
+};
 </script>
 
 <style lang="scss" scoped></style>

--- a/frontend/src/components/ui/Ecommerce/step/shipping-info.vue
+++ b/frontend/src/components/ui/Ecommerce/step/shipping-info.vue
@@ -2,8 +2,11 @@
   <div>
     <div class="bg-white dark:bg-slate-800">
       <div class="rounded p-5 space-y-5">
-        <label class="flex border dark:border-slate-700 rounded p-5">
-          <Radio v-model="picked1" name="x" value="A" checked />
+        <label
+          :for="ids.addressA"
+          class="flex border dark:border-slate-700 rounded p-5"
+        >
+          <Radio :id="ids.addressA" v-model="picked1" name="x" value="A" checked />
 
           <div
             class="flex flex-start -mt-1 space-x-3 md:space-x-5 rtl:space-x-reverse"
@@ -31,8 +34,11 @@
           </div>
         </label>
 
-        <label class="flex border dark:border-slate-700 rounded p-5">
-          <Radio v-model="picked1" name="x" value="B" />
+        <label
+          :for="ids.addressB"
+          class="flex border dark:border-slate-700 rounded p-5"
+        >
+          <Radio :id="ids.addressB" v-model="picked1" name="x" value="B" />
           <div
             class="flex flex-start -mt-1 space-x-3 md:space-x-5 rtl:space-x-reverse"
           >
@@ -85,6 +91,10 @@ const toggleModal = () => {
 };
 
 const picked1 = ref("A");
+const ids = {
+  addressA: 'shipping-address-a',
+  addressB: 'shipping-address-b',
+};
 </script>
 
 <style></style>

--- a/frontend/src/components/ui/Settings/Tools/MenuLayout.vue
+++ b/frontend/src/components/ui/Settings/Tools/MenuLayout.vue
@@ -37,10 +37,16 @@
       </div>
       <div>
         <label
+          :for="ids.collapse"
           :class="menucollaspse ? 'bg-primary-500' : 'bg-secondary-500'"
           class="relative inline-flex h-6 w-[46px] items-center rounded-full transition-all duration-150 cursor-pointer"
         >
-          <input v-model="menucollaspse" type="checkbox" class="hidden" />
+          <input
+            :id="ids.collapse"
+            v-model="menucollaspse"
+            type="checkbox"
+            class="hidden"
+          />
           <span
             :class="
               menucollaspse
@@ -61,10 +67,16 @@
       </div>
       <div>
         <label
+          :for="ids.hidden"
           :class="menuHideen ? 'bg-primary-500' : 'bg-secondary-500'"
           class="relative inline-flex h-6 w-[46px] items-center rounded-full transition-all duration-150 cursor-pointer"
         >
-          <input v-model="menuHideen" type="checkbox" class="hidden" />
+          <input
+            :id="ids.hidden"
+            v-model="menuHideen"
+            type="checkbox"
+            class="hidden"
+          />
           <span
             :class="
               menuHideen
@@ -95,6 +107,10 @@ export default {
           label: "Horizontal",
         },
       ],
+      ids: {
+        collapse: 'menu-collapsed',
+        hidden: 'menu-hidden',
+      },
     };
   },
   watch: {

--- a/frontend/src/components/ui/Settings/Tools/Semidark.vue
+++ b/frontend/src/components/ui/Settings/Tools/Semidark.vue
@@ -4,10 +4,16 @@
       <div class="text-slate-600 text-base dark:text-slate-300">Semi Dark</div>
       <div>
         <label
+          :for="ids.semidark"
           :class="semidark ? 'bg-primary-500' : 'bg-secondary-500'"
           class="relative inline-flex h-6 w-[46px] items-center rounded-full transition-all duration-150 cursor-pointer"
         >
-          <input v-model="semidark" type="checkbox" class="hidden" />
+          <input
+            :id="ids.semidark"
+            v-model="semidark"
+            type="checkbox"
+            class="hidden"
+          />
           <span
             :class="
               semidark
@@ -23,6 +29,13 @@
 </template>
 <script>
 export default {
+  data() {
+    return {
+      ids: {
+        semidark: 'semidark-toggle',
+      },
+    };
+  },
   computed: {
     semidark: {
       get() {

--- a/frontend/src/views/ReportsDashboard.vue
+++ b/frontend/src/views/ReportsDashboard.vue
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-7xl space-y-8 p-6">
     <div class="flex justify-end mb-4">
       <div class="flex flex-wrap items-end gap-2">
-        <Select v-model="range" label="Range" class="w-40">
+        <Select v-model="range" :id="ids.range" label="Range" class="w-40">
           <option value="today">Today</option>
           <option value="7">Last 7 days</option>
           <option value="30">Last 30 days</option>
@@ -11,6 +11,7 @@
         <Textinput
           v-if="range === 'custom'"
           v-model="from"
+          :id="ids.from"
           type="date"
           label="From"
           class="w-40"
@@ -18,6 +19,7 @@
         <Textinput
           v-if="range === 'custom'"
           v-model="to"
+          :id="ids.to"
           type="date"
           label="To"
           class="w-40"
@@ -46,6 +48,11 @@ import ChartCard from '@/components/reports/ChartCard.vue';
 const range = ref('today');
 const from = ref('');
 const to = ref('');
+const ids = {
+  range: 'reports-range',
+  from: 'reports-from',
+  to: 'reports-to',
+};
 const kpis = ref([] as any);
 const materials = ref([] as any);
 const materialSeries = computed(() => [

--- a/frontend/src/views/auth/dashcode/common/Signin.vue
+++ b/frontend/src/views/auth/dashcode/common/Signin.vue
@@ -2,6 +2,7 @@
   <form class="space-y-4" @submit.prevent="onSubmit">
     <Textinput
       v-model="email"
+      :id="ids.email"
       label="Email"
       type="email"
       placeholder="Type your email"
@@ -11,6 +12,7 @@
     />
     <Textinput
       v-model="password"
+      :id="ids.password"
       label="Password"
       type="password"
       placeholder="8+ characters, 1 capitat letter "
@@ -22,13 +24,13 @@
 
     <div class="flex justify-between">
       <input
-        id="signin-remember"
+        :id="ids.remember"
         type="checkbox"
         class="hidden"
         @change="() => (checkbox = !checkbox)"
       />
       <label
-        for="signin-remember"
+        :for="ids.remember"
         class="cursor-pointer flex items-start"
       >
         <span
@@ -100,6 +102,11 @@ export default {
   data() {
     return {
       checkbox: false,
+      ids: {
+        email: 'signin-email',
+        password: 'signin-password',
+        remember: 'signin-remember',
+      },
     };
   },
 };

--- a/frontend/src/views/auth/dashcode/common/Signup.vue
+++ b/frontend/src/views/auth/dashcode/common/Signup.vue
@@ -2,6 +2,7 @@
   <form class="space-y-4" @submit.prevent="onSubmit">
     <Textinput
       v-model="name"
+      :id="ids.name"
       label="Full name"
       type="text"
       placeholder="Full Name"
@@ -11,6 +12,7 @@
     />
     <Textinput
       v-model="email"
+      :id="ids.email"
       label="Email"
       type="email"
       placeholder="Type your email"
@@ -20,6 +22,7 @@
     />
     <Textinput
       v-model="password"
+      :id="ids.password"
       label="Password"
       type="password"
       placeholder="8+ characters, 1 capitat letter "
@@ -30,12 +33,12 @@
     />
 
     <input
-      id="signup-accept"
+      :id="ids.accept"
       type="checkbox"
       class="hidden"
       @change="() => (checkbox = !checkbox)"
     />
-    <label for="signup-accept" class="cursor-pointer flex items-start">
+    <label :for="ids.accept" class="cursor-pointer flex items-start">
       <span
         class="h-4 w-4 border rounded inline-flex mr-3 relative flex-none top-1 transition-all duration-150"
         :class="
@@ -129,6 +132,12 @@ export default {
   data() {
     return {
       checkbox: false,
+      ids: {
+        name: 'signup-name',
+        email: 'signup-email',
+        password: 'signup-password',
+        accept: 'signup-accept',
+      },
     };
   },
 };

--- a/frontend/src/views/manuals/ManualsList.vue
+++ b/frontend/src/views/manuals/ManualsList.vue
@@ -15,13 +15,23 @@
         <option value="">All</option>
         <option v-for="c in categories" :key="c" :value="c">{{ c }}</option>
       </select>
-      <label class="flex items-center gap-1 text-sm">
+      <label :for="ids.favorites" class="flex items-center gap-1 text-sm">
         Favorites
-        <input v-model="showFavorites" type="checkbox" class="form-switch" />
+        <input
+          :id="ids.favorites"
+          v-model="showFavorites"
+          type="checkbox"
+          class="form-switch"
+        />
       </label>
-      <label class="flex items-center gap-1 text-sm">
+      <label :for="ids.offline" class="flex items-center gap-1 text-sm">
         Offline
-        <input v-model="showOffline" type="checkbox" class="form-switch" />
+        <input
+          :id="ids.offline"
+          v-model="showOffline"
+          type="checkbox"
+          class="form-switch"
+        />
       </label>
       <button class="btn btn-primary ml-auto" @click="openCreate">
         Upload Manual
@@ -64,7 +74,12 @@ const showFavorites = ref(false);
 const showOffline = ref(false);
 const showForm = ref(false);
 const editId = ref<string | null>(null);
-const ids = { search: 'manuals-search', category: 'manuals-category' };
+const ids = {
+  search: 'manuals-search',
+  category: 'manuals-category',
+  favorites: 'manuals-favorites',
+  offline: 'manuals-offline',
+};
 
 onMounted(async () => {
   await store.fetch();

--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -23,10 +23,11 @@
         <div v-if="errors.level" class="text-red-600 text-sm">{{ errors.level }}</div>
       </div>
       <div v-if="auth.isSuperAdmin">
-        <VueSelect label="Tenant" :error="errors.tenant_id">
-          <template #default="{ inputId }">
+        <label :for="ids.tenant" class="block font-medium mb-1">Tenant</label>
+        <VueSelect :error="errors.tenant_id">
+          <template #default>
             <vSelect
-              :id="inputId"
+              :id="ids.tenant"
               v-model="tenantId"
               :options="tenantOptions"
               :reduce="(t: any) => t.id"
@@ -35,22 +36,23 @@
           </template>
         </VueSelect>
       </div>
-      <VueSelect
-        v-if="!auth.isSuperAdmin || tenantId !== null"
-        label="Abilities"
-        :error="errors.abilities"
-      >
-        <template #default="{ inputId }">
-          <vSelect
-            :id="inputId"
-            v-model="abilities"
-            :options="abilityOptions"
-            multiple
-            label="label"
-            :reduce="(a: any) => a.value"
-          />
-        </template>
-      </VueSelect>
+      <div v-if="!auth.isSuperAdmin || tenantId !== null">
+        <label :for="ids.abilities" class="block font-medium mb-1"
+          >Abilities</label
+        >
+        <VueSelect :error="errors.abilities">
+          <template #default>
+            <vSelect
+              :id="ids.abilities"
+              v-model="abilities"
+              :options="abilityOptions"
+              multiple
+              label="label"
+              :reduce="(a: any) => a.value"
+            />
+          </template>
+        </VueSelect>
+      </div>
       <div v-if="serverError" class="text-red-600 text-sm">{{ serverError }}</div>
       <button
         type="submit"
@@ -90,6 +92,10 @@ const tenantId = ref<string | null>(
   auth.isSuperAdmin ? null : tenantStore.currentTenantId,
 );
 const serverError = ref('');
+const ids = {
+  tenant: 'role-tenant',
+  abilities: 'role-abilities',
+};
 
 const tenantOptions = computed(() => [
   { id: '', name: 'Global' },


### PR DESCRIPTION
## Summary
- ensure comment editor fields have explicit labels and ids
- wire up ids/labels on settings toggles, ecommerce flows, and auth screens
- add explicit ids to reports dashboard and manuals filters

## Testing
- `npm test`
- `npm run lint` *(fails: Form label must have an associated control)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bd4ed9f8832387d65d0cace38254