### PR TITLE
Fix task type builder add/remove controls

### DIFF
--- a/frontend/src/components/types/CanvasSection.vue
+++ b/frontend/src/components/types/CanvasSection.vue
@@ -56,7 +56,15 @@
           >
             <Icon icon="heroicons-outline:bars-3" />
           </Button>
-          <span>{{ resolveI18n(element.label) }}</span>
+          <span class="flex-1">{{ resolveI18n(element.label) }}</span>
+          <Button
+            type="button"
+            btnClass="btn-outline-danger text-xs px-1 py-1"
+            :aria-label="t('actions.delete')"
+            @click.stop="$emit('remove-field', element)"
+          >
+            ✕
+          </Button>
         </Card>
       </template>
     </draggable>
@@ -106,6 +114,7 @@ defineEmits<{
   (e: 'select', field: any): void;
   (e: 'add-field'): void;
   (e: 'add-section'): void;
+  (e: 'remove-field', field: any): void;
 }>();
 const { t, locale } = useI18n();
 


### PR DESCRIPTION
## Summary
- allow adding fields to specific sections and insert sections after current
- keep field palette closed and prevent auto reopen when selecting
- add ability to remove fields from canvas sections

## Testing
- `npm run lint`
- `npm test` *(fails: 13 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5332509188323bd3b35c66aa22365