### PR TITLE
feat: refactor templates drawer to Dashcode drawer

### DIFF
--- a/frontend/src/components/types/TemplatesDrawer.vue
+++ b/frontend/src/components/types/TemplatesDrawer.vue
@@ -1,59 +1,46 @@
 <template>
-  <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
-  <div
-    v-if="open"
-    class="fixed inset-0 bg-black/50 flex justify-end"
-    role="dialog"
-    aria-modal="true"
-    tabindex="0"
-    @keydown.escape.prevent="close"
-  >
-    <div class="bg-white w-80 p-4 overflow-y-auto">
-      <h2 class="text-lg font-bold mb-4">Templates</h2>
-      <div class="mb-6">
-        <label for="export-select" class="block mb-2">
-          Export JSON
-          <select
-            id="export-select"
-            v-model="exportId"
-            class="border rounded w-full mt-2"
-          >
-            <option :value="undefined" disabled>Select type</option>
-            <option v-for="t in types" :key="t.id" :value="t.id">{{ t.name }}</option>
-          </select>
-        </label>
-        <button
-          class="bg-blue-600 text-white px-2 py-1 rounded"
-          :disabled="!exportId"
+  <Drawer :open="open" @close="close">
+    <div class="w-full max-w-md p-4 space-y-6">
+      <h2 class="text-lg font-bold">{{ t('templates.title') }}</h2>
+      <div>
+        <Select
+          id="export-select"
+          v-model="exportId"
+          :label="t('templates.export')"
+          :options="selectOptions"
+          :placeholder="t('templates.selectType')"
+        />
+        <Button
+          class="mt-2"
+          :text="t('actions.export')"
+          :is-disabled="!exportId"
           @click="doExport"
-        >
-          Export
-        </button>
+        />
       </div>
-      <div class="mb-6">
-        <label for="import-input" class="block mb-2">
-          Import JSON
-          <input
-            id="import-input"
-            type="file"
-            accept="application/json"
-            class="mt-2"
-            @change="onFile"
-          />
-        </label>
+      <div>
+        <p class="mb-2">{{ t('templates.import') }}</p>
+        <Fileinput
+          name="import-input"
+          :placeholder="t('templates.import')"
+          @input="onFile"
+        />
       </div>
-      <button
-        class="text-sm text-gray-700 underline"
+      <Button
+        btn-class="btn-outline-secondary"
+        :text="t('actions.close')"
         @click="close"
-      >
-        Close
-      </button>
+      />
     </div>
-  </div>
+  </Drawer>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Drawer from '@/components/ui/Drawer/index.vue';
+import Select from '@/components/ui/Select/index.vue';
+import Button from '@/components/ui/Button/index.vue';
+import Fileinput from '@/components/ui/Fileinput/index.vue';
 import { useTaskTypesStore } from '@/stores/taskTypes';
 
 interface Props {
@@ -61,10 +48,15 @@ interface Props {
   types: any[];
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 const emit = defineEmits(['close', 'imported']);
 const exportId = ref<number>();
 const typesStore = useTaskTypesStore();
+const { t } = useI18n();
+
+const selectOptions = computed(() =>
+  props.types.map((t: any) => ({ value: t.id, label: t.name }))
+);
 
 function close() {
   emit('close');
@@ -84,9 +76,7 @@ async function doExport() {
   URL.revokeObjectURL(url);
 }
 
-async function onFile(e: Event) {
-  const input = e.target as HTMLInputElement;
-  const file = input.files?.[0];
+async function onFile(file: File) {
   if (!file) return;
   const text = await file.text();
   const json = JSON.parse(text);

--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -1,0 +1,35 @@
+<template>
+  <TransitionRoot :show="open" as="template">
+    <Dialog as="div" class="relative z-[99999]" @close="$emit('close')">
+      <TransitionChild as="template" enter="duration-300 ease-out" enter-from="opacity-0" enter-to="opacity-100" leave="duration-200 ease-in" leave-from="opacity-100" leave-to="opacity-0">
+        <div class="fixed inset-0 bg-slate-900/50" />
+      </TransitionChild>
+      <div class="fixed inset-0 flex justify-end">
+        <TransitionChild
+          as="template"
+          enter="transform transition ease-in-out duration-300"
+          enter-from="translate-x-full"
+          enter-to="translate-x-0"
+          leave="transform transition ease-in-out duration-300"
+          leave-from="translate-x-0"
+          leave-to="translate-x-full"
+        >
+          <DialogPanel class="w-full max-w-md h-full bg-white dark:bg-slate-800 shadow-xl rounded-l-2xl overflow-y-auto">
+            <slot />
+          </DialogPanel>
+        </TransitionChild>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script setup lang="ts">
+import { TransitionRoot, TransitionChild, Dialog, DialogPanel } from '@headlessui/vue';
+
+interface Props {
+  open: boolean;
+}
+
+defineProps<Props>();
+defineEmits(['close']);
+</script>

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -16,7 +16,8 @@
     "cancel": "Ακύρωση",
     "retry": "Επανάληψη",
     "add": "Προσθήκη",
-    "select": "Επιλογή"
+    "select": "Επιλογή",
+    "close": "Κλείσιμο"
   },
   "messages": {
     "helloToast": "Γεια από το τοστ"
@@ -241,5 +242,12 @@
     "placeholder": "Υπόδειξη",
     "help": "Βοήθεια",
     "reorderHint": "Χρησιμοποιήστε Alt+βέλη για αναδιάταξη"
+  }
+  ,
+  "templates": {
+    "title": "Πρότυπα",
+    "export": "Εξαγωγή JSON",
+    "import": "Εισαγωγή JSON",
+    "selectType": "Επιλέξτε τύπο"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -16,7 +16,8 @@
     "cancel": "Cancel",
     "retry": "Retry",
     "add": "Add",
-    "select": "Select"
+    "select": "Select",
+    "close": "Close"
   },
   "messages": {
     "helloToast": "Hello from toast"
@@ -241,5 +242,12 @@
     "placeholder": "Placeholder",
     "help": "Help",
     "reorderHint": "Use Alt+Arrow keys to reorder"
+  }
+  ,
+  "templates": {
+    "title": "Templates",
+    "export": "Export JSON",
+    "import": "Import JSON",
+    "selectType": "Select type"
   }
 }


### PR DESCRIPTION
## Summary
- add reusable Drawer component based on Headless UI
- refactor TemplatesDrawer to use Drawer and Dashcode UI components
- localize templates drawer labels in English and Greek

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 4 failed, 18 skipped, 24 passed)*
- `php artisan test` *(fails: 17 failed, 70 warnings, 6 incomplete, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b316022df48323b0f88ca77c5eee48