### PR TITLE
Generate slug automatically for task statuses

### DIFF
--- a/backend/app/Models/TaskStatus.php
+++ b/backend/app/Models/TaskStatus.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 class TaskStatus extends Model
 {
@@ -14,6 +15,15 @@ class TaskStatus extends Model
         'position',
         'color',
     ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $status): void {
+            if (empty($status->slug)) {
+                $status->slug = Str::snake($status->name);
+            }
+        });
+    }
 
     public function tasks(): HasMany
     {

--- a/backend/tests/Feature/TaskStatusSlugTest.php
+++ b/backend/tests/Feature/TaskStatusSlugTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskStatusSlugTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_slug_is_generated_from_name(): void
+    {
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create([
+            'name' => 'ClientAdmin',
+            'slug' => 'client_admin',
+            'tenant_id' => $tenant->id,
+            'abilities' => ['task_statuses.manage'],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+
+        $payload = ['name' => 'In Progress'];
+
+        $id = $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/task-statuses', $payload)
+            ->assertStatus(201)
+            ->assertJsonPath('data.slug', 'in_progress')
+            ->json('data.id');
+
+        $this->assertDatabaseHas('task_statuses', [
+            'id' => $id,
+            'name' => 'In Progress',
+            'slug' => 'in_progress',
+            'tenant_id' => $tenant->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- auto-generate a slug for task statuses when none is provided
- cover task status slug generation with a feature test

## Testing
- `composer test` (fails: 7 failed, 53 warnings, 6 incomplete, 7 passed)
- `vendor/bin/phpunit tests/Feature/TaskStatusSlugTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2865ed7dc83239c7cb00b3169df38