### PR TITLE
chore: sync OpenAPI spec and types

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -310,7 +310,7 @@ paths:
         - name: tenant_id
           in: query
           schema:
-            type: string
+            type: integer
       responses:
         '200':
           description: List of roles
@@ -927,16 +927,30 @@ paths:
         - name: tenant_id
           in: query
           schema:
-            type: string
+            type: integer
       responses:
         '200':
           description: List of task statuses
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TaskStatus'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TaskStatus'
+                  meta:
+                    type: object
+                    properties:
+                      page:
+                        type: integer
+                      per_page:
+                        type: integer
+                      total:
+                        type: integer
+                      last_page:
+                        type: integer
   /task-statuses/{id}/copy-to-tenant:
     post:
       summary: Copy status to tenant
@@ -1288,9 +1302,17 @@ components:
           description: "Form schema. Text fields support string or {en,el} objects."
         statuses:
           type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
           nullable: true
         status_flow_json:
-          type: object
+          type: array
+          items:
+            type: array
+            items:
+              type: string
           nullable: true
         abilities_json:
           type: object

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -460,7 +460,7 @@ export interface paths {
             parameters: {
                 query?: {
                     scope?: string;
-                    tenant_id?: string;
+                    tenant_id?: number;
                 };
                 header?: never;
                 path?: never;
@@ -1539,7 +1539,7 @@ export interface paths {
             parameters: {
                 query?: {
                     scope?: string;
-                    tenant_id?: string;
+                    tenant_id?: number;
                 };
                 header?: never;
                 path?: never;
@@ -1553,7 +1553,15 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["TaskStatus"][];
+                        "application/json": {
+                            data?: components["schemas"]["TaskStatus"][];
+                            meta?: {
+                                page?: number;
+                                per_page?: number;
+                                total?: number;
+                                last_page?: number;
+                            };
+                        };
                     };
                 };
             };
@@ -1924,8 +1932,10 @@ export interface components {
             semver?: string;
             /** @description Form schema. Text fields support string or {en,el} objects. */
             schema_json?: Record<string, never> | null;
-            statuses?: Record<string, never> | null;
-            status_flow_json?: Record<string, never> | null;
+            statuses?: {
+                [key: string]: string[];
+            } | null;
+            status_flow_json?: string[][] | null;
             abilities_json?: Record<string, never> | null;
             created_by?: number;
             /** Format: date-time */


### PR DESCRIPTION
## Summary
- document `/roles` `tenant_id` as an integer
- describe paginated response for `/task-statuses`
- add schema for `TaskTypeVersion.statuses` and `status_flow_json` and regenerate API types

## Testing
- `pnpm gen:api:types`
- `pnpm test` *(fails: missing Playwright browsers, 11 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4082c5f3083239b300e3e9b507459