### PR TITLE
Fix status and transition selection in task type workflow editor

### DIFF
--- a/frontend/src/components/types/StatusFlowEditor.vue
+++ b/frontend/src/components/types/StatusFlowEditor.vue
@@ -67,7 +67,7 @@
         <VueSelect
           id="transition-from"
           v-model="transitionForm.from"
-          :options="statusOptions"
+          :options="transitionOptions"
           :label="t('types.workflow.from')"
           class="w-40"
           classLabel="sr-only"
@@ -77,7 +77,7 @@
         <VueSelect
           id="transition-to"
           v-model="transitionForm.to"
-          :options="statusOptions"
+          :options="transitionOptions"
           :label="t('types.workflow.to')"
           class="w-40"
           classLabel="sr-only"
@@ -167,7 +167,7 @@
         <VueSelect
           id="status-select"
           v-model="newStatus"
-          :options="statusOptions"
+          :options="addStatusOptions"
           :label="t('types.workflow.addStatus')"
           classLabel="sr-only"
           :placeholder="t('actions.select')"
@@ -246,15 +246,22 @@ const liveMessage = ref('');
 
 onMounted(async () => {
   const res = await api.get('/task-statuses');
-  allStatuses.value = res.data;
+  allStatuses.value = res.data.data;
 });
 
 const remainingStatuses = computed(() =>
   allStatuses.value.filter((s) => !localStatuses.value.includes(s.slug))
 );
 
-const statusOptions = computed(() =>
+const addStatusOptions = computed(() =>
   remainingStatuses.value.map((s) => ({ value: s.slug, label: s.name }))
+);
+
+const transitionOptions = computed(() =>
+  localStatuses.value.map((slug) => ({
+    value: slug,
+    label: allStatuses.value.find((s) => s.slug === slug)?.name || slug,
+  }))
 );
 
 function displayName(slug: string) {


### PR DESCRIPTION
## Summary
- fix fetching of available task statuses
- show existing statuses when adding transitions

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/)*

------
https://chatgpt.com/codex/tasks/task_e_68b34a73a2b48323acbe6d4cd6168a48