### PR TITLE
fix: render statuses and types lists

### DIFF
--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -113,7 +113,7 @@ const columns = [
 async function fetchStatuses({ page, perPage, sort, search }: any) {
   if (!all.value.length) {
     const tenantId = auth.isSuperAdmin ? tenantStore.currentTenantId : undefined;
-    all.value = await statusesStore.fetch(scope.value, tenantId);
+    all.value = (await statusesStore.fetch(scope.value, tenantId)).data;
   }
   let rows = all.value.slice();
   if (search) {

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -113,7 +113,7 @@ const columns = [
 async function fetchTypes({ page, perPage, sort, search }: any) {
   if (!all.value.length) {
     const tenantId = auth.isSuperAdmin ? tenantStore.currentTenantId : undefined;
-    all.value = await typesStore.fetch(scope.value, tenantId);
+    all.value = (await typesStore.fetch(scope.value, tenantId)).data;
   }
   let rows = all.value.slice();
   if (search) {


### PR DESCRIPTION
## Summary
- fix Task Statuses list fetch to unwrap data property
- fix Task Types list fetch to unwrap data property

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/)*

------
https://chatgpt.com/codex/tasks/task_e_68b2877c06c8832393214d6d486c42f4