### PR TITLE
chore: add i18n strings for builder actions

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -13,6 +13,8 @@
     "save": "Αποθήκευση",
     "publish": "Δημοσίευση",
     "duplicate": "Αντιγραφή",
+    "addSection": "Προσθήκη ενότητας",
+    "addField": "Προσθήκη πεδίου",
     "cancel": "Ακύρωση",
     "retry": "Επανάληψη",
     "add": "Προσθήκη",
@@ -25,7 +27,10 @@
   },
   "a11y": {
     "skipToContent": "Μετάβαση στο περιεχόμενο",
-    "language": "Γλώσσα"
+    "language": "Γλώσσα",
+    "dragToReorder": "Σύρετε για αναδιάταξη",
+    "removeSection": "Αφαίρεση ενότητας",
+    "enableAutomation": "Ενεργοποίηση αυτοματοποίησης"
   },
   "commandPalette": {
     "title": "Παλέτα εντολών",
@@ -40,6 +45,8 @@
   "profile": {
     "settings": "Ρυθμίσεις"
   },
+  "Version": "Έκδοση",
+  "Section": "Ενότητα",
   "routes": {
     "dashboard": "Πίνακας ελέγχου",
     "tasks": "Εργασίες",
@@ -215,6 +222,7 @@
     "title": "Προεπισκόπηση",
     "runValidation": "Εκτέλεση Ελέγχου",
     "language": "Γλώσσα",
+    "version": "Έκδοση",
     "theme": "Θέμα",
     "viewport": "Προβολή",
     "light": "Φωτεινό",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -13,6 +13,8 @@
     "save": "Save",
     "publish": "Publish",
     "duplicate": "Duplicate",
+    "addSection": "Add Section",
+    "addField": "Add Field",
     "cancel": "Cancel",
     "retry": "Retry",
     "add": "Add",
@@ -25,7 +27,10 @@
   },
   "a11y": {
     "skipToContent": "Skip to content",
-    "language": "Language"
+    "language": "Language",
+    "dragToReorder": "Drag to reorder",
+    "removeSection": "Remove section",
+    "enableAutomation": "Enable automation"
   },
   "commandPalette": {
     "title": "Command palette",
@@ -40,6 +45,8 @@
   "profile": {
     "settings": "Settings"
   },
+  "Version": "Version",
+  "Section": "Section",
   "routes": {
     "dashboard": "Dashboard",
     "tasks": "Tasks",
@@ -215,6 +222,7 @@
     "title": "Preview",
     "runValidation": "Run Validation",
     "language": "Language",
+    "version": "Version",
     "theme": "Theme",
     "viewport": "Viewport",
     "light": "Light",


### PR DESCRIPTION
## Summary
- add English and Greek translations for builder actions and a11y labels
- include preview version label in both locales

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `php artisan test` *(fails: Tests: 17 failed, 70 warnings, 6 incomplete, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b319d3b5948323b57a96e2888b6f40