### PR TITLE
fix: refresh roles on tenant change

### DIFF
--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -79,12 +79,12 @@
               </FromGroup>
             </div>
           </TabPanel>
-          <TabPanel v-if="auth.isSuperAdmin || roleOptions.length">
+          <TabPanel v-if="auth.isSuperAdmin || (roleOptions?.length ?? 0)">
             <div class="space-y-2">
               <FromGroup #default="{ inputId, labelId }" :label="t('roles.view')">
                 <div :id="inputId" :aria-labelledby="labelId" class="flex flex-col gap-1">
                   <Checkbox
-                    v-for="r in roleOptions"
+                    v-for="r in (roleOptions || [])"
                     :key="r.id"
                     v-model="roles.view"
                     :value="r.slug"
@@ -95,7 +95,7 @@
               <FromGroup #default="{ inputId, labelId }" :label="t('roles.edit')">
                 <div :id="inputId" :aria-labelledby="labelId" class="flex flex-col gap-1">
                   <Checkbox
-                    v-for="r in roleOptions"
+                    v-for="r in (roleOptions || [])"
                     :key="r.id"
                     v-model="roles.edit"
                     :value="r.slug"
@@ -139,7 +139,7 @@ const { t, locale } = useI18n();
 const auth = useAuthStore();
 const tabs = computed(() => {
   const tbs = [t('inspector.basics'), t('inspector.validation')];
-  if (auth.isSuperAdmin || props.roleOptions.length) tbs.push(t('roles.label'));
+  if (auth.isSuperAdmin || (props.roleOptions?.length ?? 0)) tbs.push(t('roles.label'));
   return tbs;
 });
 

--- a/frontend/src/components/types/PermissionsMatrix.vue
+++ b/frontend/src/components/types/PermissionsMatrix.vue
@@ -121,6 +121,10 @@ const localPermissions = reactive<Record<string, Permission>>(
 watch(
   () => props.roles,
   (roles) => {
+    const slugs = roles.map((r) => r.slug);
+    Object.keys(localPermissions).forEach((k) => {
+      if (!slugs.includes(k)) delete localPermissions[k];
+    });
     roles.forEach((r) => {
       if (!localPermissions[r.slug]) {
         localPermissions[r.slug] = {
@@ -136,7 +140,7 @@ watch(
       }
     });
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 );
 
 watch(

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -216,6 +216,7 @@
         </Card>
         <PermissionsMatrix
           v-else
+          :key="`perm-${tenantId}`"
           v-model="permissions"
           :roles="tenantRoles"
           :can-manage="canManage"
@@ -299,7 +300,7 @@
               <h3 class="text-sm font-medium">{{ t('builder.inspector') }}</h3>
             </template>
             <div class="p-4">
-              <InspectorTabs :selected="selected" :role-options="tenantRoles" />
+              <InspectorTabs :key="`insp-${tenantId}`" :selected="selected" :role-options="tenantRoles" />
             </div>
           </Card>
           </div>
@@ -376,7 +377,7 @@
                 </TabPanel>
                 <TabPanel>
                   <div class="p-2">
-                    <InspectorTabs :selected="selected" :role-options="tenantRoles" />
+                    <InspectorTabs :key="`insp-${tenantId}`" :selected="selected" :role-options="tenantRoles" />
                   </div>
                 </TabPanel>
               </template>
@@ -596,7 +597,7 @@ onMounted(async () => {
       }
       if (id) {
         try {
-          const { data } = await api.get('/roles', { params: { tenant_id: id } });
+          const { data } = await api.get('/roles', { params: { tenant_id: Number(id) } });
           tenantRoles.value = data.data ?? data;
           tenantRoles.value.forEach((r: any) => {
             if (!permissions.value[r.slug]) {
@@ -612,6 +613,11 @@ onMounted(async () => {
               permissions.value[r.slug].transition = false;
             }
           });
+          const validSlugs = tenantRoles.value.map((r: any) => r.slug);
+          if (selected.value) {
+            selected.value.roles.view = selected.value.roles.view.filter((s: string) => validSlugs.includes(s));
+            selected.value.roles.edit = selected.value.roles.edit.filter((s: string) => validSlugs.includes(s));
+          }
         } catch {
           tenantRoles.value = [];
           permissions.value = {};

--- a/frontend/tests/e2e/tenant-role-switch.spec.ts
+++ b/frontend/tests/e2e/tenant-role-switch.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('roles update when tenant changes (placeholder)', async () => {
+  const tenantARoles = ['roleA1', 'roleA2'];
+  const tenantBRoles = ['roleB1'];
+
+  // simulate toggling permissions for tenant A
+  const permissionsA: Record<string, { read: boolean }> = {
+    roleA1: { read: true },
+    roleA2: { read: false },
+  };
+
+  // switching to tenant B should drop roles from tenant A
+  const permissionsB: Record<string, { read: boolean }> = {};
+  tenantBRoles.forEach((slug) => (permissionsB[slug] = { read: false }));
+
+  expect(permissionsB.roleA1).toBeUndefined();
+  expect(permissionsB.roleA2).toBeUndefined();
+
+  // field role selections should also be cleaned up
+  const fieldRoles = { view: ['roleA1'], edit: ['roleA2'] };
+  const validSlugs = new Set(tenantBRoles);
+  fieldRoles.view = fieldRoles.view.filter((r) => validSlugs.has(r));
+  fieldRoles.edit = fieldRoles.edit.filter((r) => validSlugs.has(r));
+
+  expect(fieldRoles.view).toHaveLength(0);
+  expect(fieldRoles.edit).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
- ensure role APIs and UIs refresh on tenant switch
- harden InspectorTabs role handling and permissions matrix
- add placeholder E2E for tenant role switch

## Testing
- `npm test` *(fails: npx playwright install required)*
- `npx playwright install --with-deps` *(fails: HTTP 403 from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b40013d7d8832380e89ac7abcaab64