### PR TITLE
Allow field editing without tenant selection

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -134,10 +134,7 @@
           class="p-4 border-b"
         />
         <template v-if="canManageSLA">
-          <SLAPolicyEditor
-            :task-type-id="taskTypeId"
-            class="p-4 border-b"
-          />
+          <SLAPolicyEditor :task-type-id="taskTypeId" class="p-4 border-b" />
         </template>
         <template v-else>
           <Card class="p-4 border-b flex flex-col items-center text-center gap-2">
@@ -150,10 +147,7 @@
           </Card>
         </template>
         <template v-if="canManageAutomations">
-          <AutomationsEditor
-            :task-type-id="taskTypeId"
-            class="p-4 border-b"
-          />
+          <AutomationsEditor :task-type-id="taskTypeId" class="p-4 border-b" />
         </template>
         <template v-else>
           <Card class="p-4 border-b flex flex-col items-center text-center gap-2">
@@ -185,8 +179,28 @@
           :status-count="statuses.length"
           class="p-4 border-b"
         />
-        <div class="h-[calc(100vh-3rem)] p-4">
-          <div class="hidden lg:grid grid-cols-3 gap-4 h-full">
+      </template>
+      <Card
+        v-else
+        class="p-4 border-b flex items-center gap-2 text-sm"
+        role="alert"
+        aria-live="polite"
+      >
+        <Icon
+          icon="heroicons-outline:information-circle"
+          class="w-5 h-5 text-slate-400"
+          aria-hidden="true"
+        />
+        <p>
+          {{
+            locale === 'el'
+              ? 'Επιλέξτε μισθωτή για να συνεχίσετε τη ρύθμιση ρόλων και δικαιωμάτων.'
+              : 'Select a tenant to continue configuring roles and permissions.'
+          }}
+        </p>
+      </Card>
+      <div class="h-[calc(100vh-3rem)] p-4">
+        <div class="hidden lg:grid grid-cols-3 gap-4 h-full">
           <Card class="overflow-y-auto">
             <template #header>
               <div class="flex items-center justify-between">
@@ -266,113 +280,89 @@
               <InspectorTabs :key="`insp-${tenantId}`" :selected="selected" :role-options="tenantRoles" />
             </div>
           </Card>
-          </div>
-          <div class="lg:hidden">
-            <UiTabs>
-              <template #list>
-                <Tab as="button" class="px-3 py-2 text-sm">{{ t('builder.canvas') }}</Tab>
-                <Tab as="button" class="px-3 py-2 text-sm">{{ t('builder.preview') }}</Tab>
-                <Tab as="button" class="px-3 py-2 text-sm">{{ t('builder.inspector') }}</Tab>
-              </template>
-              <template #panel>
-                <TabPanel>
-                  <div class="mt-4">
-                    <Dropdown
-                      v-if="auth.isSuperAdmin || can('task_types.manage')"
-                      class="mb-4"
-                    >
-                      <template #default>
-                        <Button
-                          type="button"
-                          btnClass="btn-primary text-xs flex items-center gap-1"
-                          :aria-label="t('actions.add')"
-                        >
-                          {{ t('actions.add') }}
-                          <Icon icon="heroicons-outline:chevron-down" />
-                        </Button>
-                      </template>
-                      <template #menus>
-                        <MenuItem #default="{ active }">
-                          <button type="button" :class="menuItemClass(active)" @click="addSection">
-                            {{ t('actions.addSection') }}
-                          </button>
-                        </MenuItem>
-                        <MenuItem #default="{ active }">
-                          <button type="button" :class="menuItemClass(active)" @click="paletteOpen = true">
-                            {{ t('actions.addField') }}
-                          </button>
-                        </MenuItem>
-                      </template>
-                    </Dropdown>
-                    <p id="reorderHintMobile" class="sr-only">{{ t('fields.reorderHint') }}</p>
-                    <div aria-describedby="reorderHintMobile">
-                      <draggable v-model="sections" item-key="id" handle=".handle" class="space-y-4">
-                        <template #item="{ element, index }">
-                          <CanvasSection
-                            v-if="visibleSections.includes(element)"
-                            :section="element"
-                            @remove="removeSection(index)"
-                            @select="selectField"
-                            @add-field="paletteOpen = true"
-                            @add-section="addSection"
-                          />
-                        </template>
-                      </draggable>
-                    </div>
-                  </div>
-                </TabPanel>
-                <TabPanel>
-                  <div class="p-2">
-                    <div class="flex items-center gap-2 mb-2">
+        </div>
+        <div class="lg:hidden">
+          <UiTabs>
+            <template #list>
+              <Tab as="button" class="px-3 py-2 text-sm">{{ t('builder.canvas') }}</Tab>
+              <Tab as="button" class="px-3 py-2 text-sm">{{ t('builder.preview') }}</Tab>
+              <Tab as="button" class="px-3 py-2 text-sm">{{ t('builder.inspector') }}</Tab>
+            </template>
+            <template #panel>
+              <TabPanel>
+                <div class="mt-4">
+                  <Dropdown
+                    v-if="auth.isSuperAdmin || can('task_types.manage')"
+                    class="mb-4"
+                  >
+                    <template #default>
                       <Button
                         type="button"
-                        :aria-label="t('preview.runValidation')"
-                        btnClass="btn-primary text-xs px-2 py-1"
-                        @click="runValidation"
+                        btnClass="btn-primary text-xs flex items-center gap-1"
+                        :aria-label="t('actions.add')"
                       >
-                        {{ t('preview.runValidation') }}
+                        {{ t('actions.add') }}
+                        <Icon icon="heroicons-outline:chevron-down" />
                       </Button>
-                    </div>
-                    <div :class="[{ dark: previewTheme === 'dark' }, viewportClass]" class="border p-2 overflow-auto">
-                      <JsonSchemaForm ref="formRef" v-model="previewData" :schema="previewSchema" :task-id="0" />
-                    </div>
+                    </template>
+                    <template #menus>
+                      <MenuItem #default="{ active }">
+                        <button type="button" :class="menuItemClass(active)" @click="addSection">
+                          {{ t('actions.addSection') }}
+                        </button>
+                      </MenuItem>
+                      <MenuItem #default="{ active }">
+                        <button type="button" :class="menuItemClass(active)" @click="paletteOpen = true">
+                          {{ t('actions.addField') }}
+                        </button>
+                      </MenuItem>
+                    </template>
+                  </Dropdown>
+                  <p id="reorderHintMobile" class="sr-only">{{ t('fields.reorderHint') }}</p>
+                  <div aria-describedby="reorderHintMobile">
+                    <draggable v-model="sections" item-key="id" handle=".handle" class="space-y-4">
+                      <template #item="{ element, index }">
+                        <CanvasSection
+                          v-if="visibleSections.includes(element)"
+                          :section="element"
+                          @remove="removeSection(index)"
+                          @select="selectField"
+                          @add-field="paletteOpen = true"
+                          @add-section="addSection"
+                        />
+                      </template>
+                    </draggable>
                   </div>
-                </TabPanel>
-                <TabPanel>
-                  <div class="p-2">
-                    <InspectorTabs :key="`insp-${tenantId}`" :selected="selected" :role-options="tenantRoles" />
+                </div>
+              </TabPanel>
+              <TabPanel>
+                <div class="p-2">
+                  <div class="flex items-center gap-2 mb-2">
+                    <Button
+                      type="button"
+                      :aria-label="t('preview.runValidation')"
+                      btnClass="btn-primary text-xs px-2 py-1"
+                      @click="runValidation"
+                    >
+                      {{ t('preview.runValidation') }}
+                    </Button>
                   </div>
-                </TabPanel>
-              </template>
-            </UiTabs>
-          </div>
+                  <div :class="[{ dark: previewTheme === 'dark' }, viewportClass]" class="border p-2 overflow-auto">
+                    <JsonSchemaForm ref="formRef" v-model="previewData" :schema="previewSchema" :task-id="0" />
+                  </div>
+                </div>
+              </TabPanel>
+              <TabPanel>
+                <div class="p-2">
+                  <InspectorTabs :key="`insp-${tenantId}`" :selected="selected" :role-options="tenantRoles" />
+                </div>
+              </TabPanel>
+            </template>
+          </UiTabs>
         </div>
-      </template>
-      <Card
-        v-else
-        class="p-4 border-b flex items-center gap-2 text-sm"
-        role="alert"
-        aria-live="polite"
-      >
-        <Icon
-          icon="heroicons-outline:information-circle"
-          class="w-5 h-5 text-slate-400"
-          aria-hidden="true"
-        />
-        <p>
-          {{
-            locale === 'el'
-              ? 'Επιλέξτε μισθωτή για να συνεχίσετε τη ρύθμιση ρόλων και δικαιωμάτων.'
-              : 'Select a tenant to continue configuring roles and permissions.'
-          }}
-        </p>
-      </Card>
+      </div>
     </form>
-    <Drawer
-      v-if="tenantId || !isCreate"
-      :open="paletteOpen"
-      @close="paletteOpen = false"
-    >
+    <Drawer :open="paletteOpen" @close="paletteOpen = false">
       <FieldPalette :groups="fieldTypeGroups" @select="onSelectType" />
     </Drawer>
   </div>

--- a/frontend/tests/e2e/task-type-create-ui.spec.ts
+++ b/frontend/tests/e2e/task-type-create-ui.spec.ts
@@ -1,6 +1,36 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('task type create UI', () => {
+  test('can add field then access preview and inspector', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.setContent(`
+      <button id="add">Add Field</button>
+      <nav role="tablist">
+        <button role="tab">Canvas</button>
+        <button role="tab">Preview</button>
+        <button role="tab">Inspector</button>
+      </nav>
+      <div id="canvas"></div>
+      <div id="inspector">Select a field</div>
+      <script>
+        document.getElementById('add').addEventListener('click', () => {
+          const f = document.createElement('button');
+          f.textContent = 'Field 1';
+          f.id = 'f1';
+          f.addEventListener('click', () => {
+            document.getElementById('inspector').textContent = 'Field 1 selected';
+          });
+          document.getElementById('canvas').appendChild(f);
+        });
+      <\/script>
+    `);
+    await page.getByRole('button', { name: 'Add Field' }).click();
+    await expect(page.getByRole('button', { name: 'Field 1' })).toBeVisible();
+    await page.getByRole('tab', { name: 'Preview' }).click();
+    await page.getByRole('tab', { name: 'Inspector' }).click();
+    await page.getByRole('button', { name: 'Field 1' }).click();
+    await expect(page.locator('#inspector')).toHaveText('Field 1 selected');
+  });
   test('tabs render on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.setContent(`


### PR DESCRIPTION
## Summary
- Allow editing and previewing fields on create type without selecting a tenant
- Ensure field palette drawer is always available
- Test flow for adding fields and accessing preview/inspector tabs

## Testing
- `npm run lint`
- `npm test` *(fails: 13 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a98148483238e8817309675798a