### PR TITLE
feat: add color picker to status form

### DIFF
--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -47,7 +47,8 @@
         <input
           id="color"
           v-model="color"
-          class="border rounded p-2 w-full"
+          type="color"
+          class="h-10 w-20 rounded border border-slate-200"
           aria-label="Color"
         />
         <div v-if="errors.color" class="text-red-600 text-sm">{{ errors.color }}</div>


### PR DESCRIPTION
## Summary
- use native color input for status color field

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b291809fb483239fe3a82a03150c82