### PR TITLE
feat: polish permissions matrix for accessibility

### DIFF
--- a/frontend/src/components/ui/Switch/index.vue
+++ b/frontend/src/components/ui/Switch/index.vue
@@ -12,7 +12,7 @@
         :id="inputId"
         v-model="localValue"
         type="checkbox"
-        class="hidden"
+        class="sr-only peer"
         :disabled="disabled"
         :name="name"
         :value="value"
@@ -21,7 +21,7 @@
       />
       <div
         :class="ck ? activeClass : 'bg-secondary-500'"
-        class="relative inline-flex h-6 w-[46px] ltr:mr-3 rtl:ml-3 items-center rounded-full transition-all duration-150"
+        class="relative inline-flex h-6 w-[46px] ltr:mr-3 rtl:ml-3 items-center rounded-full transition-all duration-150 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary-500"
       >
         <span
           v-if="badge && ck"

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -99,7 +99,8 @@
     "delete": "Διαγραφή",
     "export": "Εξαγωγή",
     "assign": "Ανάθεση",
-    "transition": "Μετάβαση"
+    "transition": "Μετάβαση",
+    "legend": "Υπόμνημα"
   },
   "permissions": {
     "tooltip": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -99,7 +99,8 @@
     "delete": "Delete",
     "export": "Export",
     "assign": "Assign",
-    "transition": "Transition"
+    "transition": "Transition",
+    "legend": "Legend"
   },
   "permissions": {
     "tooltip": {

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -220,6 +220,7 @@
           v-model="permissions"
           :roles="tenantRoles"
           :can-manage="canManage"
+          :status-count="statuses.length"
           class="p-4 border-b"
         />
         <div class="h-[calc(100vh-3rem)] p-4">


### PR DESCRIPTION
## Summary
- make abilities header sticky and zebra-striped rows for desktop table
- add bilingual legend and focus rings for switches
- disable transition permission unless multiple statuses available

## Testing
- `npm run lint`
- `npm test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b4031798388323b4164a1fe1acbb81