### PR TITLE
Fix task attachment migration foreign key

### DIFF
--- a/backend/database/migrations/2025_01_01_170000_create_task_attachments_table.php
+++ b/backend/database/migrations/2025_01_01_170000_create_task_attachments_table.php
@@ -8,14 +8,16 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('task_attachments', function (Blueprint $table) {
+        $taskTable = Schema::hasTable('tasks') ? 'tasks' : 'appointments';
+
+        Schema::create('task_attachments', function (Blueprint $table) use ($taskTable) {
             $table->id();
             $table->unsignedBigInteger('task_id');
             $table->unsignedBigInteger('file_id');
             $table->string('field_key')->nullable();
             $table->string('section_key')->nullable();
             $table->timestamps();
-            $table->foreign('task_id')->references('id')->on('tasks')->onDelete('cascade');
+            $table->foreign('task_id')->references('id')->on($taskTable)->onDelete('cascade');
             $table->foreign('file_id')->references('id')->on('files')->onDelete('cascade');
         });
     }


### PR DESCRIPTION
## Summary
- make task attachments migration resilient to tasks table rename

## Testing
- `php artisan migrate:fresh --force` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `php artisan test` *(fails: 8 failed, 6 incomplete, 58 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b222a92fe4832382efba21dd5c86aa