### PR TITLE
feat: improve status flow editor ux

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -35,7 +35,8 @@
     "dragToReorder": "Σύρετε για αναδιάταξη",
     "removeSection": "Αφαίρεση ενότητας",
     "enableAutomation": "Ενεργοποίηση αυτοματοποίησης",
-    "movedToPosition": "Μετακινήθηκε στη θέση {pos}"
+    "movedToPosition": "Μετακινήθηκε στη θέση {pos}",
+    "reorderInstructions": "Πατήστε Enter για επιλογή, χρησιμοποιήστε τα βέλη για μετακίνηση, Escape για ακύρωση"
   },
   "commandPalette": {
     "title": "Παλέτα εντολών",
@@ -211,7 +212,9 @@
       "to": "Προς",
       "condition": "Συνθήκη",
       "noCondition": "Πάντα",
-      "transition": "Μετάβαση"
+      "transition": "Μετάβαση",
+      "quickPresets": "Γρήγορες προεπιλογές",
+      "presetBasic": "Βασικό: todo → in_progress → completed"
     },
     "form": {
       "name": "Όνομα",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -35,7 +35,8 @@
       "dragToReorder": "Drag to reorder",
       "removeSection": "Remove section",
       "enableAutomation": "Enable automation",
-      "movedToPosition": "Moved to position {pos}"
+      "movedToPosition": "Moved to position {pos}",
+      "reorderInstructions": "Press Enter to grab, use arrow keys to move, Escape to release"
     },
   "commandPalette": {
     "title": "Command palette",
@@ -211,7 +212,9 @@
       "to": "To",
       "condition": "Condition",
       "noCondition": "Always",
-      "transition": "Transition"
+      "transition": "Transition",
+      "quickPresets": "Quick presets",
+      "presetBasic": "Basic: todo → in_progress → completed"
     },
     "form": {
       "name": "Name",


### PR DESCRIPTION
## Summary
- revamp status chips into draggable, accessible pills
- add sticky headers and keyboard hints to transitions table
- support quick presets for common status flows

## Testing
- `npm run lint`
- `npm test` *(fails: browser binaries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b402087278832398015194e4d59344