### PR TITLE
Fix task status edit form data loading

### DIFF
--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -56,8 +56,8 @@
         <span class="block font-medium mb-1">Position</span>
         <input
           id="position"
-          type="number"
           v-model.number="position"
+          type="number"
           class="border rounded p-2 w-full"
           aria-label="Position"
         />
@@ -110,9 +110,9 @@ onMounted(async () => {
   await loadTenantsIfNeeded();
   if (isEdit.value) {
     const res = await api.get(`/task-statuses/${route.params.id}`);
-    const data = res.data;
+    const data = res.data.data || res.data; // handle resource-wrapped and plain responses
     name.value = data.name;
-    slug.value = data.slug;
+    slug.value = data.slug || '';
     color.value = data.color || '';
     position.value = data.position || 0;
     tenantId.value = data.tenant_id ? String(data.tenant_id) : '';


### PR DESCRIPTION
## Summary
- ensure edit form loads task status data by handling API resource wrapper

## Testing
- `npm test` *(fails: Executable doesn't exist at ... please run `npx playwright install`)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28dd09aa08323ab843df5f9325816