### PR TITLE
fix task type automation loading and tenant watcher

### DIFF
--- a/frontend/src/components/types/AutomationsEditor.vue
+++ b/frontend/src/components/types/AutomationsEditor.vue
@@ -130,17 +130,19 @@ async function load() {
     api.get('/task-statuses'),
     api.get('/teams'),
   ]);
-  statusOptions.value = statusRes.data.map((s: any) => ({
+  const statusData = statusRes.data.data ?? statusRes.data;
+  statusOptions.value = statusData.map((s: any) => ({
     value: s.slug,
     label: s.name,
   }));
-  teamOptions.value = teamRes.data.map((t: any) => ({
+  const teamData = teamRes.data.data ?? teamRes.data;
+  teamOptions.value = teamData.map((t: any) => ({
     value: t.id,
     label: t.name,
   }));
   if (props.taskTypeId) {
     const res = await api.get(`/task-types/${props.taskTypeId}/automations`);
-    automations.value = res.data.data;
+    automations.value = res.data.data ?? res.data;
   }
 }
 

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -584,7 +584,10 @@ onMounted(async () => {
   watch(
     tenantId,
     async (id, oldId) => {
-      tenantStore.setTenant(id ? String(id) : '');
+      const normalized = id ? String(id) : '';
+      if (tenantStore.tenantId !== normalized) {
+        tenantStore.setTenant(normalized);
+      }
       if (oldId !== undefined && id !== oldId) {
         sections.value.forEach((s) =>
           s.fields.forEach((f) => {


### PR DESCRIPTION
## Summary
- avoid recursive tenant watcher when selecting task type tenant
- handle API response shape when loading statuses and teams for automations

## Testing
- `npm run lint`
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4482ece1c83238ac0becd6ec2dc87