### PR TITLE
feat(tasks): add conditional field logic

### DIFF
--- a/backend/tests/Feature/TaskConditionalLogicTest.php
+++ b/backend/tests/Feature/TaskConditionalLogicTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\TaskType;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskConditionalLogicTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create([
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'tenant_id' => $tenant->id,
+            'abilities' => ['tasks.manage'],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+        $this->tenant = $tenant;
+    }
+
+    public function test_conditional_required_field(): void
+    {
+        $type = TaskType::create([
+            'name' => 'Type',
+            'tenant_id' => $this->tenant->id,
+            'schema_json' => [
+                'sections' => [[
+                    'key' => 'main',
+                    'label' => 'Main',
+                    'fields' => [
+                        ['key' => 'priority', 'label' => 'Priority', 'type' => 'select', 'enum' => ['low', 'high']],
+                        ['key' => 'due_date', 'label' => 'Due Date', 'type' => 'date'],
+                        ['key' => 'escalation_reason', 'label' => 'Escalation', 'type' => 'text'],
+                    ],
+                ]],
+                'logic' => [[
+                    'if' => ['field' => 'priority', 'eq' => 'high'],
+                    'then' => [
+                        ['require' => 'due_date'],
+                        ['show' => 'escalation_reason'],
+                    ],
+                ]],
+            ],
+        ]);
+
+        $payload = [
+            'task_type_id' => $type->id,
+            'form_data' => ['priority' => 'high'],
+        ];
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->postJson('/api/tasks', $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['form_data.due_date']);
+
+        $payload['form_data']['priority'] = 'low';
+        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+            ->postJson('/api/tasks', $payload)
+            ->assertCreated();
+    }
+}

--- a/frontend/src/components/forms/JsonSchemaForm.vue
+++ b/frontend/src/components/forms/JsonSchemaForm.vue
@@ -8,6 +8,9 @@
       :errors="errors"
       :task-id="taskId"
       :readonly="readonly"
+      :visible="logic.visible"
+      :required="logic.required"
+      :show-targets="logic.showTargets"
       @update="onUpdate"
       @error="onError"
     />
@@ -17,17 +20,26 @@
 <script setup lang="ts">
 import { reactive, watch } from 'vue';
 import SectionCard from '@/components/tasks/SectionCard.vue';
+import { evaluateLogic } from '@/utils/logic';
 
 const props = defineProps<{ schema: any; modelValue: any; taskId: number; readonly?: boolean }>();
 const emit = defineEmits<{ (e: 'update:modelValue', value: any): void }>();
 
 const form = reactive<any>({ ...props.modelValue });
 const errors = reactive<Record<string, string>>({});
+const logic = reactive<{ visible: Set<string>; required: Set<string>; showTargets: Set<string> }>(
+  {
+    visible: new Set(),
+    required: new Set(),
+    showTargets: new Set(),
+  },
+);
 
 watch(
   () => props.modelValue,
   (val) => {
     Object.assign(form, val || {});
+    recomputeLogic();
   },
   { deep: true },
 );
@@ -36,9 +48,19 @@ watch(
   form,
   (val) => {
     emit('update:modelValue', { ...val });
+    recomputeLogic();
   },
   { deep: true },
 );
+
+recomputeLogic();
+
+function recomputeLogic() {
+  const res = evaluateLogic(props.schema, form);
+  logic.visible = res.visible;
+  logic.required = res.required;
+  logic.showTargets = res.showTargets;
+}
 
 function onUpdate(payload: { key: string; value: any }) {
   form[payload.key] = payload.value;

--- a/frontend/src/utils/logic.ts
+++ b/frontend/src/utils/logic.ts
@@ -1,0 +1,33 @@
+export interface LogicRule {
+  if: { field: string; eq: any };
+  then: Array<{ show?: string; require?: string }>;
+}
+
+export function evaluateLogic(schema: any, data: Record<string, any>) {
+  const rules: LogicRule[] = schema?.logic || [];
+  const visible = new Set<string>();
+  const required = new Set<string>();
+  const showTargets = new Set<string>();
+
+  for (const rule of rules) {
+    for (const action of rule.then || []) {
+      if (action.show) {
+        showTargets.add(action.show);
+      }
+    }
+    const condField = rule.if?.field;
+    const eq = rule.if?.eq;
+    if (condField && data[condField] === eq) {
+      for (const action of rule.then || []) {
+        if (action.show) {
+          visible.add(action.show);
+        }
+        if (action.require) {
+          required.add(action.require);
+        }
+      }
+    }
+  }
+
+  return { visible, required, showTargets };
+}

--- a/frontend/tests/e2e/json-schema-form.spec.ts
+++ b/frontend/tests/e2e/json-schema-form.spec.ts
@@ -1,5 +1,25 @@
 import { test, expect } from '@playwright/test';
+import { evaluateLogic } from '../../src/utils/logic';
 
-test('json schema form placeholder e2e', async () => {
-  expect(true).toBe(true);
+test('conditional logic evaluates visibility and requiredness', async () => {
+  const schema = {
+    sections: [],
+    logic: [
+      {
+        if: { field: 'priority', eq: 'high' },
+        then: [
+          { require: 'due_date' },
+          { show: 'escalation_reason' },
+        ],
+      },
+    ],
+  };
+
+  const high = evaluateLogic(schema, { priority: 'high' });
+  expect(high.visible.has('escalation_reason')).toBe(true);
+  expect(high.required.has('due_date')).toBe(true);
+
+  const low = evaluateLogic(schema, { priority: 'low' });
+  expect(low.visible.has('escalation_reason')).toBe(false);
+  expect(low.required.has('due_date')).toBe(false);
 });


### PR DESCRIPTION
## Summary
- support conditional field visibility and requiredness in task schema forms
- enforce conditional requirements on the API
- test task logic evaluation on backend and frontend

## Testing
- `php artisan test --testsuite=Feature --filter=TaskConditionalLogicTest`
- `pnpm lint` *(fails: existing lint errors)*
- `pnpm test tests/e2e/json-schema-form.spec.ts` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cccd50a083239786bde0f7c92539