### PR TITLE
Fix task type form status loading

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -254,7 +254,7 @@ watch(
 
 onMounted(async () => {
   const { data: statusData } = await api.get('/task-statuses');
-  allStatuses.value = statusData;
+  allStatuses.value = statusData.data;
   if (auth.isSuperAdmin) {
     await tenantStore.loadTenants();
   }


### PR DESCRIPTION
## Summary
- ensure type creation form populates status options

## Testing
- `pnpm lint`
- `pnpm exec vitest run tests/unit tests/*.test.ts`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist; pnpm exec playwright install failed: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b292c087408323a471ce3c8b7d1e80