### PR TITLE
fix: reset body styles on drawer unmount

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -25,7 +25,7 @@
 
 <script setup lang="ts">
 import { TransitionRoot, TransitionChild, Dialog, DialogPanel } from '@headlessui/vue';
-import { ref, watch } from 'vue';
+import { ref, watch, onUnmounted } from 'vue';
 
 interface Props {
   open: boolean;
@@ -57,4 +57,12 @@ watch(
     }
   },
 );
+
+onUnmounted(() => {
+  const body = document.body;
+  body.style.position = '';
+  body.style.top = '';
+  body.style.width = '';
+  body.style.paddingRight = '';
+});
 </script>


### PR DESCRIPTION
## Summary
- ensure body scroll styles are cleared when Drawer unmounts

## Testing
- `npm test` *(fails: 13 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c55a96888323979ab9b4a35790be