### PR TITLE
feat: gate task type form by ability

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -225,7 +225,9 @@
     },
     "saveToConfigureSLA": "Αποθηκεύστε για να ρυθμίσετε τις Πολιτικές SLA",
     "saveToConfigureAutomations": "Αποθηκεύστε για να ρυθμίσετε Αυτοματισμούς",
-    "selectTenantToSetPermissions": "Επιλέξτε μισθωτή για να ορίσετε δικαιώματα"
+    "selectTenantToSetPermissions": "Επιλέξτε μισθωτή για να ορίσετε δικαιώματα",
+    "noSLAPermissions": "Δεν έχετε δικαίωμα διαχείρισης Πολιτικών SLA",
+    "noAutomationsPermissions": "Δεν έχετε δικαίωμα διαχείρισης Αυτοματισμών"
   },
   "slaPolicies": {
     "title": "Πολιτικές SLA",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -225,7 +225,9 @@
     },
     "saveToConfigureSLA": "Save to configure SLA policies",
     "saveToConfigureAutomations": "Save to configure automations",
-    "selectTenantToSetPermissions": "Select tenant to set permissions"
+    "selectTenantToSetPermissions": "Select tenant to set permissions",
+    "noSLAPermissions": "You do not have permission to manage SLA policies",
+    "noAutomationsPermissions": "You do not have permission to manage automations"
   },
   "slaPolicies": {
     "title": "SLA Policies",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -118,14 +118,7 @@ export const routes = [
     component: () => import('@/views/types/TypeForm.vue'),
     meta: {
       requiresAuth: true,
-      requiredAbilities: [
-        'task_types.create',
-        'task_types.manage',
-        'task_type_versions.manage',
-        'task_sla_policies.manage',
-        'task_automations.manage',
-        'task_field_snippets.manage',
-      ],
+      requiredAbilities: ['task_types.create', 'task_types.manage'],
       breadcrumb: 'routes.taskTypeCreate',
       title: 'Create Task Type',
       layout: 'app',
@@ -138,14 +131,7 @@ export const routes = [
     component: () => import('@/views/types/TypeForm.vue'),
     meta: {
       requiresAuth: true,
-      requiredAbilities: [
-        'task_types.view',
-        'task_types.manage',
-        'task_type_versions.manage',
-        'task_sla_policies.manage',
-        'task_automations.manage',
-        'task_field_snippets.manage',
-      ],
+      requiredAbilities: ['task_types.view', 'task_types.manage'],
       breadcrumb: 'routes.taskTypeEdit',
       title: 'Edit Task Type',
       layout: 'app',

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -145,63 +145,83 @@
         class="p-4 border-b"
       />
       <template v-if="tenantId || !isCreate">
-        <template v-if="auth.isSuperAdmin || can('task_sla_policies.manage')">
+        <template v-if="canManageSLA">
           <SLAPolicyEditor
             v-if="isEdit"
             :task-type-id="Number(route.params.id)"
             class="p-4 border-b"
           />
-        <Card
-          v-else
-          class="p-4 border-b flex flex-col items-center text-center gap-2"
-        >
-          <Icon
-            icon="heroicons-outline:information-circle"
-            class="w-6 h-6 text-slate-400"
-            aria-hidden="true"
-          />
-          <p class="text-sm">{{ t('types.saveToConfigureSLA') }}</p>
-          <Button
-            v-if="auth.isSuperAdmin || can('task_types.manage')"
-            type="submit"
-            :aria-label="t('actions.save')"
-            btnClass="btn-primary text-xs px-3 py-1"
-            :disabled="!isFormValid"
-            :aria-disabled="!isFormValid ? 'true' : 'false'"
-            :tabindex="!isFormValid ? -1 : 0"
+          <Card
+            v-else
+            class="p-4 border-b flex flex-col items-center text-center gap-2"
           >
-            {{ t('actions.save') }}
-          </Button>
-        </Card>
+            <Icon
+              icon="heroicons-outline:information-circle"
+              class="w-6 h-6 text-slate-400"
+              aria-hidden="true"
+            />
+            <p class="text-sm">{{ t('types.saveToConfigureSLA') }}</p>
+            <Button
+              v-if="auth.isSuperAdmin || can('task_types.manage')"
+              type="submit"
+              :aria-label="t('actions.save')"
+              btnClass="btn-primary text-xs px-3 py-1"
+              :disabled="!isFormValid"
+              :aria-disabled="!isFormValid ? 'true' : 'false'"
+              :tabindex="!isFormValid ? -1 : 0"
+            >
+              {{ t('actions.save') }}
+            </Button>
+          </Card>
         </template>
-        <template v-if="auth.isSuperAdmin || can('task_automations.manage')">
+        <template v-else>
+          <Card class="p-4 border-b flex flex-col items-center text-center gap-2">
+            <Icon
+              icon="heroicons-outline:information-circle"
+              class="w-6 h-6 text-slate-400"
+              aria-hidden="true"
+            />
+            <p class="text-sm">{{ t('types.noSLAPermissions') }}</p>
+          </Card>
+        </template>
+        <template v-if="canManageAutomations">
           <AutomationsEditor
             v-if="isEdit"
             :task-type-id="Number(route.params.id)"
             class="p-4 border-b"
           />
-        <Card
-          v-else
-          class="p-4 border-b flex flex-col items-center text-center gap-2"
-        >
-          <Icon
-            icon="heroicons-outline:information-circle"
-            class="w-6 h-6 text-slate-400"
-            aria-hidden="true"
-          />
-          <p class="text-sm">{{ t('types.saveToConfigureAutomations') }}</p>
-          <Button
-            v-if="auth.isSuperAdmin || can('task_types.manage')"
-            type="submit"
-            :aria-label="t('actions.save')"
-            btnClass="btn-primary text-xs px-3 py-1"
-            :disabled="!isFormValid"
-            :aria-disabled="!isFormValid ? 'true' : 'false'"
-            :tabindex="!isFormValid ? -1 : 0"
+          <Card
+            v-else
+            class="p-4 border-b flex flex-col items-center text-center gap-2"
           >
-            {{ t('actions.save') }}
-          </Button>
-        </Card>
+            <Icon
+              icon="heroicons-outline:information-circle"
+              class="w-6 h-6 text-slate-400"
+              aria-hidden="true"
+            />
+            <p class="text-sm">{{ t('types.saveToConfigureAutomations') }}</p>
+            <Button
+              v-if="auth.isSuperAdmin || can('task_types.manage')"
+              type="submit"
+              :aria-label="t('actions.save')"
+              btnClass="btn-primary text-xs px-3 py-1"
+              :disabled="!isFormValid"
+              :aria-disabled="!isFormValid ? 'true' : 'false'"
+              :tabindex="!isFormValid ? -1 : 0"
+            >
+              {{ t('actions.save') }}
+            </Button>
+          </Card>
+        </template>
+        <template v-else>
+          <Card class="p-4 border-b flex flex-col items-center text-center gap-2">
+            <Icon
+              icon="heroicons-outline:information-circle"
+              class="w-6 h-6 text-slate-400"
+              aria-hidden="true"
+            />
+            <p class="text-sm">{{ t('types.noAutomationsPermissions') }}</p>
+          </Card>
         </template>
         <Card
           v-if="!tenantId"
@@ -504,6 +524,12 @@ const statusFlow = ref<[string, string][]>([]);
 const permissions = ref<Record<string, Permission>>({});
 const tenantRoles = ref<any[]>([]);
 const canManage = computed(() => auth.isSuperAdmin || can('task_types.manage'));
+const canManageSLA = computed(
+  () => auth.isSuperAdmin || can('task_sla_policies.manage'),
+);
+const canManageAutomations = computed(
+  () => auth.isSuperAdmin || can('task_automations.manage'),
+);
 const isFormValid = computed(() => name.value.trim().length > 0 && tenantId.value !== '');
 
 const fieldTypes = [
@@ -552,7 +578,8 @@ const isCreate = computed(
 const canAccess = computed(
   () =>
     auth.isSuperAdmin ||
-    (isEdit.value ? can('task_types.view') : can('task_types.create')),
+    (can('task_types.manage') &&
+      (isEdit.value ? can('task_types.view') : can('task_types.create'))),
 );
 
 watch(previewLang, (lang) => {


### PR DESCRIPTION
## Summary
- restrict task type create/edit routes to required abilities
- gate TypeForm sections by ability with localized fallbacks
- add translations for SLA and automation permission warnings

## Testing
- `npm run lint` *(fails: Form label must have an associated control)*
- `npm test` *(fails: 11 failing tests; playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b405defbf883238073891f9cca7b21