### PR TITLE
feat: support photo and repeater fields in task type schemas

### DIFF
--- a/backend/app/Services/StatusFlowService.php
+++ b/backend/app/Services/StatusFlowService.php
@@ -92,7 +92,7 @@ class StatusFlowService
                     return 'missing_photo';
                 }
             } else {
-                if ($value === null || $value === '') {
+                if ($value === null || $value === '' || (is_array($value) && count($value) === 0)) {
                     return 'missing_field';
                 }
             }


### PR DESCRIPTION
## Summary
- allow task type schemas to define photo and repeater fields
- validate required photos and repeater data during status transitions
- test status flow service for missing photo and repeater cases

## Testing
- `composer test` *(fails: Tests: 6 failed, 55 warnings, 6 incomplete, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b29c75581483238a6cf0417fac6c5f