### PR TITLE
Fix tooltip labels in permissions matrix

### DIFF
--- a/frontend/src/components/types/PermissionsMatrix.vue
+++ b/frontend/src/components/types/PermissionsMatrix.vue
@@ -18,10 +18,11 @@
               scope="col"
               class="px-4 py-2 text-center"
             >
-              <Tooltip :content="t(`permissions.tooltip.${ability.key}`)" theme="light">
+              <Tooltip theme="light">
                 <template #button>
                   <span>{{ ability.label }}</span>
                 </template>
+                {{ t(`permissions.tooltip.${ability.key}`) }}
               </Tooltip>
             </th>
           </tr>


### PR DESCRIPTION
## Summary
- ensure task type permissions matrix renders ability labels instead of placeholder tooltip text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b345e3504c8323869d8e49d828dad1