### PR TITLE
chore(i18n): remove hardcoded strings and add missing translations

### DIFF
--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -73,7 +73,7 @@
             :aria-label="tr(field.label)"
             @change="emitUpdate(field)"
           >
-            <option value="" disabled>Select...</option>
+            <option value="" disabled>{{ t('common.select') }}</option>
             <option v-for="opt in field.enum" :key="opt" :value="opt">{{ opt }}</option>
           </select>
           <select

--- a/frontend/src/components/types/AutomationsEditor.vue
+++ b/frontend/src/components/types/AutomationsEditor.vue
@@ -31,7 +31,7 @@
                   :label="t('automations.event')"
                   class="w-full"
                 >
-                  <option value="status_changed">status_changed</option>
+                  <option value="status_changed">{{ t('automations.events.statusChanged') }}</option>
                 </Select>
               </td>
               <td class="table-td">

--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -132,7 +132,7 @@ const props = withDefaults(
 const { t, locale } = useI18n();
 const auth = useAuthStore();
 const tabs = computed(() => {
-  const tbs = ['Basics', 'Validation'];
+  const tbs = [t('inspector.basics'), t('inspector.validation')];
   if (auth.isSuperAdmin || props.roleOptions.length) tbs.push(t('roles.label'));
   return tbs;
 });

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -26,6 +26,9 @@
   "messages": {
     "helloToast": "Γεια από το τοστ"
   },
+  "common": {
+    "select": "Επιλέξτε..."
+  },
   "a11y": {
     "skipToContent": "Μετάβαση στο περιεχόμενο",
     "language": "Γλώσσα",
@@ -46,6 +49,9 @@
   },
   "profile": {
     "settings": "Ρυθμίσεις"
+  },
+  "version": {
+    "fallback": "v{n}"
   },
   "Version": "Έκδοση",
   "Section": "Ενότητα",
@@ -232,7 +238,10 @@
     "event": "Συμβάν",
     "status": "Κατάσταση",
     "team": "Ομάδα",
-    "enabled": "Ενεργό"
+    "enabled": "Ενεργό",
+    "events": {
+      "statusChanged": "Αλλαγή κατάστασης"
+    }
   },
   "dashboard": {
     "messages": {
@@ -261,6 +270,10 @@
     "canvas": "Καμβάς",
     "preview": "Προεπισκόπηση",
     "inspector": "Επιθεωρητής"
+  },
+  "inspector": {
+    "basics": "Βασικά",
+    "validation": "Επικύρωση"
   },
   "validation": {
     "regex": "Πρότυπο",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -26,8 +26,11 @@
   "messages": {
     "helloToast": "Hello from toast"
   },
-    "a11y": {
-      "skipToContent": "Skip to content",
+  "common": {
+    "select": "Select..."
+  },
+  "a11y": {
+    "skipToContent": "Skip to content",
       "language": "Language",
       "dragToReorder": "Drag to reorder",
       "removeSection": "Remove section",
@@ -46,6 +49,9 @@
   },
   "profile": {
     "settings": "Settings"
+  },
+  "version": {
+    "fallback": "v{n}"
   },
   "Version": "Version",
   "Section": "Section",
@@ -232,7 +238,10 @@
     "event": "Event",
     "status": "Status",
     "team": "Team",
-    "enabled": "Enabled"
+    "enabled": "Enabled",
+    "events": {
+      "statusChanged": "Status changed"
+    }
   },
   "dashboard": {
     "messages": {
@@ -261,6 +270,10 @@
     "canvas": "Canvas",
     "preview": "Preview",
     "inspector": "Inspector"
+  },
+  "inspector": {
+    "basics": "Basics",
+    "validation": "Validation"
   },
   "validation": {
     "regex": "Pattern",

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -15,7 +15,13 @@
             classInput="text-xs"
             @change="onVersionChange"
           />
-          <span v-else class="text-xs px-2 py-1 border rounded" :aria-label="t('Version')">v1</span>
+          <span
+            v-else
+            class="text-xs px-2 py-1 border rounded"
+            :aria-label="t('Version')"
+          >
+            {{ t('version.fallback', { n: 1 }) }}
+          </span>
           <Badge
             v-if="currentVersion"
             :label="t(`versionStatus.${versionStatusLabel}`)"


### PR DESCRIPTION
## Summary
- replace hardcoded strings in type builder and related components with localized translations
- add English fallbacks for version label, inspector tabs, automation event, and select placeholder

## Testing
- `pnpm lint`
- `pnpm gen:api:types`
- `pnpm test` *(fails: browsers missing)*
- `php artisan test` *(fails: 20 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b35f0c1d448323a3a9c85346487615