### PR TITLE
Hide status flow editor until tenant selection

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -120,31 +120,12 @@
         :tenant-options="tenantOptions"
         class="border-b mb-4"
       />
-      <Card
-        v-if="isCreate && !tenantId"
-        class="p-4 border-b flex items-center gap-2 text-sm"
-        role="alert"
-        aria-live="polite"
-      >
-        <Icon
-          icon="heroicons-outline:information-circle"
-          class="w-5 h-5 text-slate-400"
-          aria-hidden="true"
-        />
-        <p>
-          {{
-            locale === 'el'
-              ? 'Επιλέξτε μισθωτή για να συνεχίσετε τη ρύθμιση ρόλων και δικαιωμάτων.'
-              : 'Select a tenant to continue configuring roles and permissions.'
-          }}
-        </p>
-      </Card>
-      <StatusFlowEditor
-        v-model="statusFlow"
-        v-model:statuses="statuses"
-        class="p-4 border-b"
-      />
       <template v-if="tenantId || !isCreate">
+        <StatusFlowEditor
+          v-model="statusFlow"
+          v-model:statuses="statuses"
+          class="p-4 border-b"
+        />
         <template v-if="canManageSLA">
           <SLAPolicyEditor
             v-if="isEdit"
@@ -406,6 +387,25 @@
           </div>
         </div>
       </template>
+      <Card
+        v-else
+        class="p-4 border-b flex items-center gap-2 text-sm"
+        role="alert"
+        aria-live="polite"
+      >
+        <Icon
+          icon="heroicons-outline:information-circle"
+          class="w-5 h-5 text-slate-400"
+          aria-hidden="true"
+        />
+        <p>
+          {{
+            locale === 'el'
+              ? 'Επιλέξτε μισθωτή για να συνεχίσετε τη ρύθμιση ρόλων και δικαιωμάτων.'
+              : 'Select a tenant to continue configuring roles and permissions.'
+          }}
+        </p>
+      </Card>
     </form>
     <Drawer
       v-if="tenantId || !isCreate"


### PR DESCRIPTION
## Summary
- Hide status flow editor and related sections until a tenant is chosen during task type creation
- Show a prompt when no tenant is selected to guide users to pick a tenant before editing workflow

## Testing
- `pnpm lint`
- `pnpm test` *(fails: field-palette filters groups, permissions empty state, validation errors, tenant role switch)*

------
https://chatgpt.com/codex/tasks/task_e_68b40fc3c238832394596d81da2fe020