### PR TITLE
Fix task type builder sidebar and inspector tabs

### DIFF
--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -74,7 +74,7 @@
               </FromGroup>
             </div>
           </TabPanel>
-          <TabPanel v-if="roleOptions.length">
+          <TabPanel v-if="auth.isSuperAdmin || roleOptions.length">
             <div class="space-y-2">
               <FromGroup #default="{ inputId, labelId }" :label="t('roles.view')">
                 <div :id="inputId" :aria-labelledby="labelId" class="flex flex-col gap-1">
@@ -117,6 +117,7 @@ import Textinput from '@/components/ui/Textinput/index.vue';
 import Switch from '@/components/ui/Switch/index.vue';
 import FromGroup from '@/components/ui/FromGroup/index.vue';
 import Checkbox from '@/components/ui/Checkbox/index.vue';
+import { useAuthStore } from '@/stores/auth';
 
 interface RoleOption {
   id: number;
@@ -129,9 +130,10 @@ const props = withDefaults(
   { roleOptions: () => [] },
 );
 const { t, locale } = useI18n();
+const auth = useAuthStore();
 const tabs = computed(() => {
   const tbs = ['Basics', 'Validation'];
-  if (props.roleOptions.length) tbs.push(t('roles.label'));
+  if (auth.isSuperAdmin || props.roleOptions.length) tbs.push(t('roles.label'));
   return tbs;
 });
 

--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -41,11 +41,18 @@ watch(
   (isOpen) => {
     if (isOpen) {
       scrollY.value = window.scrollY;
-      document.body.style.top = `-${scrollY.value}px`;
-      document.body.style.position = 'fixed';
+      const body = document.body;
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      body.style.top = `-${scrollY.value}px`;
+      body.style.position = 'fixed';
+      body.style.width = '100%';
+      body.style.paddingRight = `${scrollbarWidth}px`;
     } else {
-      document.body.style.position = '';
-      document.body.style.top = '';
+      const body = document.body;
+      body.style.position = '';
+      body.style.top = '';
+      body.style.width = '';
+      body.style.paddingRight = '';
       window.scrollTo(0, scrollY.value);
     }
   },


### PR DESCRIPTION
## Summary
- prevent sidebar drawer from shifting layout and reset scroll position
- show roles tab in field inspector to super admins

## Testing
- `npm run lint`
- `npm test` *(fails: missing Playwright browsers and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b32b839e308323b4cc53f2f7c2f86f