### PR TITLE
fix card header slot to show builder panes

### DIFF
--- a/frontend/src/components/ui/Card/index.vue
+++ b/frontend/src/components/ui/Card/index.vue
@@ -5,7 +5,7 @@
   >
     <div :class="cn('card-body flex flex-col', bodyClass)">
       <header
-        v-if="title || subtitle"
+        v-if="title || subtitle || $slots.header"
         :class="cn('flex mb-5 items-center', {
         'order-1': imgTop,
         'border-b border-slate-100 dark:border-slate-700 pb-5 -mx-6 px-6': !noborder


### PR DESCRIPTION
## Summary
- ensure Card component displays header slot without title/subtitle

## Testing
- `pnpm lint`
- `pnpm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b323e7e6948323b0cfa59a2b86020d