### PR TITLE
Add compute and validation tests

### DIFF
--- a/frontend/tests/e2e/task-filters.spec.ts
+++ b/frontend/tests/e2e/task-filters.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test';
 
 test('save and load filter view', async ({ page }) => {
-  await page.goto('about:blank');
+  // provide an http origin and fulfill with empty page so localStorage works
+  await page.route('**/*', (route) => route.fulfill({ body: '<html></html>', contentType: 'text/html' }));
+  await page.goto('http://localhost');
   await page.evaluate(() => {
     localStorage.clear();
     const views: Record<string, any> = {};
@@ -13,7 +15,8 @@ test('save and load filter view', async ({ page }) => {
 });
 
 test('bulk status change respects allowed actions', async ({ page }) => {
-  await page.goto('about:blank');
+  await page.route('**/*', (route) => route.fulfill({ body: '<html></html>', contentType: 'text/html' }));
+  await page.goto('http://localhost');
   const updated = await page.evaluate(() => {
     const selected = [1, 2];
     const actions: Record<number, string[]> = { 1: ['done'], 2: [] };

--- a/frontend/tests/unit/compute.test.ts
+++ b/frontend/tests/unit/compute.test.ts
@@ -6,4 +6,14 @@ describe('compute evaluator', () => {
     const data = { a: 1, b: 2 };
     expect(evaluate('a + b * 3', data)).toBe(7);
   });
+
+  it('supports parentheses and nested fields', () => {
+    const data = { a: 1, b: { c: 2 } };
+    expect(evaluate('(a + b.c) * 2', data)).toBe(6);
+  });
+
+  it('treats unknown fields and division by zero as zero', () => {
+    const data = { a: 5 };
+    expect(evaluate('a / missing', data)).toBe(0);
+  });
 });

--- a/frontend/tests/unit/logic.test.ts
+++ b/frontend/tests/unit/logic.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateLogic } from '../../src/utils/logic';
+
+describe('conditional logic evaluation', () => {
+  const schema = {
+    logic: [
+      {
+        if: { field: 'status', eq: 'A' },
+        then: [{ show: 'field1' }, { require: 'field2' }],
+      },
+    ],
+  };
+
+  it('returns visible and required sets when condition matches', () => {
+    const result = evaluateLogic(schema, { status: 'A' });
+    expect(Array.from(result.visible)).toEqual(['field1']);
+    expect(Array.from(result.required)).toEqual(['field2']);
+    expect(Array.from(result.showTargets)).toEqual(['field1']);
+  });
+
+  it('collects show targets even when condition does not match', () => {
+    const result = evaluateLogic(schema, { status: 'B' });
+    expect(Array.from(result.visible)).toEqual([]);
+    expect(Array.from(result.required)).toEqual([]);
+    expect(Array.from(result.showTargets)).toEqual(['field1']);
+  });
+
+  it('handles multiple rules', () => {
+    const multiSchema = {
+      logic: [
+        { if: { field: 'status', eq: 'A' }, then: [{ show: 'field1' }] },
+        { if: { field: 'type', eq: 1 }, then: [{ require: 'field3' }] },
+      ],
+    };
+    const result = evaluateLogic(multiSchema, { status: 'C', type: 1 });
+    expect(Array.from(result.visible)).toEqual([]);
+    expect(Array.from(result.required)).toEqual(['field3']);
+    expect(Array.from(result.showTargets)).toEqual(['field1']);
+  });
+});

--- a/frontend/tests/unit/validators.test.ts
+++ b/frontend/tests/unit/validators.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { validate } from '../../src/utils/validators';
+
+describe('validators', () => {
+  it('validates required fields', () => {
+    expect(validate('', { required: true })).toBe('Required');
+    expect(validate('value', { required: true })).toBeNull();
+  });
+
+  it('validates regex patterns', () => {
+    expect(validate('abc', { regex: '^a.c$' })).toBeNull();
+    expect(validate('ab', { regex: '^a.c$' })).toBe('Invalid format');
+  });
+
+  it('validates numeric ranges', () => {
+    expect(validate(5, { min: 3, max: 10 })).toBeNull();
+    expect(validate(2, { min: 3 })).toBe('Min 3');
+    expect(validate(20, { max: 10 })).toBe('Max 10');
+  });
+
+  it('validates string length ranges', () => {
+    expect(validate('hello', { lengthMin: 3, lengthMax: 10 })).toBeNull();
+    expect(validate('hi', { lengthMin: 3 })).toBe('Min length 3');
+    expect(validate('this is long', { lengthMax: 5 })).toBe('Max length 5');
+  });
+
+  it('validates file mime types and size', () => {
+    const file = { mime: 'image/png', size: 500 };
+    expect(validate(file, { mime: ['image/png'], size: 1000 })).toBeNull();
+    expect(validate(file, { mime: ['application/pdf'] })).toBe('Invalid file type');
+    expect(validate(file, { size: 100 })).toBe('File too large');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for compute evaluator, validators, and conditional logic
- ensure task filter Playwright specs run with localStorage by stubbing an HTTP origin

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e7c3aa108323b4a1b91419d5b5ef