### PR TITLE
fix: enable preview on task type creation form

### DIFF
--- a/frontend/src/components/tasks/AssigneePicker.vue
+++ b/frontend/src/components/tasks/AssigneePicker.vue
@@ -1,18 +1,25 @@
 <template>
   <div class="space-y-2">
     <Tabs v-model="tab" :tabs="tabs" />
-    <vSelect
-      v-model="selected"
-      :options="options"
-      label="label"
-      placeholder="Select assignee"
-    />
+    <VueSelect>
+      <template #default="{ inputId }">
+        <vSelect
+          :id="inputId"
+          v-model="selected"
+          :options="options"
+          label="label"
+          placeholder="Select assignee"
+        />
+      </template>
+    </VueSelect>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
 import vSelect from 'vue-select';
+import 'vue-select/dist/vue-select.css';
+import VueSelect from '@/components/ui/Select/VueSelect.vue';
 import Tabs from '@/components/ui/Tabs.vue';
 import { useLookupsStore } from '@/stores/lookups';
 

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -189,7 +189,7 @@ const fieldTypes = [
   { key: 'date', label: 'Date', schema: { type: 'string', format: 'date' } },
   { key: 'time', label: 'Time', schema: { type: 'string', format: 'time' } },
   { key: 'boolean', label: 'Checkbox', schema: { type: 'boolean' } },
-  { key: 'assignee', label: 'Assignee', schema: { type: 'object', 'x-control': 'assignee' } },
+  { key: 'assignee', label: 'Assignee', schema: { type: 'object', kind: 'assignee' } },
 ];
 
 const isEdit = computed(() => route.name === 'taskTypes.edit');
@@ -223,13 +223,30 @@ function removeField(index: number) {
 const formSchemaObj = computed(() => {
   const properties: Record<string, any> = {};
   const required: string[] = [];
-  fields.value.forEach((f) => {
+  const fieldsArr = fields.value.map((f) => {
     const def = fieldTypes.find((ft) => ft.key === f.typeKey);
-    if (!def) return;
-    properties[f.name] = { title: f.label, ...def.schema, 'x-cols': f.cols };
+    properties[f.name] = {
+      title: f.label,
+      type: def?.schema?.type || 'string',
+      ...def?.schema,
+      'x-cols': f.cols,
+    };
     if (f.required) required.push(f.name);
+    return {
+      key: f.name,
+      label: f.label,
+      type: f.typeKey,
+      required: f.required,
+      'x-cols': f.cols,
+    };
   });
-  const schema: any = { type: 'object', properties };
+  const schema: any = {
+    type: 'object',
+    properties,
+    sections: [
+      { key: 'main', label: 'Main', fields: fieldsArr, photos: [] },
+    ],
+  };
   if (required.length) schema.required = required;
   return schema;
 });


### PR DESCRIPTION
## Summary
- include field metadata in generated schema for create task type form
- build JSON schema with sections so new task type preview renders
- style AssigneePicker with shared VueSelect wrapper for consistent field design

## Testing
- `pnpm lint`
- `pnpm test` *(fails: tests/e2e/task-filters.spec.ts:3:1 › save and load filter view — SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied)*

------
https://chatgpt.com/codex/tasks/task_e_68b293b2d09483239a706f1794f81eed