### PR TITLE
fix: populate status edit form and allow tenant assignment

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskStatusController.php
+++ b/backend/app/Http/Controllers/Api/TaskStatusController.php
@@ -73,9 +73,9 @@ class TaskStatusController extends Controller
         $data = $request->validated();
 
         if ($request->user()->hasRole('SuperAdmin')) {
-            if (array_key_exists('tenant_id', $data)) {
-                $data['tenant_id'] = $data['tenant_id'];
-            }
+            $data['tenant_id'] = array_key_exists('tenant_id', $data)
+                ? $data['tenant_id']
+                : $taskStatus->tenant_id;
         } else {
             $data['tenant_id'] = $request->user()->tenant_id;
         }

--- a/backend/app/Http/Requests/TaskStatusUpsertRequest.php
+++ b/backend/app/Http/Requests/TaskStatusUpsertRequest.php
@@ -15,7 +15,7 @@ class TaskStatusUpsertRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string'],
-            'tenant_id' => ['sometimes', 'integer'],
+            'tenant_id' => ['sometimes', 'nullable', 'integer'],
         ];
     }
 

--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -63,9 +63,10 @@ onMounted(async () => {
     await tenantStore.loadTenants();
   }
   if (isEdit.value) {
-    const { data } = await api.get(`/task-statuses/${route.params.id}`);
+    const res = await api.get(`/task-statuses/${route.params.id}`);
+    const data = res.data;
     name.value = data.name;
-    tenantId.value = data.tenant_id || '';
+    tenantId.value = data.tenant_id ?? '';
   }
 });
 
@@ -78,7 +79,7 @@ const onSubmit = handleSubmit(async () => {
   if (!canSubmit.value) return;
   const payload: any = { name: name.value };
   if (auth.isSuperAdmin) {
-    payload.tenant_id = tenantId.value || undefined;
+    payload.tenant_id = tenantId.value === '' ? null : tenantId.value;
   }
   try {
     if (isEdit.value) {


### PR DESCRIPTION
## Summary
- populate status edit form with existing name and tenant
- allow super admins to reassign a status to a tenant
- permit null tenant_id in validation and update logic

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `php artisan test` *(fails: Failed asserting that null is identical to 'subtasks_incomplete')*

------
https://chatgpt.com/codex/tasks/task_e_68b289e4b9648323b7aed75df49a914b