### PR TITLE
feat: add advanced field types and compute engine

### DIFF
--- a/backend/app/Services/ComputeService.php
+++ b/backend/app/Services/ComputeService.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services;
+
+class ComputeService
+{
+    /**
+     * Evaluate a simple arithmetic expression with field references.
+     * Supported operators: + - * /
+     * Field references use dot notation.
+     */
+    public function evaluate(string $expr, array $data): float
+    {
+        $tokens = preg_match_all('/[A-Za-z_][A-Za-z0-9_.]*|\d+(?:\.\d+)?|[()+\-*\/]/', $expr, $m)
+            ? $m[0]
+            : [];
+        $output = [];
+        $ops = [];
+        $prec = ['+' => 1, '-' => 1, '*' => 2, '/' => 2];
+
+        $apply = function () use (&$output, &$ops) {
+            $op = array_pop($ops);
+            $b = array_pop($output) ?? 0;
+            $a = array_pop($output) ?? 0;
+            switch ($op) {
+                case '+': $output[] = $a + $b; break;
+                case '-': $output[] = $a - $b; break;
+                case '*': $output[] = $a * $b; break;
+                case '/': $output[] = $b == 0 ? 0 : $a / $b; break;
+            }
+        };
+
+        foreach ($tokens as $token) {
+            if (preg_match('/^\d/', $token)) {
+                $output[] = (float) $token;
+            } elseif (preg_match('/^[A-Za-z_]/', $token)) {
+                $output[] = (float) ($this->getField($token, $data) ?? 0);
+            } elseif ($token === '(') {
+                $ops[] = $token;
+            } elseif ($token === ')') {
+                while ($ops && end($ops) !== '(') {
+                    $apply();
+                }
+                array_pop($ops);
+            } elseif (isset($prec[$token])) {
+                while ($ops && end($ops) !== '(' && $prec[end($ops)] >= $prec[$token]) {
+                    $apply();
+                }
+                $ops[] = $token;
+            }
+        }
+        while ($ops) {
+            $apply();
+        }
+        return array_pop($output) ?? 0.0;
+    }
+
+    protected function getField(string $path, array $data): mixed
+    {
+        $segments = explode('.', $path);
+        foreach ($segments as $seg) {
+            if (! is_array($data) || ! array_key_exists($seg, $data)) {
+                return 0;
+            }
+            $data = $data[$seg];
+        }
+        return $data;
+    }
+}

--- a/backend/tests/Feature/ComputedFieldTest.php
+++ b/backend/tests/Feature/ComputedFieldTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\TaskType;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ComputedFieldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Tenant::create(['id' => 1, 'name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create([
+            'name' => 'User',
+            'slug' => 'user',
+            'tenant_id' => 1,
+            'abilities' => ['tasks.manage'],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => 1,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => 1]);
+        Sanctum::actingAs($user);
+    }
+
+    public function test_computed_field_recalculates(): void
+    {
+        $schema = [
+            'sections' => [
+                [
+                    'key' => 'main',
+                    'label' => 'Main',
+                    'fields' => [
+                        ['key' => 'a', 'label' => 'A', 'type' => 'number'],
+                        ['key' => 'b', 'label' => 'B', 'type' => 'number'],
+                        ['key' => 'total', 'label' => 'Total', 'type' => 'computed', 'expr' => 'a + b'],
+                    ],
+                ],
+            ],
+        ];
+        $type = TaskType::create([
+            'name' => 'T',
+            'tenant_id' => 1,
+            'schema_json' => $schema,
+            'statuses' => ['draft' => []],
+            'status_flow_json' => [['draft']],
+        ]);
+        $payload = [
+            'task_type_id' => $type->id,
+            'form_data' => ['a' => 2, 'b' => 3, 'total' => 99],
+        ];
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson('/api/tasks', $payload)
+            ->assertStatus(201)
+            ->assertJsonPath('data.form_data.total', 5);
+    }
+}

--- a/backend/tests/Feature/TaskTypeSchemaTest.php
+++ b/backend/tests/Feature/TaskTypeSchemaTest.php
@@ -56,4 +56,41 @@ class TaskTypeSchemaTest extends TestCase
             }
         }
     }
+
+    public function test_lookup_requires_source(): void
+    {
+        $service = new FormSchemaService();
+        $schema = [
+            'sections' => [
+                [
+                    'key' => 'main',
+                    'label' => 'Main',
+                    'fields' => [
+                        ['key' => 'l1', 'label' => 'L1', 'type' => 'lookup'],
+                    ],
+                ],
+            ],
+        ];
+        $this->expectException(ValidationException::class);
+        $service->validate($schema);
+    }
+
+    public function test_computed_references_must_exist(): void
+    {
+        $service = new FormSchemaService();
+        $schema = [
+            'sections' => [
+                [
+                    'key' => 'main',
+                    'label' => 'Main',
+                    'fields' => [
+                        ['key' => 'a', 'label' => 'A', 'type' => 'number'],
+                        ['key' => 'c', 'label' => 'C', 'type' => 'computed', 'expr' => 'a + b'],
+                    ],
+                ],
+            ],
+        ];
+        $this->expectException(ValidationException::class);
+        $service->validate($schema);
+    }
 }

--- a/frontend/src/components/fields/ComputedDisplay.vue
+++ b/frontend/src/components/fields/ComputedDisplay.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="p-2" role="textbox" :aria-label="label" tabindex="0">
+    {{ value }}
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ label: string; value: string | number | null }>();
+</script>

--- a/frontend/src/components/fields/LocationPicker.vue
+++ b/frontend/src/components/fields/LocationPicker.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="flex gap-2">
+    <label class="flex-1">
+      <span class="sr-only">{{ label }} Latitude</span>
+      <input
+        type="number"
+        class="form-input w-full"
+        :value="modelValue.lat"
+        aria-label="Latitude"
+        @input="onLat"
+      />
+    </label>
+    <label class="flex-1">
+      <span class="sr-only">{{ label }} Longitude</span>
+      <input
+        type="number"
+        class="form-input w-full"
+        :value="modelValue.lng"
+        aria-label="Longitude"
+        @input="onLng"
+      />
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ label: string; modelValue: { lat: number; lng: number } }>();
+const emit = defineEmits<{ 'update:modelValue': [{ lat: number; lng: number }] }>();
+function onLat(e: Event) {
+  const val = parseFloat((e.target as HTMLInputElement).value);
+  emit('update:modelValue', { ...props.modelValue, lat: val });
+}
+function onLng(e: Event) {
+  const val = parseFloat((e.target as HTMLInputElement).value);
+  emit('update:modelValue', { ...props.modelValue, lng: val });
+}
+</script>

--- a/frontend/src/components/fields/LookupSelect.vue
+++ b/frontend/src/components/fields/LookupSelect.vue
@@ -1,0 +1,32 @@
+<template>
+  <label class="block">
+    <span class="sr-only">{{ label }}</span>
+    <select
+      class="form-select"
+      :aria-label="label"
+      :value="modelValue"
+      @change="onChange"
+    >
+      <option v-for="opt in options" :key="opt.value" :value="opt.value">
+        {{ opt.label }}
+      </option>
+    </select>
+  </label>
+</template>
+
+<script setup lang="ts">
+interface Option {
+  label: string;
+  value: string | number;
+}
+const props = defineProps<{
+  label: string;
+  modelValue: string | number | null;
+  options: Option[];
+}>();
+const emit = defineEmits<{'update:modelValue':[string | number | null]}>();
+function onChange(e: Event) {
+  const target = e.target as HTMLSelectElement;
+  emit('update:modelValue', target.value);
+}
+</script>

--- a/frontend/src/components/fields/PrioritySelect.vue
+++ b/frontend/src/components/fields/PrioritySelect.vue
@@ -1,0 +1,28 @@
+<template>
+  <label class="block">
+    <span class="sr-only">{{ label }}</span>
+    <select
+      class="form-select"
+      :aria-label="label"
+      :value="modelValue"
+      @change="onChange"
+    >
+      <option v-for="opt in options" :key="opt.value" :value="opt.value">
+        {{ opt.label }}
+      </option>
+    </select>
+  </label>
+</template>
+
+<script setup lang="ts">
+interface Option { label: string; value: string }
+const props = defineProps<{
+  label: string;
+  modelValue: string | null;
+  options: Option[];
+}>();
+const emit = defineEmits<{ 'update:modelValue': [string | null] }>();
+function onChange(e: Event) {
+  emit('update:modelValue', (e.target as HTMLSelectElement).value);
+}
+</script>

--- a/frontend/src/components/fields/RatingStars.vue
+++ b/frontend/src/components/fields/RatingStars.vue
@@ -1,0 +1,24 @@
+<template>
+  <div role="radiogroup" :aria-label="label" class="flex gap-1">
+    <button
+      v-for="i in 5"
+      :key="i"
+      type="button"
+      role="radio"
+      class="text-xl"
+      :aria-checked="modelValue === i"
+      @click="setRating(i)"
+      @keyup.enter="setRating(i)"
+    >
+      {{ modelValue >= i ? '★' : '☆' }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ label: string; modelValue: number }>();
+const emit = defineEmits<{ 'update:modelValue': [number] }>();
+function setRating(val: number) {
+  emit('update:modelValue', val);
+}
+</script>

--- a/frontend/src/components/fields/SignaturePad.vue
+++ b/frontend/src/components/fields/SignaturePad.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <span class="sr-only">{{ label }}</span>
+    <canvas
+      ref="canvas"
+      class="border"
+      :aria-label="label"
+      tabindex="0"
+    />
+    <button
+      type="button"
+      class="mt-2 px-2 py-1 border"
+      @click="clearPad"
+      aria-label="Clear signature"
+    >
+      Clear
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const props = defineProps<{ label: string }>();
+const emit = defineEmits<{ 'update:modelValue': [string] }>();
+const canvas = ref<HTMLCanvasElement | null>(null);
+function clearPad() {
+  const ctx = canvas.value?.getContext('2d');
+  if (ctx && canvas.value) {
+    ctx.clearRect(0, 0, canvas.value.width, canvas.value.height);
+  }
+  emit('update:modelValue', '');
+}
+</script>

--- a/frontend/src/components/fields/StatusSelect.vue
+++ b/frontend/src/components/fields/StatusSelect.vue
@@ -1,0 +1,28 @@
+<template>
+  <label class="block">
+    <span class="sr-only">{{ label }}</span>
+    <select
+      class="form-select"
+      :aria-label="label"
+      :value="modelValue"
+      @change="onChange"
+    >
+      <option v-for="opt in options" :key="opt.value" :value="opt.value">
+        {{ opt.label }}
+      </option>
+    </select>
+  </label>
+</template>
+
+<script setup lang="ts">
+interface Option { label: string; value: string }
+const props = defineProps<{
+  label: string;
+  modelValue: string | null;
+  options: Option[];
+}>();
+const emit = defineEmits<{ 'update:modelValue': [string | null] }>();
+function onChange(e: Event) {
+  emit('update:modelValue', (e.target as HTMLSelectElement).value);
+}
+</script>

--- a/frontend/src/utils/compute.ts
+++ b/frontend/src/utils/compute.ts
@@ -1,0 +1,60 @@
+export function getField(path: string, data: Record<string, any>): number {
+  return path.split('.').reduce<any>((acc, key) => {
+    if (acc && typeof acc === 'object' && key in acc) {
+      return acc[key];
+    }
+    return 0;
+  }, data) as number;
+}
+
+export function evaluate(expr: string, data: Record<string, any>): number {
+  const tokens = expr.match(/[A-Za-z_][A-Za-z0-9_.]*|\d+(?:\.\d+)?|[()+\-*/]/g);
+  if (!tokens) return 0;
+  const output: number[] = [];
+  const ops: string[] = [];
+  const prec: Record<string, number> = { '+': 1, '-': 1, '*': 2, '/': 2 };
+
+  const apply = () => {
+    const op = ops.pop();
+    if (!op) return;
+    const b = output.pop() ?? 0;
+    const a = output.pop() ?? 0;
+    switch (op) {
+      case '+':
+        output.push(a + b);
+        break;
+      case '-':
+        output.push(a - b);
+        break;
+      case '*':
+        output.push(a * b);
+        break;
+      case '/':
+        output.push(b === 0 ? 0 : a / b);
+        break;
+    }
+  };
+
+  for (const token of tokens) {
+    if (/^\d/.test(token)) {
+      output.push(parseFloat(token));
+    } else if (/^[A-Za-z_]/.test(token)) {
+      output.push(Number(getField(token, data)) || 0);
+    } else if (token === '(') {
+      ops.push(token);
+    } else if (token === ')') {
+      while (ops.length && ops[ops.length - 1] !== '(') {
+        apply();
+      }
+      ops.pop();
+    } else if (token in prec) {
+      while (ops.length && ops[ops.length - 1] in prec && prec[ops[ops.length - 1]] >= prec[token]) {
+        apply();
+      }
+      ops.push(token);
+    }
+  }
+
+  while (ops.length) apply();
+  return output.pop() ?? 0;
+}

--- a/frontend/tests/e2e/compute.spec.ts
+++ b/frontend/tests/e2e/compute.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+import { evaluate } from '../../src/utils/compute';
+
+test('evaluate expression', async () => {
+  expect(evaluate('a + b', { a: 2, b: 3 })).toBe(5);
+});

--- a/frontend/tests/unit/compute.test.ts
+++ b/frontend/tests/unit/compute.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate } from '../../src/utils/compute';
+
+describe('compute evaluator', () => {
+  it('evaluates arithmetic with field references', () => {
+    const data = { a: 1, b: 2 };
+    expect(evaluate('a + b * 3', data)).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary
- add safe expression evaluator on frontend and backend
- extend form schema validation for lookup and computed fields
- recompute computed fields on save and add UI stubs for new types

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `./vendor/bin/phpunit --filter ComputedFieldTest`
- `pnpm test` *(fails: Need to install with app.use function)*
- `npx vitest run tests/unit/compute.test.ts`
- `npx playwright test tests/e2e/compute.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2c870ed248323a592ca7e656d9379