### PR TITLE
Ensure transitions and SLA policies save correctly

### DIFF
--- a/frontend/src/components/types/SLAPolicyEditor.vue
+++ b/frontend/src/components/types/SLAPolicyEditor.vue
@@ -44,6 +44,7 @@
             type="button"
             btnClass="btn-outline-primary text-xs px-3 py-1"
             :aria-label="t('actions.save')"
+            :disabled="!props.taskTypeId"
             @click="save(p)"
           >
             {{ t('actions.save') }}
@@ -56,6 +57,7 @@
       class="mt-2"
       btnClass="btn-outline-primary text-xs px-3 py-1"
       :aria-label="t('actions.add')"
+      :disabled="!props.taskTypeId"
       @click="addPolicy"
     >
       {{ t('actions.add') }}

--- a/frontend/src/components/types/TransitionsEditor.vue
+++ b/frontend/src/components/types/TransitionsEditor.vue
@@ -226,6 +226,18 @@ function emitEdges() {
   emit('update:modelValue', edges.value);
 }
 
+function commitPending() {
+  if (
+    showTransitionForm.value &&
+    transitionForm.value.from &&
+    transitionForm.value.to
+  ) {
+    saveTransition();
+  }
+}
+
+defineExpose({ commitPending });
+
 function menuItemClass(active: boolean) {
   return (
     (active

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -127,6 +127,7 @@
           class="p-4 border-b"
         />
         <TransitionsEditor
+          ref="transitionsEditor"
           v-model="statusFlow"
           :statuses="statuses"
           :tenant-id="tenantId"
@@ -453,6 +454,7 @@ interface Permission {
 const name = ref('');
 const search = ref('');
 const tenantId = ref<number | ''>('');
+const transitionsEditor = ref<any>(null);
 const sections = ref<Section[]>([]);
 const selected = ref<Field | null>(null);
 const previewData = ref<Record<string, any>>({});
@@ -798,6 +800,7 @@ function selectField(field: Field) {
 }
 
 function onSubmit() {
+  transitionsEditor.value?.commitPending?.();
   const logicRules = sections.value.flatMap((s) =>
     s.fields.flatMap((f) =>
       (f.logic || []).map((r) => ({


### PR DESCRIPTION
## Summary
- ensure unsaved transitions are committed before submitting Task Types
- expose commitPending in transition editor to allow parent to save unfinished edits
- disable SLA policy Save/Add buttons when Task Type ID is missing to avoid no-ops

## Testing
- `npm run lint`
- `npm test` (fails: tests/e2e/addMenu.spec.ts:3:1, tests/e2e/field-palette.spec.ts:3:1, tests/e2e/sla-policies.spec.ts:3:1, tests/e2e/task-filters.spec.ts:3:1, tests/e2e/task-filters.spec.ts:17:1, tests/e2e/task-type-create-ui.spec.ts:4:3, tests/e2e/task-type-create-ui.spec.ts:18:3, tests/e2e/task-type-create-ui.spec.ts:31:3, tests/e2e/task-type-create-ui.spec.ts:42:3, tests/e2e/task-type-create-ui.spec.ts:53:3, tests/e2e/tenant-role-switch.spec.ts:4:1, tests/e2e/upload.spec.ts:3:1)

------
https://chatgpt.com/codex/tasks/task_e_68b4690dfb108323bf2a4f703e2e6f89