### PR TITLE
Align RBAC abilities and finalize upload schema

### DIFF
--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -45,6 +45,7 @@ return [
             'task_types.manage',
             'task_type_versions.manage',
             'task_automations.manage',
+            'task_field_snippets.manage',
         ],
     ],
     'teams' => [

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -383,6 +383,11 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - filename
+                - task_id
+                - field_key
+                - section_key
               properties:
                 filename:
                   type: string

--- a/backend/tests/Feature/TaskTypeAbilityTest.php
+++ b/backend/tests/Feature/TaskTypeAbilityTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\TaskType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskTypeAbilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @dataProvider abilityProvider
+     */
+    public function test_routes_require_abilities(string $method, callable $resolver, string $ability): void
+    {
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['task_types']]);
+        $role = Role::create([
+            'name' => 'User',
+            'slug' => 'user',
+            'tenant_id' => $tenant->id,
+            'abilities' => [],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+
+        $type = TaskType::create([
+            'name' => 'Type',
+            'tenant_id' => $tenant->id,
+            'schema_json' => ['sections' => []],
+            'statuses' => ['draft' => []],
+        ]);
+
+        [$url, $payload] = $resolver($type);
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->json($method, $url, $payload)
+            ->assertStatus(403);
+
+        $abilityRole = Role::create([
+            'name' => 'Ability',
+            'slug' => 'ability',
+            'tenant_id' => $tenant->id,
+            'abilities' => [$ability],
+            'level' => 1,
+        ]);
+        $user->roles()->attach($abilityRole->id, ['tenant_id' => $tenant->id]);
+        $user->refresh();
+
+        $expected = $method === 'POST' ? 201 : 200;
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->json($method, $url, $payload)
+            ->assertStatus($expected);
+    }
+
+    public static function abilityProvider(): array
+    {
+        return [
+            'versions index' => ['GET', fn($type) => ['/api/task-type-versions', ['task_type_id' => $type->id]], 'task_type_versions.manage'],
+            'automations store' => [
+                'POST',
+                fn($type) => ["/api/task-types/{$type->id}/automations", [
+                    'event' => 'status_changed',
+                    'conditions_json' => null,
+                    'actions_json' => [['type' => 'noop']],
+                    'enabled' => true,
+                ]],
+                'task_automations.manage'
+            ],
+        ];
+    }
+}
+

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -113,7 +113,7 @@ export const routes = [
     meta: {
       requiresAuth: true,
       requiredAbilities: ['task_types.view'],
-      abilities: ['task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage'],
+      abilities: ['task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage', 'task_field_snippets.manage'],
       breadcrumb: 'routes.taskTypeCreate',
       title: 'Create Task Type',
       layout: 'app',
@@ -127,7 +127,7 @@ export const routes = [
     meta: {
       requiresAuth: true,
       requiredAbilities: ['task_types.view'],
-      abilities: ['task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage'],
+      abilities: ['task_types.manage', 'task_type_versions.manage', 'task_sla_policies.manage', 'task_automations.manage', 'task_field_snippets.manage'],
       breadcrumb: 'routes.taskTypeEdit',
       title: 'Edit Task Type',
       layout: 'app',

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -595,10 +595,10 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        filename?: string;
-                        task_id?: number;
-                        field_key?: string;
-                        section_key?: string;
+                        filename: string;
+                        task_id: number;
+                        field_key: string;
+                        section_key: string;
                     };
                 };
             };


### PR DESCRIPTION
## Summary
- map task field snippet ability to task type feature
- require filename, task_id, field_key, and section_key in upload finalize schema
- enforce task type management abilities and generate API types

## Testing
- `php artisan test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf)*
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist... run pnpm exec playwright install)*


------
https://chatgpt.com/codex/tasks/task_e_68b31c9a1ef083238e620f660bcf7c34