### PR TITLE
Fix status editor modal visibility

### DIFF
--- a/frontend/src/components/types/StatusesEditor.vue
+++ b/frontend/src/components/types/StatusesEditor.vue
@@ -57,10 +57,12 @@
       <span class="sr-only" aria-live="assertive">{{ liveMessage }}</span>
     </Card>
     <Modal
-      :open="showAddStatusModal"
+      v-if="editable"
+      ref="addStatusModal"
+      label=""
+      labelClass="hidden"
       :title="t('types.workflow.addStatus')"
-      :label="t('types.workflow.addStatus')"
-      @close="closeAddStatusModal"
+      @close="onModalClose"
     >
       <template #header>{{ t('types.workflow.addStatus') }}</template>
       <template #body>
@@ -127,7 +129,7 @@ watch(
 
 const allStatuses = ref<StatusOption[]>([]);
 const newStatus = ref('');
-const showAddStatusModal = ref(false);
+const addStatusModal = ref<InstanceType<typeof Modal> | null>(null);
 const grabbedIndex = ref<number | null>(null);
 const liveMessage = ref('');
 
@@ -144,11 +146,11 @@ watch(
     if (id) {
       await fetchStatuses(id);
       localStatuses.value = [];
-      emitStatuses();
+      if (props.modelValue.length) emitStatuses();
     } else {
       allStatuses.value = [];
       localStatuses.value = [];
-      emitStatuses();
+      if (props.modelValue.length) emitStatuses();
     }
   },
   { immediate: true },
@@ -167,10 +169,16 @@ function displayName(slug: string) {
 }
 
 function openAddStatusModal() {
-  showAddStatusModal.value = true;
+  if (!allStatuses.value.length && props.tenantId) {
+    fetchStatuses(props.tenantId);
+  }
+  addStatusModal.value?.openModal();
 }
 function closeAddStatusModal() {
-  showAddStatusModal.value = false;
+  addStatusModal.value?.closeModal();
+  newStatus.value = '';
+}
+function onModalClose() {
   newStatus.value = '';
 }
 function confirmAddStatus() {

--- a/frontend/src/components/types/TransitionsEditor.vue
+++ b/frontend/src/components/types/TransitionsEditor.vue
@@ -155,11 +155,11 @@ watch(
     if (id) {
       await fetchStatuses(id);
       edges.value = [];
-      emitEdges();
+      if (props.modelValue.length) emitEdges();
     } else {
       allStatuses.value = [];
       edges.value = [];
-      emitEdges();
+      if (props.modelValue.length) emitEdges();
     }
   },
   { immediate: true },


### PR DESCRIPTION
## Summary
- hide built-in modal trigger in `StatusesEditor` and open it via custom button
- load tenant statuses when opening the modal and reset selection on close
- avoid recursive status/transition resets when tenant changes

## Testing
- `npm run lint`
- `npm test` *(fails: No browser engines were found. Please run "npx playwright install" to install browsers)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b445145b148323b2f22599c938b227