### PR TITLE
Fix role loading for super admin task type creation

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -605,8 +605,16 @@ onMounted(async () => {
       }
       if (id) {
         try {
-          const { data } = await api.get('/roles', { params: { tenant_id: Number(id) } });
-          tenantRoles.value = data.data ?? data;
+          const params: Record<string, any> = auth.isSuperAdmin
+            ? { scope: 'all' }
+            : { tenant_id: Number(id) };
+          const { data } = await api.get('/roles', { params });
+          let roles = data.data ?? data;
+          if (auth.isSuperAdmin) {
+            const tid = Number(id);
+            roles = roles.filter((r: any) => r.tenant_id === null || r.tenant_id === tid);
+          }
+          tenantRoles.value = roles;
           tenantRoles.value.forEach((r: any) => {
             if (!permissions.value[r.slug]) {
               permissions.value[r.slug] = {


### PR DESCRIPTION
## Summary
- ensure task type creation loads global and tenant roles for super admins

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b466c335b48323a2ddb5042a4bdad1