### PR TITLE
Align task type RBAC meta and UI with abilities

### DIFF
--- a/frontend/src/components/types/TemplatesDrawer.vue
+++ b/frontend/src/components/types/TemplatesDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <Drawer :open="open" @close="close">
+  <Drawer v-if="can('task_field_snippets.manage')" :open="open" @close="close">
     <div class="w-full max-w-md p-4 space-y-6">
       <h2 class="text-lg font-bold">{{ t('templates.title') }}</h2>
       <div>
@@ -41,6 +41,7 @@ import Drawer from '@/components/ui/Drawer/index.vue';
 import Select from '@/components/ui/Select/index.vue';
 import Button from '@/components/ui/Button/index.vue';
 import Fileinput from '@/components/ui/Fileinput/index.vue';
+import { can } from '@/stores/auth';
 import { useTaskTypesStore } from '@/stores/taskTypes';
 
 interface Props {

--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -16,7 +16,7 @@ export const menuItems = [
     title: "Task Types",
     icon: "heroicons-outline:tag",
     link: "taskTypes.list",
-    requiredAbilities: ["task_types.view", "task_types.manage"],
+    requiredAbilities: ["task_types.view"],
   },
   {
     title: "Teams",
@@ -107,7 +107,7 @@ export const topMenu = [
     title: "Task Types",
     icon: "heroicons-outline:tag",
     link: "taskTypes.list",
-    requiredAbilities: ["task_types.view", "task_types.manage"],
+    requiredAbilities: ["task_types.view"],
   },
   {
     title: "Teams",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -99,7 +99,8 @@ export const routes = [
     component: () => import('@/views/types/TypesList.vue'),
     meta: {
       requiresAuth: true,
-      requiredAbilities: ['task_types.view', 'task_types.manage'],
+      requiredAbilities: ['task_types.view'],
+      abilities: ['task_types.manage', 'task_field_snippets.manage'],
       breadcrumb: 'routes.taskTypes',
       title: 'Task Types',
       layout: 'app',
@@ -111,7 +112,8 @@ export const routes = [
     component: () => import('@/views/types/TypeForm.vue'),
     meta: {
       requiresAuth: true,
-      requiredAbilities: ['task_types.create', 'task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage'],
+      requiredAbilities: ['task_types.view'],
+      abilities: ['task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage'],
       breadcrumb: 'routes.taskTypeCreate',
       title: 'Create Task Type',
       layout: 'app',
@@ -124,7 +126,8 @@ export const routes = [
     component: () => import('@/views/types/TypeForm.vue'),
     meta: {
       requiresAuth: true,
-      requiredAbilities: ['task_types.update', 'task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage'],
+      requiredAbilities: ['task_types.view'],
+      abilities: ['task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage'],
       breadcrumb: 'routes.taskTypeEdit',
       title: 'Edit Task Type',
       layout: 'app',

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -59,6 +59,7 @@
             classInput="text-xs"
           />
           <Button
+            v-if="can('task_types.manage') && can('task_type_versions.manage')"
             type="button"
             :aria-label="t('actions.duplicate')"
             btnClass="btn-outline-primary text-xs px-3 py-1"
@@ -67,6 +68,7 @@
             {{ t('actions.duplicate') }}
           </Button>
           <Button
+            v-if="can('task_types.manage') && can('task_type_versions.manage')"
             type="button"
             :aria-label="t('actions.publish')"
             btnClass="btn-outline-primary text-xs px-3 py-1"
@@ -75,6 +77,7 @@
             {{ t('actions.publish') }}
           </Button>
           <Button
+            v-if="can('task_types.manage') && can('task_type_versions.manage')"
             type="button"
             :aria-label="t('actions.delete')"
             btnClass="btn-outline-danger text-xs px-3 py-1"
@@ -83,6 +86,7 @@
             {{ t('actions.delete') }}
           </Button>
           <Button
+            v-if="can('task_types.manage')"
             type="submit"
             :aria-label="t('actions.save')"
             btnClass="btn-primary text-xs px-3 py-1"
@@ -122,12 +126,12 @@
         class="p-4 border-b"
       />
       <SLAPolicyEditor
-        v-if="isEdit"
+        v-if="isEdit && can('task_sla_policies.manage')"
         :task-type-id="Number(route.params.id)"
         class="p-4 border-b"
       />
       <AutomationsEditor
-        v-if="isEdit"
+        v-if="isEdit && can('task_automations.manage')"
         :task-type-id="Number(route.params.id)"
         class="p-4 border-b"
       />
@@ -140,6 +144,7 @@
                 <h3 class="text-sm font-medium">{{ t('builder.canvas') }}</h3>
                 <div class="flex gap-2">
                   <Button
+                    v-if="can('task_types.manage')"
                     type="button"
                     btnClass="btn-outline-primary text-xs"
                     :aria-label="t('actions.add')"
@@ -148,6 +153,7 @@
                     {{ t('Section') }}
                   </Button>
                   <Button
+                    v-if="can('task_types.manage')"
                     type="button"
                     btnClass="btn-outline-primary text-xs"
                     :aria-label="t('actions.add')"
@@ -212,6 +218,7 @@
               <TabPanel>
                 <div class="mt-4">
                   <Button
+                    v-if="can('task_types.manage')"
                     type="button"
                     btnClass="btn-outline-primary text-xs mb-4"
                     :aria-label="t('actions.add')"
@@ -220,6 +227,7 @@
                     {{ t('Section') }}
                   </Button>
                   <Button
+                    v-if="can('task_types.manage')"
                     type="button"
                     btnClass="btn-outline-primary text-xs mb-4 ml-2"
                     :aria-label="t('actions.add')"
@@ -378,11 +386,7 @@ const fieldTypes = [
 const tenants = computed(() => tenantStore.tenants);
 
 const isEdit = computed(() => route.name === 'taskTypes.edit');
-const canAccess = computed(() =>
-  isEdit.value
-    ? can('task_types.update') || can('task_types.manage')
-    : can('task_types.create') || can('task_types.manage'),
-);
+const canAccess = computed(() => can('task_types.view'));
 
 watch(previewLang, (lang) => {
   locale.value = lang;

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -16,6 +16,7 @@
         </div>
         <div class="flex gap-2">
           <button
+            v-if="can('task_field_snippets.manage')"
             class="bg-gray-200 px-4 py-2 rounded"
             aria-label="Templates"
             @click="templatesOpen = true"
@@ -78,6 +79,7 @@
       </template>
     </DashcodeServerTable>
     <TemplatesDrawer
+      v-if="can('task_field_snippets.manage')"
       :open="templatesOpen"
       :types="all"
       @close="templatesOpen = false"


### PR DESCRIPTION
## Summary
- gate Task Type routes by view ability and list feature-specific abilities
- restrict Task Type UI actions via task_types.manage and related codes
- show Templates drawer only to users with task_field_snippets.manage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b31b0e00d88323bd85eb5fb871255d