### PR TITLE
Prevent recursive tenant watcher loop

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -585,6 +585,11 @@ onMounted(async () => {
     tenantId,
     async (id, oldId) => {
       const normalized = id ? String(id) : '';
+      const prev = oldId ? String(oldId) : '';
+
+      // Avoid triggering the watcher again when the value hasn't actually changed
+      if (normalized === prev) return;
+
       if (tenantStore.tenantId !== normalized) {
         tenantStore.setTenant(normalized);
       }


### PR DESCRIPTION
## Summary
- guard TypeForm tenant watcher against redundant updates to avoid recursive render loop

## Testing
- `npm test` *(fails: requires Playwright browsers)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44bb1640483239b42e80ae02c430c