### PR TITLE
refactor: centralize ability checks

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -115,6 +115,10 @@ export function can(ability: string): boolean {
   return useAuthStore().can(ability);
 }
 
+export function hasAny(abilities: string[]): boolean {
+  return useAuthStore().hasAny(abilities);
+}
+
 export function hasFeature(feature: string): boolean {
   return useAuthStore().features.includes(feature);
 }

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -14,7 +14,7 @@
         </select>
       </div>
       <RouterLink
-        v-if="can('roles.create') || can('roles.manage')"
+        v-if="hasAny(['roles.create', 'roles.manage'])"
         class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
         :to="{ name: 'roles.create' }"
       >
@@ -28,12 +28,12 @@
       :fetcher="fetchRoles"
     >
       <template
-        v-if="can('roles.update') || can('roles.delete') || can('roles.manage')"
+        v-if="hasAny(['roles.update', 'roles.delete', 'roles.manage'])"
         #actions="{ row }"
       >
         <div v-if="row.name !== 'SuperAdmin'" class="flex gap-2">
           <button
-            v-if="can('roles.update') || can('roles.manage')"
+            v-if="hasAny(['roles.update', 'roles.manage'])"
             class="text-blue-600"
             title="Edit"
             @click="edit(row.id)"
@@ -41,7 +41,7 @@
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
           <button
-            v-if="can('roles.delete') || can('roles.manage')"
+            v-if="hasAny(['roles.delete', 'roles.manage'])"
             class="text-red-600"
             title="Delete"
             @click="remove(row.id)"
@@ -76,7 +76,7 @@ import Swal from 'sweetalert2';
 import Icon from '@/components/ui/Icon';
 import { useNotify } from '@/plugins/notify';
 import { useRolesStore } from '@/stores/roles';
-import { useAuthStore, can } from '@/stores/auth';
+import { useAuthStore, can, hasAny } from '@/stores/auth';
 import { useTenantStore } from '@/stores/tenant';
 import AssignRoleModal from './AssignRoleModal.vue';
 

--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -2,7 +2,7 @@
     <div>
       <div class="flex items-center justify-end mb-4">
         <RouterLink
-          v-if="can('tasks.create') || can('tasks.manage')"
+          v-if="hasAny(['tasks.create', 'tasks.manage'])"
           class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
           :to="{ name: 'tasks.create' }"
         >
@@ -143,7 +143,7 @@
             <Icon icon="heroicons-outline:eye" class="w-5 h-5" />
           </button>
           <button
-            v-if="can('tasks.update') || can('tasks.manage')"
+            v-if="hasAny(['tasks.update', 'tasks.manage'])"
             class="text-blue-600"
             title="Edit"
             aria-label="Edit"
@@ -153,7 +153,7 @@
             <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
           </button>
           <button
-            v-if="can('tasks.delete') || can('tasks.manage')"
+            v-if="hasAny(['tasks.delete', 'tasks.manage'])"
             class="text-red-600"
             title="Delete"
             aria-label="Delete"
@@ -162,7 +162,7 @@
           >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
-          <template v-if="can('tasks.update') || can('tasks.manage')">
+          <template v-if="hasAny(['tasks.update', 'tasks.manage'])">
             <button
               v-for="s in getChangeActions(row)"
               :key="s"
@@ -191,7 +191,7 @@ import { useNotify } from '@/plugins/notify';
 import Icon from '@/components/ui/Icon';
 import Swal from 'sweetalert2';
 import { parseISO, formatDisplay } from '@/utils/datetime';
-import { can, useAuthStore } from '@/stores/auth';
+import { hasAny, useAuthStore } from '@/stores/auth';
 import AssigneePicker from '@/components/tasks/AssigneePicker.vue';
 
 const router = useRouter();
@@ -319,7 +319,7 @@ async function applyBulkStatus() {
   for (const id of selected.value) {
     const row = all.value.find((r) => r.id === id);
     if (!row) continue;
-    if (!(can('tasks.update') || can('tasks.manage'))) continue;
+    if (!hasAny(['tasks.update', 'tasks.manage'])) continue;
     if (!getChangeActions(row).includes(bulkStatus.value)) continue;
     await api.post(`/tasks/${id}/status`, { status: bulkStatus.value });
     row.status = bulkStatus.value;


### PR DESCRIPTION
## Summary
- add `hasAny` helper to auth store for multi-ability checks
- use `hasAny` in Roles and Tasks list views to gate CRUD UI actions

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch missing browser; Playwright dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b28859c41c8323b90d0411bb6f4e36