### PR TITLE
feat: add headless UI tabs wrapper

### DIFF
--- a/frontend/src/components/ui/Tabs/index.vue
+++ b/frontend/src/components/ui/Tabs/index.vue
@@ -1,0 +1,18 @@
+<template>
+  <TabGroup>
+    <TabList class="lg:space-x-8 md:space-x-4 space-x-0 rtl:space-x-reverse flex">
+      <slot name="list" />
+    </TabList>
+    <TabPanels>
+      <slot name="panel" />
+    </TabPanels>
+  </TabGroup>
+</template>
+
+<script setup lang="ts">
+import { TabGroup, TabList, TabPanels } from '@headlessui/vue'
+
+defineOptions({
+  name: 'UiTabs',
+})
+</script>


### PR DESCRIPTION
## Summary
- add `<UiTabs>` wrapper around Headless UI TabGroup

## Testing
- `pnpm lint` *(fails: 41 errors)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3068433108323b86c81005aefe280