### PR TITLE
feat(tasks): add subtask management

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskSubtaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskSubtaskController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Task;
+use App\Models\TaskSubtask;
+use Illuminate\Http\Request;
+
+class TaskSubtaskController extends Controller
+{
+    public function store(Request $request, Task $task)
+    {
+        $this->authorize('update', $task);
+
+        $data = $request->validate([
+            'title' => 'required|string',
+            'is_completed' => 'boolean',
+            'assigned_user_id' => 'nullable|integer',
+            'is_required' => 'boolean',
+        ]);
+        $data['position'] = ($task->subtasks()->max('position') ?? 0) + 1;
+        $subtask = $task->subtasks()->create($data);
+        return response()->json($subtask, 201);
+    }
+
+    public function update(Request $request, Task $task, TaskSubtask $subtask)
+    {
+        $this->authorize('update', $task);
+        if ($subtask->task_id !== $task->id) {
+            abort(404);
+        }
+        $data = $request->validate([
+            'title' => 'sometimes|required|string',
+            'is_completed' => 'sometimes|boolean',
+            'assigned_user_id' => 'nullable|integer',
+            'is_required' => 'sometimes|boolean',
+        ]);
+        $subtask->update($data);
+        return response()->json($subtask);
+    }
+
+    public function destroy(Task $task, TaskSubtask $subtask)
+    {
+        $this->authorize('update', $task);
+        if ($subtask->task_id !== $task->id) {
+            abort(404);
+        }
+        $subtask->delete();
+        return response()->json(['message' => 'deleted']);
+    }
+
+    public function reorder(Request $request, Task $task)
+    {
+        $this->authorize('update', $task);
+        $data = $request->validate([
+            'order' => 'required|array',
+            'order.*' => 'integer',
+        ]);
+        foreach ($data['order'] as $index => $id) {
+            $task->subtasks()->where('id', $id)->update(['position' => $index + 1]);
+        }
+        return response()->json(['message' => 'reordered']);
+    }
+}

--- a/backend/app/Models/TaskSubtask.php
+++ b/backend/app/Models/TaskSubtask.php
@@ -11,14 +11,23 @@ class TaskSubtask extends Model
         'task_id',
         'title',
         'is_completed',
+        'assigned_user_id',
+        'is_required',
+        'position',
     ];
 
     protected $casts = [
         'is_completed' => 'boolean',
+        'is_required' => 'boolean',
     ];
 
     public function task(): BelongsTo
     {
         return $this->belongsTo(Task::class);
+    }
+
+    public function assignee(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_user_id');
     }
 }

--- a/backend/app/Models/TaskType.php
+++ b/backend/app/Models/TaskType.php
@@ -16,6 +16,7 @@ class TaskType extends Model
         'statuses',
         'status_flow_json',
         'tenant_id',
+        'require_subtasks_complete',
     ];
 
     protected $casts = [
@@ -23,6 +24,7 @@ class TaskType extends Model
         'statuses' => 'array',
         'status_flow_json' => 'array',
         'tenant_id' => 'integer',
+        'require_subtasks_complete' => 'boolean',
     ];
 
     public function tasks(): HasMany

--- a/backend/app/Policies/TaskPolicy.php
+++ b/backend/app/Policies/TaskPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Gate;
 
 class TaskPolicy extends TenantOwnedPolicy
@@ -16,5 +17,12 @@ class TaskPolicy extends TenantOwnedPolicy
     public function assign(User $user, Task $task): bool
     {
         return Gate::allows('tasks.assign') && $user->tenant_id === $task->tenant_id;
+    }
+
+    public function update(User $user, Model $task): bool
+    {
+        return $task instanceof Task
+            && Gate::allows('tasks.update')
+            && $user->tenant_id === $task->tenant_id;
     }
 }

--- a/backend/app/Services/StatusFlowService.php
+++ b/backend/app/Services/StatusFlowService.php
@@ -98,7 +98,8 @@ class StatusFlowService
             }
         }
 
-        if ($task->subtasks()->where('is_completed', false)->exists()) {
+        if ($type->require_subtasks_complete &&
+            $task->subtasks()->where('is_required', true)->where('is_completed', false)->exists()) {
             return 'subtasks_incomplete';
         }
 

--- a/backend/database/migrations/2025_09_10_000008_create_task_subtasks_table.php
+++ b/backend/database/migrations/2025_09_10_000008_create_task_subtasks_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
             $table->unsignedBigInteger('task_id');
             $table->string('title');
             $table->boolean('is_completed')->default(false);
+            $table->unsignedBigInteger('assigned_user_id')->nullable();
+            $table->boolean('is_required')->default(false);
+            $table->unsignedInteger('position')->default(0);
             $table->timestamps();
         });
     }

--- a/backend/database/migrations/2025_10_05_000004_add_require_subtasks_complete_to_task_types.php
+++ b/backend/database/migrations/2025_10_05_000004_add_require_subtasks_complete_to_task_types.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('task_types', function (Blueprint $table) {
+            $table->boolean('require_subtasks_complete')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('task_types', function (Blueprint $table) {
+            $table->dropColumn('require_subtasks_complete');
+        });
+    }
+};

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -79,6 +79,94 @@ paths:
                 $ref: '#/components/schemas/Task'
         '422':
           description: Invalid transition
+  /tasks/{id}/subtasks:
+    post:
+      summary: Create task subtask
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskSubtask'
+      responses:
+        '201':
+          description: Created subtask
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskSubtask'
+  /tasks/{id}/subtasks/{subtask}:
+    patch:
+      summary: Update task subtask
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: subtask
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskSubtask'
+      responses:
+        '200':
+          description: Updated subtask
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskSubtask'
+    delete:
+      summary: Delete task subtask
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: subtask
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Deleted
+  /tasks/{id}/subtasks/reorder:
+    patch:
+      summary: Reorder subtasks
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                order:
+                  type: array
+                  items:
+                    type: integer
+      responses:
+        '200':
+          description: Reordered
   /tasks/{id}/comments:
     get:
       summary: List task comments
@@ -493,6 +581,24 @@ components:
         created_at:
           type: string
           format: date-time
+    TaskSubtask:
+      type: object
+      properties:
+        id:
+          type: integer
+        task_id:
+          type: integer
+        title:
+          type: string
+        is_completed:
+          type: boolean
+        assigned_user_id:
+          type: integer
+          nullable: true
+        is_required:
+          type: boolean
+        position:
+          type: integer
     Role:
       type: object
       properties:

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -20,6 +20,7 @@ use App\Http\Controllers\Api\TeamController;
 use App\Http\Controllers\Api\LookupController;
 use App\Http\Controllers\Api\CalendarController;
 use App\Http\Controllers\Api\BrandingController;
+use App\Http\Controllers\Api\TaskSubtaskController;
 use App\Http\Middleware\EnsureTenantScope;
 use App\Http\Middleware\Ability;
 use Illuminate\Http\Request;
@@ -86,6 +87,16 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         ->middleware(Ability::class . ':tasks.status.update');
     Route::post('tasks/{task}/files', [FileController::class, 'attachToTask'])
         ->middleware(Ability::class . ':tasks.attach.upload');
+    Route::post('tasks/{task}/subtasks', [TaskSubtaskController::class, 'store'])
+        ->middleware(Ability::class . ':tasks.update');
+    Route::patch('tasks/{task}/subtasks/reorder', [TaskSubtaskController::class, 'reorder'])
+        ->middleware(Ability::class . ':tasks.update');
+    Route::patch('tasks/{task}/subtasks/{subtask}', [TaskSubtaskController::class, 'update'])
+        ->middleware(Ability::class . ':tasks.update')
+        ->whereNumber('subtask');
+    Route::delete('tasks/{task}/subtasks/{subtask}', [TaskSubtaskController::class, 'destroy'])
+        ->middleware(Ability::class . ':tasks.update')
+        ->whereNumber('subtask');
 
     Route::apiResource('task-types', TaskTypeController::class)
         ->only(['index', 'show'])

--- a/backend/tests/Feature/TaskSubtaskTest.php
+++ b/backend/tests/Feature/TaskSubtaskTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Task;
+use App\Models\TaskSubtask;
+use App\Models\TaskType;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskSubtaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Task $task;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Tenant::create(['id' => 1, 'name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create([
+            'name' => 'User',
+            'slug' => 'user',
+            'tenant_id' => 1,
+            'abilities' => ['tasks.update', 'tasks.status.update', 'tasks.manage'],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => 1,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => 1]);
+        Sanctum::actingAs($user);
+        $type = TaskType::create([
+            'name' => 'T',
+            'tenant_id' => 1,
+            'statuses' => ['draft' => [], 'completed' => []],
+            'status_flow_json' => [ ['draft', 'completed'] ],
+            'require_subtasks_complete' => true,
+        ]);
+        $this->task = Task::create([
+            'tenant_id' => 1,
+            'user_id' => $user->id,
+            'task_type_id' => $type->id,
+            'status' => 'draft',
+        ]);
+    }
+
+    public function test_crud_and_reorder_subtasks(): void
+    {
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$this->task->id}/subtasks", ['title' => 'A'])
+            ->assertStatus(201)
+            ->assertJsonPath('title', 'A');
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$this->task->id}/subtasks", ['title' => 'B'])
+            ->assertStatus(201);
+        $s1 = TaskSubtask::where('title', 'A')->first();
+        $s2 = TaskSubtask::where('title', 'B')->first();
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->patchJson("/api/tasks/{$this->task->id}/subtasks/{$s1->id}", ['title' => 'A1', 'is_completed' => true])
+            ->assertStatus(200)
+            ->assertJsonPath('title', 'A1');
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->patchJson("/api/tasks/{$this->task->id}/subtasks/reorder", ['order' => [$s2->id, $s1->id]])
+            ->assertStatus(200);
+        $this->assertEquals(1, $s2->fresh()->position);
+        $this->assertEquals(2, $s1->fresh()->position);
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->deleteJson("/api/tasks/{$this->task->id}/subtasks/{$s1->id}")
+            ->assertStatus(200);
+        $this->assertDatabaseMissing('task_subtasks', ['id' => $s1->id]);
+    }
+
+    public function test_status_constraint_blocks_incomplete_subtasks(): void
+    {
+        $sub = TaskSubtask::create([
+            'task_id' => $this->task->id,
+            'title' => 'Req',
+            'is_required' => true,
+        ]);
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$this->task->id}/status", ['status' => 'completed'])
+            ->assertStatus(422)
+            ->assertJson(['reason' => 'subtasks_incomplete']);
+
+        $sub->update(['is_completed' => true]);
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$this->task->id}/status", ['status' => 'completed'])
+            ->assertStatus(200)
+            ->assertJsonPath('data.status', 'completed');
+    }
+}

--- a/frontend/src/components/tasks/SubtaskList.vue
+++ b/frontend/src/components/tasks/SubtaskList.vue
@@ -1,0 +1,101 @@
+<template>
+  <div>
+    <h3 class="font-semibold mb-2">{{ t('tasks.subtasks.title') }}</h3>
+    <draggable
+      v-model="items"
+      item-key="id"
+      class="flex flex-col gap-2"
+      handle=".handle"
+      @end="onReorder"
+    >
+      <template #item="{ element }">
+        <div class="flex items-center gap-2">
+          <button
+            class="handle cursor-move"
+            aria-label="Drag to reorder"
+          >⋮⋮</button>
+          <input
+            type="checkbox"
+            v-model="element.is_completed"
+            @change="save(element)"
+            :aria-label="t('tasks.subtasks.title')"
+          />
+          <input
+            v-model="element.title"
+            @keyup.enter="save(element)"
+            @blur="save(element)"
+            :aria-label="t('tasks.subtasks.title')"
+            class="flex-1 border rounded p-1"
+          />
+          <button
+            @click="remove(element)"
+            @keyup.enter="remove(element)"
+            class="text-red-600"
+            aria-label="Delete subtask"
+          >✕</button>
+        </div>
+      </template>
+    </draggable>
+    <div class="mt-2 flex items-center gap-2">
+      <input
+        v-model="newTitle"
+        @keyup.enter="add"
+        :aria-label="t('tasks.subtasks.add')"
+        class="flex-1 border rounded p-1"
+        :placeholder="t('tasks.subtasks.add')"
+      />
+      <button
+        @click="add"
+        @keyup.enter="add"
+        class="btn btn-primary"
+        :aria-label="t('tasks.subtasks.add')"
+      >{{ t('tasks.subtasks.add') }}</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import api from '@/services/api';
+import draggable from 'vuedraggable';
+
+const props = defineProps<{ taskId: number }>();
+const { t } = useI18n();
+const items = ref<any[]>([]);
+const newTitle = ref('');
+
+async function load() {
+  const { data } = await api.get(`/tasks/${props.taskId}`);
+  items.value = data.subtasks || [];
+}
+
+onMounted(load);
+
+async function add() {
+  if (!newTitle.value) return;
+  const { data } = await api.post(`/tasks/${props.taskId}/subtasks`, {
+    title: newTitle.value,
+  });
+  items.value.push(data);
+  newTitle.value = '';
+}
+
+async function save(item: any) {
+  await api.patch(`/tasks/${props.taskId}/subtasks/${item.id}`, {
+    title: item.title,
+    is_completed: item.is_completed,
+  });
+}
+
+async function remove(item: any) {
+  await api.delete(`/tasks/${props.taskId}/subtasks/${item.id}`);
+  items.value = items.value.filter((s) => s.id !== item.id);
+}
+
+async function onReorder() {
+  await api.patch(`/tasks/${props.taskId}/subtasks/reorder`, {
+    order: items.value.map((s) => s.id),
+  });
+}
+</script>

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -35,6 +35,7 @@
     "appointmentDetail": "Λεπτομέρειες Ραντεβού",
     "appointmentCreate": "Δημιουργία Ραντεβού",
     "appointmentEdit": "Επεξεργασία Ραντεβού",
+    "taskDetail": "Λεπτομέρειες Εργασίας",
     "manuals": "Εγχειρίδια",
     "manualDetail": "Λεπτομέρειες Εγχειριδίου",
     "manualCreate": "Μεταφόρτωση Εγχειριδίου",
@@ -105,6 +106,10 @@
       "placeholder": "Προσθέστε σχόλιο",
       "mentions": "Αναφορές",
       "mentionUsers": "Αναφέρετε χρήστες"
+    },
+    "subtasks": {
+      "title": "Υποεργασίες",
+      "add": "Προσθήκη υποεργασίας"
     }
   },
   "dashboard": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -35,6 +35,7 @@
     "appointmentDetail": "Appointment Detail",
     "appointmentCreate": "Create Appointment",
     "appointmentEdit": "Edit Appointment",
+    "taskDetail": "Task Detail",
     "manuals": "Manuals",
     "manualDetail": "Manual Detail",
     "manualCreate": "Upload Manual",
@@ -105,6 +106,10 @@
       "placeholder": "Add a comment",
       "mentions": "Mentions",
       "mentionUsers": "Mention users"
+    },
+    "subtasks": {
+      "title": "Subtasks",
+      "add": "Add subtask"
     }
   },
   "dashboard": {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -83,6 +83,18 @@ export const routes = [
     },
   },
   {
+    path: '/tasks/:id',
+    name: 'tasks.details',
+    component: () => import('@/views/tasks/TaskDetails.vue'),
+    meta: {
+      requiresAuth: true,
+      requiredAbilities: ['tasks.view', 'tasks.manage'],
+      breadcrumb: 'routes.taskDetail',
+      title: 'Task Detail',
+      layout: 'app',
+    },
+  },
+  {
     path: '/types',
     name: 'types.list',
     component: () => import('@/views/types/TypesList.vue'),

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -157,6 +157,154 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/tasks/{id}/subtasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create task subtask */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["TaskSubtask"];
+                };
+            };
+            responses: {
+                /** @description Created subtask */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskSubtask"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/tasks/{id}/subtasks/{subtask}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete task subtask */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                    subtask: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Deleted */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Update task subtask */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                    subtask: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["TaskSubtask"];
+                };
+            };
+            responses: {
+                /** @description Updated subtask */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TaskSubtask"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/tasks/{id}/subtasks/reorder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Reorder subtasks */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        order?: number[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Reordered */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
     "/tasks/{id}/comments": {
         parameters: {
             query?: never;
@@ -866,6 +1014,15 @@ export interface components {
             mentions?: components["schemas"]["Employee"][];
             /** Format: date-time */
             created_at?: string;
+        };
+        TaskSubtask: {
+            id?: number;
+            task_id?: number;
+            title?: string;
+            is_completed?: boolean;
+            assigned_user_id?: number | null;
+            is_required?: boolean;
+            position?: number;
         };
         Role: {
             id?: number;

--- a/frontend/src/views/tasks/TaskDetails.vue
+++ b/frontend/src/views/tasks/TaskDetails.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <SubtaskList :task-id="Number(route.params.id)" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router';
+import SubtaskList from '@/components/tasks/SubtaskList.vue';
+
+const route = useRoute();
+</script>

--- a/frontend/tests/e2e/tasks.spec.ts
+++ b/frontend/tests/e2e/tasks.spec.ts
@@ -4,3 +4,7 @@ test('tasks status flow e2e placeholder', async () => {
   // Backend not available in test environment; placeholder asserts always true.
   expect(true).toBe(true);
 });
+
+test('subtasks e2e placeholder', async () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add CRUD API and controller for task subtasks with ordering and assignment
- require subtask completion on status change when task type demands
- add Vue subtask list component and route for task details

## Testing
- `pnpm gen:api:types`
- `php artisan test tests/Feature/TaskSubtaskTest.php`
- `pnpm test` *(fails: Host system missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fb8472bc8323b8c584c3fe9f5cdd