### PR TITLE
refactor: use dashcode table for automations

### DIFF
--- a/frontend/src/components/types/AutomationsEditor.vue
+++ b/frontend/src/components/types/AutomationsEditor.vue
@@ -1,71 +1,103 @@
 <template>
   <div>
     <h2 class="text-lg font-semibold mb-2">{{ t('automations.title') }}</h2>
-    <table class="w-full text-sm border" aria-label="Automations">
-      <thead>
-        <tr class="border-b">
-          <th class="p-2 text-left">{{ t('automations.event') }}</th>
-          <th class="p-2 text-left">{{ t('automations.status') }}</th>
-          <th class="p-2 text-left">{{ t('automations.team') }}</th>
-          <th class="p-2 text-left">{{ t('automations.enabled') }}</th>
-          <th class="p-2"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="(a, idx) in automations" :key="a.id ?? idx" class="border-b">
-          <td class="p-2">
-            <label :for="`event-${idx}`" class="sr-only">{{ t('automations.event') }}</label>
-            <select
-              :id="`event-${idx}`"
-              v-model="a.event"
-              class="border rounded px-2 py-1 w-full"
+    <div class="bg-white dark:bg-slate-800 rounded-md shadow-base">
+      <div class="overflow-x-auto">
+        <table
+          class="min-w-full divide-y divide-slate-100 table-fixed dark:divide-slate-700"
+          aria-label="Automations"
+        >
+          <thead class="bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300">
+            <tr>
+              <th scope="col" class="table-th">{{ t('automations.event') }}</th>
+              <th scope="col" class="table-th">{{ t('automations.status') }}</th>
+              <th scope="col" class="table-th">{{ t('automations.team') }}</th>
+              <th scope="col" class="table-th">{{ t('automations.enabled') }}</th>
+              <th scope="col" class="table-th sr-only">{{ t('actions.save') }}</th>
+            </tr>
+          </thead>
+          <tbody
+            class="bg-white divide-y divide-slate-100 dark:bg-slate-800 dark:divide-slate-700"
+          >
+            <tr
+              v-for="(a, idx) in automations"
+              :key="a.id ?? idx"
+              class="hover:bg-slate-50 dark:hover:bg-slate-700"
             >
-              <option value="status_changed">status_changed</option>
-            </select>
-          </td>
-          <td class="p-2">
-            <label :for="`status-${idx}`" class="sr-only">{{ t('automations.status') }}</label>
-            <input
-              :id="`status-${idx}`"
-              v-model="a.conditions_json.status"
-              class="border rounded px-2 py-1 w-full"
-            />
-          </td>
-          <td class="p-2">
-            <label :for="`team-${idx}`" class="sr-only">{{ t('automations.team') }}</label>
-            <input
-              type="number"
-              :id="`team-${idx}`"
-              v-model.number="a.actions_json[0].team_id"
-              class="border rounded px-2 py-1 w-full"
-            />
-          </td>
-          <td class="p-2">
-            <label :for="`enabled-${idx}`" class="sr-only">{{ t('automations.enabled') }}</label>
-            <input
-              type="checkbox"
-              :id="`enabled-${idx}`"
-              v-model="a.enabled"
-              class="mr-2"
-            />
-          </td>
-          <td class="p-2">
-            <button
-              type="button"
-              class="px-2 py-1 border rounded"
-              @click="save(a)"
-              :aria-label="t('actions.save')"
-            >{{ t('actions.save') }}</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <button
+              <td class="table-td">
+                <Select
+                  :id="`event-${idx}`"
+                  v-model="a.event"
+                  :label="t('automations.event')"
+                  class="w-full"
+                >
+                  <option value="status_changed">status_changed</option>
+                </Select>
+              </td>
+              <td class="table-td">
+                <Select
+                  :id="`status-${idx}`"
+                  v-model="a.conditions_json.status"
+                  :label="t('automations.status')"
+                  class="w-full"
+                >
+                  <option
+                    v-for="s in statusOptions"
+                    :key="s.value"
+                    :value="s.value"
+                  >
+                    {{ s.label }}
+                  </option>
+                </Select>
+              </td>
+              <td class="table-td">
+                <Select
+                  :id="`team-${idx}`"
+                  v-model="a.actions_json[0].team_id"
+                  :label="t('automations.team')"
+                  class="w-full"
+                  @change="(e) => (a.actions_json[0].team_id = Number((e.target as HTMLSelectElement).value))"
+                >
+                  <option
+                    v-for="team in teamOptions"
+                    :key="team.value"
+                    :value="team.value"
+                  >
+                    {{ team.label }}
+                  </option>
+                </Select>
+              </td>
+              <td class="table-td">
+                <Switch
+                  :id="`enabled-${idx}`"
+                  v-model="a.enabled"
+                  :aria-label="t('automations.enabled')"
+                />
+              </td>
+              <td class="table-td">
+                <Button
+                  type="button"
+                  btnClass="btn-outline-primary text-xs px-3 py-1"
+                  @click="save(a)"
+                  :aria-label="t('actions.save')"
+                >
+                  {{ t('actions.save') }}
+                </Button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <Button
       type="button"
-      class="mt-2 px-2 py-1 border rounded"
+      class="mt-2"
+      btnClass="btn-outline-primary text-xs px-3 py-1"
       @click="addAutomation"
       :aria-label="t('actions.add')"
-    >{{ t('actions.add') }}</button>
+    >
+      {{ t('actions.add') }}
+    </Button>
   </div>
 </template>
 
@@ -73,6 +105,9 @@
 import { ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import api from '@/services/api';
+import Select from '@/components/ui/Select/index.vue';
+import Switch from '@/components/ui/Switch/index.vue';
+import Button from '@/components/ui/Button/index.vue';
 
 interface Automation {
   id?: number;
@@ -85,12 +120,26 @@ interface Automation {
 const props = defineProps<{ taskTypeId: number }>();
 const { t } = useI18n();
 const automations = ref<Automation[]>([]);
+const statusOptions = ref<{ value: string; label: string }[]>([]);
+const teamOptions = ref<{ value: number; label: string }[]>([]);
 
 onMounted(load);
 
 async function load() {
-  const res = await api.get(`/task-types/${props.taskTypeId}/automations`);
+  const [res, statusRes, teamRes] = await Promise.all([
+    api.get(`/task-types/${props.taskTypeId}/automations`),
+    api.get('/task-statuses'),
+    api.get('/teams'),
+  ]);
   automations.value = res.data.data;
+  statusOptions.value = statusRes.data.map((s: any) => ({
+    value: s.slug,
+    label: s.name,
+  }));
+  teamOptions.value = teamRes.data.map((t: any) => ({
+    value: t.id,
+    label: t.name,
+  }));
 }
 
 function addAutomation() {


### PR DESCRIPTION
## Summary
- refactor automations editor to use Dashcode table styling
- replace manual inputs with Dashcode Select and Switch components
- load status and team options from API

## Testing
- `pnpm gen:api:types`
- `pnpm lint` *(fails: FieldPalette.vue, SLAPolicyEditor.vue accessibility issues)*
- `pnpm test` *(fails: Playwright missing browser deps)*

------
https://chatgpt.com/codex/tasks/task_e_68b30dcc37088323be5bea897cb7a856