### PR TITLE
Focus first invalid field after validation

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -364,7 +364,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, watch, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import draggable from 'vuedraggable';
@@ -772,6 +772,10 @@ function runValidation() {
   const feErrors = formRef.value?.errors || {};
   if (Object.keys(feErrors).length) {
     validationErrors.value = feErrors;
+    const first = Object.keys(validationErrors.value)[0];
+    if (first) {
+      nextTick(() => document.getElementById(first)?.focus());
+    }
     return;
   }
   const url = isEdit.value
@@ -786,10 +790,7 @@ function runValidation() {
       validationErrors.value = err.response?.data?.errors || { error: 'validation failed' };
       const first = Object.keys(validationErrors.value)[0];
       if (first) {
-        const el = formRef.value?.$el?.querySelector(
-          `[name="${first}"]`,
-        ) as HTMLElement | null;
-        el?.focus();
+        nextTick(() => document.getElementById(first)?.focus());
       }
     });
 }


### PR DESCRIPTION
## Summary
- ensure type builder validation focuses the first errored field

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `pnpm exec playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_68b360b1733c8323a86aba167fc573d6