### PR TITLE
fix: enable preview on task type creation form

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -223,22 +223,25 @@ function removeField(index: number) {
 const formSchemaObj = computed(() => {
   const properties: Record<string, any> = {};
   const required: string[] = [];
-  const fieldsArr = fields.value.map((f) => {
+  const fieldsArr: any[] = [];
+
+  fields.value.forEach((f) => {
     const def = fieldTypes.find((ft) => ft.key === f.typeKey);
+    if (!def) return;
     properties[f.name] = {
       title: f.label,
-      type: def?.schema?.type || 'string',
-      ...def?.schema,
+      type: def.schema?.type || 'string',
+      ...(def.schema || {}),
       'x-cols': f.cols,
     };
     if (f.required) required.push(f.name);
-    return {
+    fieldsArr.push({
       key: f.name,
       label: f.label,
       type: f.typeKey,
       required: f.required,
       'x-cols': f.cols,
-    };
+    });
   });
   const schema: any = {
     type: 'object',


### PR DESCRIPTION
## Summary
- include field metadata in generated schema for create task type form
- build JSON schema with sections so new task type preview renders
- style AssigneePicker with shared VueSelect wrapper for consistent field design
- guard schema generation against unknown field types so legacy task types load

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b298098c10832382ae8a0484824c1a