### PR TITLE
Allow editing all task status fields

### DIFF
--- a/backend/app/Http/Requests/TaskStatusUpsertRequest.php
+++ b/backend/app/Http/Requests/TaskStatusUpsertRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class TaskStatusUpsertRequest extends FormRequest
 {
@@ -13,8 +14,13 @@ class TaskStatusUpsertRequest extends FormRequest
 
     public function rules(): array
     {
+        $statusId = $this->route('task_status')?->id;
+
         return [
             'name' => ['required', 'string'],
+            'slug' => ['sometimes', 'string', Rule::unique('task_statuses')->ignore($statusId)],
+            'color' => ['sometimes', 'nullable', 'string', 'max:7'],
+            'position' => ['sometimes', 'integer'],
             'tenant_id' => ['sometimes', 'nullable', 'integer'],
         ];
     }
@@ -23,6 +29,9 @@ class TaskStatusUpsertRequest extends FormRequest
     {
         return [
             'name' => 'name',
+            'slug' => 'slug',
+            'color' => 'color',
+            'position' => 'position',
             'tenant_id' => 'tenant',
         ];
     }
@@ -33,6 +42,7 @@ class TaskStatusUpsertRequest extends FormRequest
             'required' => 'Please provide a :attribute.',
             'string' => 'The :attribute must be a string.',
             'integer' => 'The :attribute must be an integer.',
+            'max' => 'The :attribute may not be greater than :max characters.',
         ];
     }
 }

--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -32,6 +32,37 @@
         />
         <div v-if="errors.name" class="text-red-600 text-sm">{{ errors.name }}</div>
       </div>
+      <div>
+        <span class="block font-medium mb-1">Slug</span>
+        <input
+          id="slug"
+          v-model="slug"
+          class="border rounded p-2 w-full"
+          aria-label="Slug"
+        />
+        <div v-if="errors.slug" class="text-red-600 text-sm">{{ errors.slug }}</div>
+      </div>
+      <div>
+        <span class="block font-medium mb-1">Color</span>
+        <input
+          id="color"
+          v-model="color"
+          class="border rounded p-2 w-full"
+          aria-label="Color"
+        />
+        <div v-if="errors.color" class="text-red-600 text-sm">{{ errors.color }}</div>
+      </div>
+      <div>
+        <span class="block font-medium mb-1">Position</span>
+        <input
+          id="position"
+          type="number"
+          v-model.number="position"
+          class="border rounded p-2 w-full"
+          aria-label="Position"
+        />
+        <div v-if="errors.position" class="text-red-600 text-sm">{{ errors.position }}</div>
+      </div>
       <div v-if="serverError" class="text-red-600 text-sm">{{ serverError }}</div>
       <button
         type="submit"
@@ -56,6 +87,9 @@ const auth = useAuthStore();
 const tenantStore = useTenantStore();
 
 const name = ref('');
+const slug = ref('');
+const color = ref('');
+const position = ref(0);
 const serverError = ref('');
 const tenantId = ref('');
 
@@ -78,6 +112,9 @@ onMounted(async () => {
     const res = await api.get(`/task-statuses/${route.params.id}`);
     const data = res.data;
     name.value = data.name;
+    slug.value = data.slug;
+    color.value = data.color || '';
+    position.value = data.position || 0;
     tenantId.value = data.tenant_id ? String(data.tenant_id) : '';
   }
 });
@@ -98,7 +135,12 @@ const { handleSubmit, setErrors, errors } = useForm();
 const onSubmit = handleSubmit(async () => {
   serverError.value = '';
   if (!canSubmit.value) return;
-  const payload: any = { name: name.value };
+  const payload: any = {
+    name: name.value,
+    slug: slug.value || undefined,
+    color: color.value || null,
+    position: position.value,
+  };
   if (auth.isSuperAdmin) {
     payload.tenant_id = tenantId.value === '' ? null : Number(tenantId.value);
   }


### PR DESCRIPTION
## Summary
- extend task status form to edit slug, color and position
- allow backend to accept slug, color and position fields

## Testing
- `composer test` *(fails: StatusFlowServiceTest, etc.)*
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b28c7b500883239da93be0a041b87b