### PR TITLE
feat: support task attachments by field and section

### DIFF
--- a/backend/app/Http/Controllers/Api/UploadController.php
+++ b/backend/app/Http/Controllers/Api/UploadController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Jobs\MergeChunks;
 use App\Services\FileStorageService;
+use App\Models\Task;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
@@ -68,6 +69,9 @@ class UploadController extends Controller
     {
         $data = $request->validate([
             'filename' => 'required|string',
+            'task_id' => 'required|exists:tasks,id',
+            'field_key' => 'required|string',
+            'section_key' => 'required|string',
         ]);
 
         $tempPath = 'files/' . $data['filename'];
@@ -85,6 +89,12 @@ class UploadController extends Controller
         );
 
         $file = $storage->store($uploaded);
+
+        $task = Task::findOrFail($data['task_id']);
+        $task->attachments()->attach($file->id, [
+            'field_key' => $data['field_key'],
+            'section_key' => $data['section_key'],
+        ]);
 
         Storage::delete($tempPath);
 

--- a/backend/app/Models/File.php
+++ b/backend/app/Models/File.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class File extends Model
 {
@@ -19,4 +20,11 @@ class File extends Model
     protected $casts = [
         'variants' => 'array',
     ];
+
+    public function tasks(): BelongsToMany
+    {
+        return $this->belongsToMany(Task::class, 'task_attachments')
+            ->withPivot('field_key', 'section_key')
+            ->withTimestamps();
+    }
 }

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Models\File;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Task extends Model
@@ -90,5 +92,22 @@ class Task extends Model
     public function subtasks(): HasMany
     {
         return $this->hasMany(TaskSubtask::class);
+    }
+
+    public function attachments(): BelongsToMany
+    {
+        return $this->belongsToMany(File::class, 'task_attachments')
+            ->withPivot('field_key', 'section_key')
+            ->withTimestamps();
+    }
+
+    public function attachmentsByField(string $fieldKey): BelongsToMany
+    {
+        return $this->attachments()->wherePivot('field_key', $fieldKey);
+    }
+
+    public function attachmentsBySection(string $sectionKey): BelongsToMany
+    {
+        return $this->attachments()->wherePivot('section_key', $sectionKey);
     }
 }

--- a/backend/database/migrations/2025_01_01_170000_create_task_attachments_table.php
+++ b/backend/database/migrations/2025_01_01_170000_create_task_attachments_table.php
@@ -8,19 +8,20 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('appointment_photos', function (Blueprint $table) {
+        Schema::create('task_attachments', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('appointment_id');
+            $table->unsignedBigInteger('task_id');
             $table->unsignedBigInteger('file_id');
-            $table->string('type')->nullable();
+            $table->string('field_key')->nullable();
+            $table->string('section_key')->nullable();
             $table->timestamps();
-            $table->foreign('appointment_id')->references('id')->on('appointments')->onDelete('cascade');
+            $table->foreign('task_id')->references('id')->on('tasks')->onDelete('cascade');
             $table->foreign('file_id')->references('id')->on('files')->onDelete('cascade');
         });
     }
 
     public function down(): void
     {
-        Schema::dropIfExists('appointment_photos');
+        Schema::dropIfExists('task_attachments');
     }
 };

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -198,6 +198,44 @@ paths:
       responses:
         '204':
           description: Deleted
+  /uploads/{uploadId}/finalize:
+    post:
+      summary: Finalize upload
+      parameters:
+        - name: uploadId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filename:
+                  type: string
+                task_id:
+                  type: integer
+                field_key:
+                  type: string
+                section_key:
+                  type: string
+      responses:
+        '200':
+          description: Uploaded file info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  file_id:
+                    type: integer
+                  name:
+                    type: string
+                  variants:
+                    type: object
   /roles/{roleId}/assign:
     post:
       summary: Assign user to role

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -57,7 +57,8 @@ Route::get('files/{file}/{variant?}', [FileController::class, 'download'])
 
 Route::prefix('uploads')->middleware(['auth:sanctum', EnsureTenantScope::class])->group(function () {
     Route::post('chunk', [UploadController::class, 'chunk'])->middleware('throttle:uploads');
-    Route::post('{uploadId}/finalize', [UploadController::class, 'finalize'])->middleware('throttle:uploads');
+    Route::post('{uploadId}/finalize', [UploadController::class, 'finalize'])
+        ->middleware(['throttle:uploads', Ability::class . ':tasks.attach.upload']);
     Route::delete('cleanup', [UploadController::class, 'cleanup'])->middleware('throttle:uploads');
 });
 

--- a/backend/tests/Feature/UploadControllerTest.php
+++ b/backend/tests/Feature/UploadControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Task;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UploadControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_finalize_attaches_file_to_task_with_field_and_section(): void
+    {
+        Storage::fake('local');
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create(['name' => 'User', 'slug' => 'user', 'tenant_id' => $tenant->id, 'abilities' => ['tasks.attach.upload'], 'level' => 1]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        $task = Task::create(['tenant_id' => $tenant->id, 'user_id' => $user->id]);
+        Sanctum::actingAs($user);
+
+        $file = UploadedFile::fake()->image('test.jpg', 100, 100)->size(100);
+        Storage::put('files/test.jpg', file_get_contents($file->getRealPath()));
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/uploads/abc/finalize', [
+                'filename' => 'test.jpg',
+                'task_id' => $task->id,
+                'field_key' => 'photo',
+                'section_key' => 'sec1',
+            ])
+            ->assertStatus(200)
+            ->assertJsonStructure(['file_id', 'name']);
+
+        $this->assertDatabaseHas('task_attachments', [
+            'task_id' => $task->id,
+            'field_key' => 'photo',
+            'section_key' => 'sec1',
+        ]);
+    }
+
+    public function test_chunk_validates_mime_and_size(): void
+    {
+        Storage::fake('local');
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create(['name' => 'User', 'slug' => 'user', 'tenant_id' => $tenant->id, 'abilities' => ['tasks.attach.upload'], 'level' => 1]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u2@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+
+        $badMime = UploadedFile::fake()->create('bad.txt', 10, 'text/plain');
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->post('/api/uploads/chunk', [
+                'upload_id' => '1',
+                'index' => 0,
+                'total' => 1,
+                'filename' => 'bad.txt',
+                'chunk' => $badMime,
+            ])
+            ->assertStatus(422);
+
+        $big = UploadedFile::fake()->create('big.jpg', config('security.max_upload_size') + 1000);
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->post('/api/uploads/chunk', [
+                'upload_id' => '2',
+                'index' => 0,
+                'total' => 1,
+                'filename' => 'big.jpg',
+                'chunk' => $big,
+            ])
+            ->assertStatus(422);
+    }
+}

--- a/frontend/src/components/forms/JsonSchemaForm.vue
+++ b/frontend/src/components/forms/JsonSchemaForm.vue
@@ -6,6 +6,7 @@
       :section="section"
       :form="form"
       :errors="errors"
+      :task-id="taskId"
       :readonly="readonly"
       @update="onUpdate"
       @error="onError"
@@ -17,7 +18,7 @@
 import { reactive, watch } from 'vue';
 import SectionCard from '@/components/tasks/SectionCard.vue';
 
-const props = defineProps<{ schema: any; modelValue: any; readonly?: boolean }>();
+const props = defineProps<{ schema: any; modelValue: any; taskId: number; readonly?: boolean }>();
 const emit = defineEmits<{ (e: 'update:modelValue', value: any): void }>();
 
 const form = reactive<any>({ ...props.modelValue });

--- a/frontend/src/components/tasks/PhotoField.vue
+++ b/frontend/src/components/tasks/PhotoField.vue
@@ -1,20 +1,63 @@
 <template>
   <div class="col-span-2">
     <span class="block font-medium mb-1">{{ photo.label }}</span>
-    <input type="file" :aria-label="photo.label" @change="onChange" />
+    <div v-if="preview" class="mb-2 relative inline-block">
+      <img :src="preview" class="w-32 h-32 object-cover" alt="" />
+      <button
+        type="button"
+        class="absolute top-0 right-0 bg-red-600 text-white px-1"
+        :aria-label="t('actions.delete')"
+        @click="remove"
+        @keyup.enter.prevent="remove"
+        @keyup.space.prevent="remove"
+      >
+        ×
+      </button>
+    </div>
+    <input
+      v-if="!preview"
+      type="file"
+      :aria-label="photo.label"
+      @change="onChange"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { uploadFile } from '@/services/uploader';
-const props = defineProps<{ photo: any; sectionKey: string; modelValue: any }>();
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{ photo: any; sectionKey: string; taskId: number; modelValue: any }>();
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>();
+const { t } = useI18n();
+
+const preview = ref<string | null>(null);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    preview.value = val?.preview || null;
+  },
+  { immediate: true }
+);
 
 async function onChange(e: Event) {
   const file = (e.target as HTMLInputElement).files?.[0];
   if (file) {
-    const uploaded = await uploadFile(file, { fieldKey: props.photo.key, sectionKey: props.sectionKey });
+    const uploaded = await uploadFile(file, {
+      taskId: props.taskId,
+      fieldKey: props.photo.key,
+      sectionKey: props.sectionKey,
+    });
+    uploaded.preview = URL.createObjectURL(file);
+    preview.value = uploaded.preview;
     emit('update:modelValue', uploaded);
   }
+}
+
+function remove() {
+  preview.value = null;
+  emit('update:modelValue', null);
 }
 </script>

--- a/frontend/src/components/tasks/PhotoRepeater.vue
+++ b/frontend/src/components/tasks/PhotoRepeater.vue
@@ -1,25 +1,65 @@
 <template>
   <div class="col-span-2">
     <span class="block font-medium mb-1">{{ photo.label }}</span>
-    <input type="file" multiple :aria-label="photo.label" @change="onChange" />
-    <ul class="mt-2 list-disc list-inside">
-      <li v-for="(p, idx) in modelValue || []" :key="idx">{{ p.filename || p }}</li>
+    <input
+      type="file"
+      multiple
+      :aria-label="photo.label"
+      @change="onChange"
+    />
+    <ul class="mt-2 grid grid-cols-3 gap-2">
+      <li v-for="(p, idx) in items" :key="idx" class="relative">
+        <img :src="p.preview" class="w-32 h-32 object-cover" alt="" />
+        <button
+          type="button"
+          class="absolute top-0 right-0 bg-red-600 text-white px-1"
+          :aria-label="t('actions.delete')"
+          @click="remove(idx)"
+          @keyup.enter.prevent="remove(idx)"
+          @keyup.space.prevent="remove(idx)"
+        >
+          ×
+        </button>
+      </li>
     </ul>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { uploadFile } from '@/services/uploader';
-const props = defineProps<{ photo: any; sectionKey: string; modelValue: any[] }>();
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{ photo: any; sectionKey: string; taskId: number; modelValue: any[] }>();
 const emit = defineEmits<{ (e: 'update:modelValue', v: any[]): void }>();
+const { t } = useI18n();
+
+const items = ref<any[]>([]);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    items.value = (val || []).map((v: any) => ({ ...v }));
+  },
+  { immediate: true }
+);
 
 async function onChange(e: Event) {
   const files = Array.from((e.target as HTMLInputElement).files || []);
-  const uploaded: any[] = [];
   for (const file of files) {
-    uploaded.push(await uploadFile(file, { fieldKey: props.photo.key, sectionKey: props.sectionKey }));
+    const uploaded = await uploadFile(file, {
+      taskId: props.taskId,
+      fieldKey: props.photo.key,
+      sectionKey: props.sectionKey,
+    });
+    uploaded.preview = URL.createObjectURL(file);
+    items.value.push(uploaded);
   }
-  const arr = [...(props.modelValue || []), ...uploaded];
-  emit('update:modelValue', arr);
+  emit('update:modelValue', [...items.value]);
+}
+
+function remove(idx: number) {
+  items.value.splice(idx, 1);
+  emit('update:modelValue', [...items.value]);
 }
 </script>

--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -80,6 +80,7 @@
           v-if="photo.type === 'photo_single'"
           :photo="photo"
           :section-key="section.key"
+          :task-id="taskId"
           :model-value="local[photo.key]"
           @update:modelValue="(v) => updatePhoto(photo.key, v)"
         />
@@ -87,6 +88,7 @@
           v-else
           :photo="photo"
           :section-key="section.key"
+          :task-id="taskId"
           :model-value="local[photo.key]"
           @update:modelValue="(v) => updatePhoto(photo.key, v)"
         />
@@ -101,7 +103,7 @@ import AssigneePicker from '@/components/tasks/AssigneePicker.vue';
 import PhotoField from '@/components/tasks/PhotoField.vue';
 import PhotoRepeater from '@/components/tasks/PhotoRepeater.vue';
 
-const props = defineProps<{ section: any; form: any; errors: Record<string, string>; readonly?: boolean }>();
+const props = defineProps<{ section: any; form: any; errors: Record<string, string>; taskId: number; readonly?: boolean }>();
 const emit = defineEmits<{ (e: 'update', payload: { key: string; value: any }): void; (e: 'error', payload: { key: string; msg: string }): void }>();
 
 const local = reactive<any>(props.form);

--- a/frontend/src/services/uploader.ts
+++ b/frontend/src/services/uploader.ts
@@ -5,6 +5,7 @@ export interface UploadOptions {
   onProgress?: (percent: number) => void;
   fieldKey?: string;
   sectionKey?: string;
+  taskId?: number;
 }
 
 export const DEFAULT_CHUNK_SIZE = 1024 * 1024; // 1MB default, backend allows up to 5MB
@@ -42,6 +43,7 @@ export async function uploadFile(file: File, options: UploadOptions = {}) {
 
   const { data } = await api.post(`/uploads/${uploadId}/finalize`, {
     filename: file.name,
+    task_id: options.taskId,
     field_key: options.fieldKey,
     section_key: options.sectionKey,
   });

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -350,6 +350,57 @@ export interface paths {
         };
         trace?: never;
     };
+    "/uploads/{uploadId}/finalize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Finalize upload */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    uploadId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        filename?: string;
+                        task_id?: number;
+                        field_key?: string;
+                        section_key?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Uploaded file info */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            file_id?: number;
+                            name?: string;
+                            variants?: Record<string, never>;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/roles/{roleId}/assign": {
         parameters: {
             query?: never;

--- a/frontend/src/views/appointments/AppointmentForm.vue
+++ b/frontend/src/views/appointments/AppointmentForm.vue
@@ -27,6 +27,7 @@
         :key="appointmentTypeId"
         v-model="formData"
         :schema="currentSchemaNoAssignee"
+        :task-id="0"
       />
 
       <div class="pt-2">

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -143,6 +143,7 @@
           v-if="formSchemaObj"
           v-model="previewModel"
           :schema="formSchemaObj"
+          :task-id="0"
         />
       </div>
     </form>

--- a/frontend/tests/e2e/upload.spec.ts
+++ b/frontend/tests/e2e/upload.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('file input is accessible', async ({ page }) => {
+  await page.setContent('<input type="file" aria-label="photo" />');
+  const input = page.getByLabel('photo');
+  await expect(input).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- allow uploading task attachments bound to specific form fields/sections
- add chunked photo field and repeater components with previews and delete
- document new uploads API and generate types

## Testing
- `php artisan test` *(fails: Failed opening required vendor/autoload.php)*
- `pnpm test tests/e2e/upload.spec.ts` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f92042c0832385e04cee8f9dc2fe