### PR TITLE
fix inspector roles tab error

### DIFF
--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -180,7 +180,7 @@
           <span class="block mb-1">{{ t('View roles') }}</span>
           <select
             id="rolesView"
-            v-model="roles.value.view"
+            v-model="roles.view"
             multiple
             class="w-full rounded border px-2 py-1"
             aria-label="View roles"
@@ -192,7 +192,7 @@
           <span class="block mb-1">{{ t('Edit roles') }}</span>
           <select
             id="rolesEdit"
-            v-model="roles.value.edit"
+            v-model="roles.edit"
             multiple
             class="w-full rounded border px-2 py-1"
             aria-label="Edit roles"
@@ -358,7 +358,7 @@ function removeLogicAction(rule: any, idx: number) {
 
 const roles = computed(() => {
   if (!props.selected) return { view: [], edit: [] } as any;
-  return props.selected.roles;
+  return props.selected.roles ?? { view: [], edit: [] };
 });
 const availableRoles = computed(() => props.roleOptions);
 

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -289,7 +289,7 @@ onMounted(async () => {
       if (id) {
         try {
           const { data } = await api.get('/roles', { params: { tenant_id: id } });
-          tenantRoles.value = data;
+          tenantRoles.value = data.data ?? data;
         } catch {
           tenantRoles.value = [];
         }


### PR DESCRIPTION
## Summary
- prevent roles tab from crashing when selected field lacks role data
- parse roles API response so select options show labels

## Testing
- `npm test` (fails: browserType.launch: Executable doesn't exist)
- `npm run lint` (fails: 41 problems)
- `npx playwright install` (fails: Download failed: server returned code 403)


------
https://chatgpt.com/codex/tasks/task_e_68b2ef71f1b48323a69eec7700edf4bf