### PR TITLE
test: stabilize TaskFieldSnippet tests

### DIFF
--- a/frontend/src/stores/snippets.ts
+++ b/frontend/src/stores/snippets.ts
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia';
+
+export interface TaskFieldSnippet {
+  id: string;
+  name: string;
+  fields: string[];
+}
+
+export const useSnippetsStore = defineStore('snippets', {
+  state: () => ({
+    snippets: [] as TaskFieldSnippet[],
+  }),
+  actions: {
+    async create(snippet: Omit<TaskFieldSnippet, 'id'> & { id?: string }) {
+      await Promise.resolve();
+      const id = snippet.id ?? `${Date.now()}`;
+      const newSnippet: TaskFieldSnippet = {
+        id,
+        name: snippet.name,
+        fields: [...snippet.fields],
+      };
+      this.snippets.push(newSnippet);
+      return newSnippet;
+    },
+    async get(id: string) {
+      await Promise.resolve();
+      return this.snippets.find((s) => s.id === id);
+    },
+  },
+});

--- a/frontend/tests/unit/jsonSchemaForm.render.test.ts
+++ b/frontend/tests/unit/jsonSchemaForm.render.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi } from 'vitest';
 import { createApp } from 'vue';
+import { createI18n } from 'vue-i18n';
 import JsonSchemaForm from '@/components/forms/JsonSchemaForm.vue';
 
 vi.mock('@/components/tasks/AssigneePicker.vue', () => ({
@@ -37,7 +38,13 @@ describe('JsonSchemaForm', () => {
         },
       ],
     };
-    const app = createApp(JsonSchemaForm, { schema, modelValue: {} });
+    const app = createApp(JsonSchemaForm, {
+      schema,
+      modelValue: {},
+      taskId: 1,
+    });
+    const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } });
+    app.use(i18n);
     const div = document.createElement('div');
     app.mount(div);
     expect(div.querySelector('input[type="text"]')).toBeTruthy();

--- a/frontend/tests/unit/stores/snippets.spec.ts
+++ b/frontend/tests/unit/stores/snippets.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// The snippets store performs asynchronous operations when creating and
+// retrieving snippets. These tests ensure we wait for those operations to
+// complete before making assertions.
+
+describe('snippets store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('creates and retrieves a snippet', async () => {
+    const { useSnippetsStore } = await import('@/stores/snippets');
+    const store = useSnippetsStore();
+    const created = await store.create({ name: 'Group', fields: ['a'] });
+    const loaded = await store.get(created.id);
+    expect(loaded).toEqual(created);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure JsonSchemaForm test mounts i18n and passes required props
- add TaskFieldSnippet Pinia store and asynchronous unit test

## Testing
- `npx eslint src/stores/snippets.ts tests/unit/stores/snippets.spec.ts`
- `npx vitest run tests/unit tests/*.test.ts`
- `npx playwright test tests/e2e` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c9bec7c8832386742e6ee2c8ddc5