### PR TITLE
feat: clarify task type permission hints

### DIFF
--- a/frontend/src/components/types/PermissionsMatrix.vue
+++ b/frontend/src/components/types/PermissionsMatrix.vue
@@ -18,10 +18,18 @@
               scope="col"
               class="px-4 py-2 text-center"
             >
-              <Tooltip :content="t(`permissions.tooltip.${ability.key}`)" theme="light">
+              <Tooltip theme="light" trigger="mouseenter focus click">
                 <template #button>
-                  <span>{{ ability.label }}</span>
+                  <span class="inline-flex items-center gap-1 cursor-help">
+                    {{ ability.label }}
+                    <Icon
+                      icon="heroicons-outline:question-mark-circle"
+                      class="w-4 h-4"
+                      aria-hidden="true"
+                    />
+                  </span>
                 </template>
+                {{ t(`permissions.tooltip.${ability.key}`) }}
               </Tooltip>
             </th>
           </tr>
@@ -76,6 +84,7 @@ import { useI18n } from 'vue-i18n';
 import Card from '@/components/ui/Card/index.vue';
 import Switch from '@/components/ui/Switch/index.vue';
 import Tooltip from '@/components/ui/Tooltip/index.vue';
+import Icon from '@/components/Icon';
 
 interface Role {
   id: number;


### PR DESCRIPTION
## Summary
- show info icons for permission columns
- enable click and focus triggers on permission tooltips

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68b345e3504c8323869d8e49d828dad1