### PR TITLE
feat(tasks): add advanced filter views and bulk status

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -77,7 +77,24 @@
     },
     "filters": {
       "global": "Αναζήτηση εργασιών",
-      "statusPlaceholder": "Επιλογή καταστάσεων"
+      "statusPlaceholder": "Επιλογή καταστάσεων",
+      "toggle": "Φίλτρα",
+      "status": "Κατάσταση",
+      "type": "Τύπος",
+      "assignee": "Υπεύθυνος/Ομάδα",
+      "priority": "Προτεραιότητα",
+      "dueFrom": "Προθεσμία από",
+      "dueTo": "Προθεσμία έως",
+      "hasPhotos": "Με φωτογραφίες",
+      "mine": "Δικές μου",
+      "allStatuses": "Όλες οι καταστάσεις",
+      "allTypes": "Όλοι οι τύποι",
+      "allPriorities": "Όλες οι προτεραιότητες",
+      "savedViews": "Αποθηκευμένες προβολές",
+      "savedViewsPlaceholder": "Αποθηκευμένες προβολές",
+      "saveView": "Αποθήκευση προβολής",
+      "saveViewPrompt": "Όνομα προβολής",
+      "selectStatus": "Επιλογή κατάστασης"
     },
     "messages": {
       "created": "Η εργασία δημιουργήθηκε",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -77,7 +77,24 @@
     },
     "filters": {
       "global": "Search tasks",
-      "statusPlaceholder": "Select statuses"
+      "statusPlaceholder": "Select statuses",
+      "toggle": "Filters",
+      "status": "Status",
+      "type": "Type",
+      "assignee": "Assignee/Team",
+      "priority": "Priority",
+      "dueFrom": "Due From",
+      "dueTo": "Due To",
+      "hasPhotos": "Has photos",
+      "mine": "Mine",
+      "allStatuses": "All statuses",
+      "allTypes": "All types",
+      "allPriorities": "All priorities",
+      "savedViews": "Saved views",
+      "savedViewsPlaceholder": "Saved views",
+      "saveView": "Save View",
+      "saveViewPrompt": "View name",
+      "selectStatus": "Select status"
     },
     "messages": {
       "created": "Task created",

--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -7,47 +7,132 @@
           :to="{ name: 'tasks.create' }"
         >
           <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
-          New
+          {{ t('tasks.new') }}
         </RouterLink>
       </div>
-    <div class="flex gap-4 mb-4">
-      <div class="flex flex-col">
-        <span id="tasks-status-label" class="mb-1 text-sm">Status</span>
+
+      <div class="flex items-center gap-2 mb-4">
+          <button
+            class="btn btn-outline-dark"
+            :aria-expanded="showFilters.toString()"
+            aria-controls="task-filters"
+            @click="toggleFilters"
+          >
+            {{ t('tasks.filters.toggle', 'Filters') }}
+          </button>
         <select
-          v-model="statusFilter"
+          v-if="Object.keys(savedViews).length"
+          v-model="selectedView"
           class="border rounded p-2"
-          aria-labelledby="tasks-status-label"
+          :aria-label="t('tasks.filters.savedViews')"
+          @change="applyView"
         >
-          <option value="">All Statuses</option>
-          <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
+          <option value="">{{ t('tasks.filters.savedViewsPlaceholder') }}</option>
+          <option v-for="(v, name) in savedViews" :key="name" :value="name">{{ name }}</option>
         </select>
+        <button
+          class="btn btn-outline-dark"
+          :aria-label="t('tasks.filters.saveView')"
+          @click="saveView"
+        >
+          {{ t('tasks.filters.saveView') }}
+        </button>
       </div>
-      <div class="flex flex-col">
-        <span id="tasks-start-label" class="mb-1 text-sm">Start Date</span>
-        <input
-          v-model="startDate"
-          type="date"
-          class="border rounded p-2"
-          aria-labelledby="tasks-start-label"
-        />
+
+      <div v-if="showFilters" id="task-filters" class="p-4 border rounded mb-4">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <label class="flex flex-col" for="filter-status">
+              <span class="mb-1 text-sm">{{ t('tasks.filters.status') }}</span>
+              <select
+                id="filter-status"
+                v-model="statusFilter"
+                class="border rounded p-2"
+              >
+                <option value="">{{ t('tasks.filters.allStatuses') }}</option>
+                <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
+              </select>
+            </label>
+            <label class="flex flex-col" for="filter-type">
+              <span class="mb-1 text-sm">{{ t('tasks.filters.type') }}</span>
+              <select
+                id="filter-type"
+                v-model="typeFilter"
+                class="border rounded p-2"
+              >
+                <option value="">{{ t('tasks.filters.allTypes') }}</option>
+                <option v-for="type in typeOptions" :key="type.id" :value="type.id">{{ type.name }}</option>
+              </select>
+            </label>
+            <div class="flex flex-col sm:col-span-2 lg:col-span-1">
+              <span id="filter-assignee-label" class="mb-1 text-sm">{{ t('tasks.filters.assignee') }}</span>
+              <AssigneePicker v-model="assigneeFilter" :aria-labelledby="'filter-assignee-label'" />
+            </div>
+            <label class="flex flex-col" for="filter-priority">
+              <span class="mb-1 text-sm">{{ t('tasks.filters.priority') }}</span>
+              <select
+                id="filter-priority"
+                v-model="priorityFilter"
+                class="border rounded p-2"
+              >
+                <option value="">{{ t('tasks.filters.allPriorities') }}</option>
+                <option v-for="p in priorityOptions" :key="p.value" :value="p.value">{{ t(`tasks.priority.${p.value}`) }}</option>
+              </select>
+            </label>
+            <label class="flex flex-col" for="filter-due-start">
+              <span class="mb-1 text-sm">{{ t('tasks.filters.dueFrom') }}</span>
+              <input id="filter-due-start" v-model="dueStart" type="date" class="border rounded p-2" />
+            </label>
+            <label class="flex flex-col" for="filter-due-end">
+              <span class="mb-1 text-sm">{{ t('tasks.filters.dueTo') }}</span>
+              <input id="filter-due-end" v-model="dueEnd" type="date" class="border rounded p-2" />
+            </label>
+            <label class="flex items-center" for="filter-photos">
+              <input id="filter-photos" v-model="hasPhotos" type="checkbox" class="mr-2" />
+              <span class="text-sm">{{ t('tasks.filters.hasPhotos') }}</span>
+            </label>
+            <label class="flex items-center" for="filter-mine">
+              <input id="filter-mine" v-model="mine" type="checkbox" class="mr-2" />
+              <span class="text-sm">{{ t('tasks.filters.mine') }}</span>
+            </label>
+          </div>
+        </div>
+
+        <div v-if="selected.length" class="mb-4 flex items-center gap-2">
+          <label class="flex flex-col text-sm" for="bulk-status">
+            {{ t('tasks.status.update') }}
+            <select
+              id="bulk-status"
+              v-model="bulkStatus"
+              class="border rounded p-2"
+              :aria-label="t('tasks.status.update')"
+            >
+              <option value="">{{ t('tasks.filters.selectStatus', 'Select status') }}</option>
+              <option v-for="s in bulkStatusOptions" :key="s" :value="s">{{ s }}</option>
+            </select>
+          </label>
+          <button
+            class="btn btn-dark"
+            :disabled="!bulkStatus"
+            :aria-label="t('tasks.status.update')"
+            @click="applyBulkStatus"
+          >
+            {{ t('actions.save') }}
+          </button>
       </div>
-      <div class="flex flex-col">
-        <span id="tasks-end-label" class="mb-1 text-sm">End Date</span>
-        <input
-          v-model="endDate"
-          type="date"
-          class="border rounded p-2"
-          aria-labelledby="tasks-end-label"
-        />
-      </div>
-    </div>
     <DashcodeServerTable
       :key="tableKey"
       :columns="columns"
       :fetcher="fetchTasks"
     >
       <template #actions="{ row }">
-        <div class="flex gap-2">
+        <div class="flex gap-2 items-center">
+          <input
+            v-model="selected"
+            :value="row.id"
+            type="checkbox"
+            :aria-label="`Select task ${row.id}`"
+            @keyup.enter="toggleSelect(row.id)"
+          />
           <button
             class="text-blue-600"
             title="View"
@@ -97,25 +182,46 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
 import api from '@/services/api';
 import { useNotify } from '@/plugins/notify';
 import Icon from '@/components/ui/Icon';
 import Swal from 'sweetalert2';
 import { parseISO, formatDisplay } from '@/utils/datetime';
-import { can } from '@/stores/auth';
+import { can, useAuthStore } from '@/stores/auth';
+import AssigneePicker from '@/components/tasks/AssigneePicker.vue';
 
 const router = useRouter();
 const notify = useNotify();
+const { t } = useI18n();
+const auth = useAuthStore();
 
+const showFilters = ref(false);
 const statusFilter = ref('');
-const startDate = ref('');
-const endDate = ref('');
+const typeFilter = ref('');
+const assigneeFilter = ref<any | null>(null);
+const priorityFilter = ref('');
+const dueStart = ref('');
+const dueEnd = ref('');
+const hasPhotos = ref(false);
+const mine = ref(false);
+
+const savedViews = ref<Record<string, any>>({});
+const selectedView = ref('');
+
 const tableKey = ref(0);
 
 const statusOptions = ref<string[]>([]);
+const typeOptions = ref<any[]>([]);
+const priorityOptions = [
+  { value: 'low' },
+  { value: 'normal' },
+  { value: 'high' },
+  { value: 'urgent' },
+];
 
 const columns = [
   { label: 'ID', field: 'id', sortable: true },
@@ -143,12 +249,85 @@ const statusIcons: Record<string, string> = {
   redo: 'heroicons-outline:arrow-path',
 };
 
+const selected = ref<number[]>([]);
+const bulkStatus = ref('');
 const all = ref<any[]>([]);
 
-onMounted(async () => {
-  const { data } = await api.get('/task-statuses');
-  statusOptions.value = data.map((s: any) => s.name);
+const bulkStatusOptions = computed(() => {
+  if (!selected.value.length) return [] as string[];
+  const first = all.value.find((r) => r.id === selected.value[0]);
+  let allowed = first ? getChangeActions(first) : [];
+  for (const id of selected.value.slice(1)) {
+    const row = all.value.find((r) => r.id === id);
+    const actions = row ? getChangeActions(row) : [];
+    allowed = allowed.filter((a: string) => actions.includes(a));
+  }
+  return allowed;
 });
+
+onMounted(async () => {
+  const [statusRes, typeRes] = await Promise.all([
+    api.get('/task-statuses'),
+    api.get('/task-types'),
+  ]);
+  statusOptions.value = statusRes.data.map((s: any) => s.name);
+  typeOptions.value = typeRes.data;
+  const stored = localStorage.getItem('taskViews');
+  if (stored) savedViews.value = JSON.parse(stored);
+});
+
+function toggleFilters() {
+  showFilters.value = !showFilters.value;
+}
+
+function saveView() {
+  const name = window.prompt(t('tasks.filters.saveViewPrompt'));
+  if (!name) return;
+  savedViews.value[name] = {
+    status: statusFilter.value,
+    type: typeFilter.value,
+    assignee: assigneeFilter.value,
+    priority: priorityFilter.value,
+    dueStart: dueStart.value,
+    dueEnd: dueEnd.value,
+    hasPhotos: hasPhotos.value,
+    mine: mine.value,
+  };
+  localStorage.setItem('taskViews', JSON.stringify(savedViews.value));
+}
+
+function applyView() {
+  const v = savedViews.value[selectedView.value];
+  if (!v) return;
+  statusFilter.value = v.status || '';
+  typeFilter.value = v.type || '';
+  assigneeFilter.value = v.assignee || null;
+  priorityFilter.value = v.priority || '';
+  dueStart.value = v.dueStart || '';
+  dueEnd.value = v.dueEnd || '';
+  hasPhotos.value = v.hasPhotos || false;
+  mine.value = v.mine || false;
+}
+
+function toggleSelect(id: number) {
+  const i = selected.value.indexOf(id);
+  if (i >= 0) selected.value.splice(i, 1);
+  else selected.value.push(id);
+}
+
+async function applyBulkStatus() {
+  for (const id of selected.value) {
+    const row = all.value.find((r) => r.id === id);
+    if (!row) continue;
+    if (!(can('tasks.update') || can('tasks.manage'))) continue;
+    if (!getChangeActions(row).includes(bulkStatus.value)) continue;
+    await api.post(`/tasks/${id}/status`, { status: bulkStatus.value });
+    row.status = bulkStatus.value;
+  }
+  selected.value = [];
+  bulkStatus.value = '';
+  reload();
+}
 
 async function fetchTasks({ page, perPage, sort, search }: any) {
   if (!all.value.length) {
@@ -160,17 +339,33 @@ async function fetchTasks({ page, perPage, sort, search }: any) {
   if (statusFilter.value) {
     rows = rows.filter((r) => r.status === statusFilter.value);
   }
-  if (startDate.value) {
-    const start = parseISO(startDate.value);
+  if (typeFilter.value) {
+    rows = rows.filter((r) => r.type && r.type.id === Number(typeFilter.value));
+  }
+  if (assigneeFilter.value) {
     rows = rows.filter(
-      (r) => r.scheduled_at && parseISO(r.scheduled_at) >= start,
+      (r) =>
+        r.assignee &&
+        r.assignee.id === assigneeFilter.value.id &&
+        r.assignee.kind === assigneeFilter.value.kind,
     );
   }
-  if (endDate.value) {
-    const end = parseISO(endDate.value);
-    rows = rows.filter(
-      (r) => r.scheduled_at && parseISO(r.scheduled_at) <= end,
-    );
+  if (priorityFilter.value) {
+    rows = rows.filter((r) => r.priority === priorityFilter.value);
+  }
+  if (dueStart.value) {
+    const start = parseISO(dueStart.value);
+    rows = rows.filter((r) => r.due_at && parseISO(r.due_at) >= start);
+  }
+  if (dueEnd.value) {
+    const end = parseISO(dueEnd.value);
+    rows = rows.filter((r) => r.due_at && parseISO(r.due_at) <= end);
+  }
+  if (hasPhotos.value) {
+    rows = rows.filter((r) => r.photos && r.photos.length);
+  }
+  if (mine.value && auth.user) {
+    rows = rows.filter((r) => r.assignee && r.assignee.id === auth.user.id);
   }
   if (search) {
     const q = String(search).toLowerCase();
@@ -205,7 +400,20 @@ function reload() {
   tableKey.value++;
 }
 
-watch([statusFilter, startDate, endDate], reload);
+watch(
+  [
+    statusFilter,
+    typeFilter,
+    assigneeFilter,
+    priorityFilter,
+    dueStart,
+    dueEnd,
+    hasPhotos,
+    mine,
+  ],
+  reload,
+  { deep: true },
+);
 
 function view(id: number) {
   router.push({ name: 'tasks.details', params: { id } });

--- a/frontend/tests/e2e/task-filters.spec.ts
+++ b/frontend/tests/e2e/task-filters.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('save and load filter view', async ({ page }) => {
+  await page.goto('about:blank');
+  await page.evaluate(() => {
+    localStorage.clear();
+    const views: Record<string, any> = {};
+    views['My View'] = { status: 'draft' };
+    localStorage.setItem('taskViews', JSON.stringify(views));
+  });
+  const result = await page.evaluate(() => JSON.parse(localStorage.getItem('taskViews') || '{}'));
+  expect(result['My View'].status).toBe('draft');
+});
+
+test('bulk status change respects allowed actions', async ({ page }) => {
+  await page.goto('about:blank');
+  const updated = await page.evaluate(() => {
+    const selected = [1, 2];
+    const actions: Record<number, string[]> = { 1: ['done'], 2: [] };
+    const target = 'done';
+    return selected.filter((id) => actions[id]?.includes(target));
+  });
+  expect(updated).toEqual([1]);
+});


### PR DESCRIPTION
## Summary
- extend Tasks list with advanced filters and locally saved views
- allow bulk status updates with RBAC checks
- document i18n strings and add basic Playwright tests

## Testing
- `pnpm lint`
- `pnpm gen:api:types`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b21033ef00832389c3243ab2457a2f