### PR TITLE
fix: reset field role assignments when tenant changes

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -275,22 +275,30 @@ onMounted(async () => {
   }
 });
 
-watch(
-  tenantId,
-  async (id) => {
-    if (id) {
-      try {
-        const { data } = await api.get('/roles', { params: { tenant_id: id } });
-        tenantRoles.value = data;
-      } catch {
+  watch(
+    tenantId,
+    async (id, oldId) => {
+      if (oldId !== undefined && id !== oldId) {
+        sections.value.forEach((s) =>
+          s.fields.forEach((f) => {
+            f.roles.view = [];
+            f.roles.edit = [];
+          }),
+        );
+      }
+      if (id) {
+        try {
+          const { data } = await api.get('/roles', { params: { tenant_id: id } });
+          tenantRoles.value = data;
+        } catch {
+          tenantRoles.value = [];
+        }
+      } else {
         tenantRoles.value = [];
       }
-    } else {
-      tenantRoles.value = [];
-    }
-  },
-  { immediate: true },
-);
+    },
+    { immediate: true },
+  );
 
 function addSection() {
   sections.value.push({


### PR DESCRIPTION
## Summary
- clear section field role selections when tenant changes

## Testing
- `npm run lint` (fails: 41 errors)
- `npm test` (fails: browserType.launch executable doesn't exist)


------
https://chatgpt.com/codex/tasks/task_e_68b2ee6c082083238041561fc8705a99