### PR TITLE
feat: add task type validation endpoint

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -607,6 +607,8 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - schema_json
               properties:
                 schema_json:
                   type: object
@@ -615,6 +617,13 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
         '422':
           description: Validation errors
   /task-types/{id}/validate:

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1017,7 +1017,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        schema_json?: Record<string, never>;
+                        schema_json: Record<string, never>;
                         form_data?: Record<string, never>;
                     };
                 };
@@ -1028,7 +1028,11 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            message?: string;
+                        };
+                    };
                 };
                 /** @description Validation errors */
                 422: {


### PR DESCRIPTION
## Summary
- document task type validation endpoint
- regenerate API types

## Testing
- `pnpm gen:api:types`
- `php artisan test` *(fails: chunk field must be a file; 20 failed)*
- `pnpm test` *(fails: Playwright executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b361ab58f08323a895733bc6f25adf