### PR TITLE
fix inspector roles tab error

### DIFF
--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -180,7 +180,7 @@
           <span class="block mb-1">{{ t('View roles') }}</span>
           <select
             id="rolesView"
-            v-model="roles.value.view"
+            v-model="roles.view"
             multiple
             class="w-full rounded border px-2 py-1"
             aria-label="View roles"
@@ -192,7 +192,7 @@
           <span class="block mb-1">{{ t('Edit roles') }}</span>
           <select
             id="rolesEdit"
-            v-model="roles.value.edit"
+            v-model="roles.edit"
             multiple
             class="w-full rounded border px-2 py-1"
             aria-label="Edit roles"
@@ -358,7 +358,7 @@ function removeLogicAction(rule: any, idx: number) {
 
 const roles = computed(() => {
   if (!props.selected) return { view: [], edit: [] } as any;
-  return props.selected.roles;
+  return props.selected.roles ?? { view: [], edit: [] };
 });
 const availableRoles = computed(() => props.roleOptions);
 


### PR DESCRIPTION
## Summary
- prevent roles tab from crashing when selected field lacks role data

## Testing
- `npm test` (fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)
- `npm run lint` (fails: 41 problems)
- `npx playwright install` (fails: Download failed: server returned code 403)


------
https://chatgpt.com/codex/tasks/task_e_68b2ef71f1b48323a69eec7700edf4bf