### PR TITLE
fix duplicate description keys in UI controls

### DIFF
--- a/frontend/src/components/ui/Checkbox/index.vue
+++ b/frontend/src/components/ui/Checkbox/index.vue
@@ -55,9 +55,9 @@
       {{ successText }}
     </p>
     <span
-      v-if="description"
+      v-if="descriptionText"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
-      >{{ description }}</span
+      >{{ descriptionText }}</span
     >
   </div>
 </template>
@@ -143,7 +143,7 @@ export default defineComponent({
       errorText,
       successText,
       showSuccessIcon,
-      description: props.description,
+      descriptionText: props.description,
     };
   },
 });

--- a/frontend/src/components/ui/Radio/index.vue
+++ b/frontend/src/components/ui/Radio/index.vue
@@ -49,9 +49,9 @@
       {{ successText }}
     </p>
     <span
-      v-if="description"
+      v-if="descriptionText"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
-      >{{ description }}</span
+      >{{ descriptionText }}</span
     >
   </div>
 </template>
@@ -133,7 +133,7 @@ export default defineComponent({
       errorText,
       successText,
       showSuccessIcon,
-      description: props.description,
+      descriptionText: props.description,
     };
   },
 });

--- a/frontend/src/components/ui/Switch/index.vue
+++ b/frontend/src/components/ui/Switch/index.vue
@@ -75,9 +75,9 @@
       {{ successText }}
     </p>
     <span
-      v-if="description"
+      v-if="descriptionText"
       class="block text-secondary-500 font-light leading-4 text-xs mt-2"
-      >{{ description }}</span
+      >{{ descriptionText }}</span
     >
   </div>
 </template>
@@ -165,7 +165,7 @@ export default defineComponent({
       errorText,
       successText,
       showSuccessIcon,
-      description: props.description,
+      descriptionText: props.description,
     };
   },
 });


### PR DESCRIPTION
## Summary
- rename returned `description` properties in Checkbox, Radio, and Switch components to avoid `vue/no-dupe-keys` lint errors

## Testing
- `npx eslint src/components/ui/Checkbox/index.vue src/components/ui/Radio/index.vue src/components/ui/Switch/index.vue`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bfddbb508323b41cc17ebc883ed9