### PR TITLE
T7 tighten tenant filtering for roles index

### DIFF
--- a/backend/app/Http/Controllers/Api/RoleController.php
+++ b/backend/app/Http/Controllers/Api/RoleController.php
@@ -30,12 +30,16 @@ class RoleController extends Controller
         $scope = $request->query('scope');
         $tenantId = $request->query('tenant_id');
 
+        if ($tenantId !== null) {
+            $tenantId = (int) $tenantId;
+            $scope = 'tenant';
+        }
+
         if (! $request->user()->isSuperAdmin()) {
             $tenantId = $request->user()->tenant_id;
             $userLevel = $request->user()->roleLevel($tenantId);
-            $base = Role::where(function ($query) use ($tenantId) {
-                $query->where('tenant_id', $tenantId)->orWhereNull('tenant_id');
-            })->where('level', '>=', $userLevel);
+            $base = Role::where('tenant_id', $tenantId)
+                ->where('level', '>=', $userLevel);
             $result = $this->listQuery($base, $request, ['name'], ['name']);
             return RoleResource::collection($result['data'])->additional([
                 'meta' => $result['meta'],


### PR DESCRIPTION
## Summary
- Ensure tenant ID query casts to integer and forces tenant scope
- Limit tenant users to their own roles at or above their level
- Add feature tests for tenant and super admin role filtering

## Testing
- `cd backend && ./vendor/bin/phpunit tests/Feature/RoleRoutesTest.php tests/Feature/RoleLevelRestrictionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4075f9f8083239025e0d4927e3299