### PR TITLE
Refactor appointments to tasks

### DIFF
--- a/backend/app/Http/Controllers/Api/CalendarController.php
+++ b/backend/app/Http/Controllers/Api/CalendarController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Appointment;
+use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -21,7 +21,7 @@ class CalendarController extends Controller
             'status_id' => 'nullable|string',
         ]);
 
-        $query = Appointment::where('tenant_id', $request->user()->tenant_id)
+        $query = Task::where('tenant_id', $request->user()->tenant_id)
             ->with(['type', 'assignee'])
             ->whereBetween('scheduled_at', [$data['start'], $data['end']]);
 
@@ -36,23 +36,23 @@ class CalendarController extends Controller
         }
 
         if ($request->filled('type_id')) {
-            $query->where('appointment_type_id', $request->query('type_id'));
+            $query->where('task_type_id', $request->query('type_id'));
         }
 
         if ($request->filled('status_id')) {
             $query->where('status', $request->query('status_id'));
         }
 
-        $events = $query->get()->map(function ($a) {
+        $events = $query->get()->map(function ($t) {
             return [
-                'id' => $a->id,
-                'title' => $a->title ?? $a->type->name ?? 'Appointment ' . $a->id,
-                'start' => $a->scheduled_at,
-                'end' => $a->sla_end_at ?? $a->scheduled_at,
+                'id' => $t->id,
+                'title' => $t->title ?? $t->type->name ?? 'Task ' . $t->id,
+                'start' => $t->scheduled_at,
+                'end' => $t->sla_end_at ?? $t->scheduled_at,
                 'extendedProps' => [
-                    'status' => $a->status,
-                    'type' => $a->type->name ?? null,
-                    'assignee' => $a->assignee->name ?? null,
+                    'status' => $t->status,
+                    'type' => $t->type->name ?? null,
+                    'assignee' => $t->assignee->name ?? null,
                 ],
             ];
         });

--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -47,7 +47,7 @@ class TenantController extends Controller
             $tenant = Tenant::create([
                 'name' => $data['name'],
                 'quota_storage_mb' => $data['quota_storage_mb'] ?? null,
-                'features' => $data['features'] ?? ['appointments'],
+                'features' => $data['features'] ?? ['tasks'],
                 'phone' => $data['phone'] ?? null,
                 'address' => $data['address'] ?? null,
             ]);

--- a/backend/app/Notifications/TaskCommentMentioned.php
+++ b/backend/app/Notifications/TaskCommentMentioned.php
@@ -2,16 +2,16 @@
 
 namespace App\Notifications;
 
-use App\Models\AppointmentComment;
+use App\Models\TaskComment;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class AppointmentCommentMentioned extends Notification
+class TaskCommentMentioned extends Notification
 {
     use Queueable;
 
-    public function __construct(public AppointmentComment $comment)
+    public function __construct(public TaskComment $comment)
     {
     }
 
@@ -23,14 +23,14 @@ class AppointmentCommentMentioned extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->line('You were mentioned in an appointment comment.')
-            ->action('View Appointment', url('/appointments/' . $this->comment->appointment_id));
+            ->line('You were mentioned in a task comment.')
+            ->action('View Task', url('/tasks/' . $this->comment->task_id));
     }
 
     public function toArray(object $notifiable): array
     {
         return [
-            'appointment_id' => $this->comment->appointment_id,
+            'task_id' => $this->comment->task_id,
             'comment_id' => $this->comment->id,
         ];
     }

--- a/backend/database/seeders/DefaultFeatureRolesSeeder.php
+++ b/backend/database/seeders/DefaultFeatureRolesSeeder.php
@@ -17,7 +17,7 @@ class DefaultFeatureRolesSeeder extends Seeder
 
         foreach ($features as $feature) {
             switch ($feature) {
-                case 'appointments':
+                case 'tasks':
                 case 'notifications':
                 case 'types':
                 case 'teams':

--- a/backend/database/seeders/TenantRolesBackfillSeeder.php
+++ b/backend/database/seeders/TenantRolesBackfillSeeder.php
@@ -9,7 +9,7 @@ class TenantRolesBackfillSeeder extends Seeder
 {
     public function run(): void
     {
-        $defaultFeatures = ['appointments','notifications','roles','types','teams','statuses','themes'];
+        $defaultFeatures = ['tasks','notifications','roles','types','teams','statuses','themes'];
 
         Tenant::query()->lazy()->each(function (Tenant $tenant) use ($defaultFeatures) {
             if (empty($tenant->features)) {


### PR DESCRIPTION
## Summary
- refactor SLA service and controllers to use Task model instead of legacy Appointment
- update notifications, storage cleanup job, and seeders to use task terminology and tables
- default new tenants to `tasks` feature instead of `appointments`

## Testing
- `composer test` (fails: missing .env and several failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68b284e1ad648323a244c8c6b55ccc26