### PR TITLE
fix: prevent field palette re-open on selection

### DIFF
--- a/frontend/src/components/types/FieldPalette.vue
+++ b/frontend/src/components/types/FieldPalette.vue
@@ -16,7 +16,7 @@
             type="button"
             btnClass="w-full text-left px-2 py-1 rounded hover:bg-gray-100"
             :aria-label="`${t('actions.add')} ${item.label}`"
-            @click="$emit('select', item)"
+            @click.stop.prevent="$emit('select', item)"
           >
             {{ item.label }}
           </Button>

--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -25,7 +25,7 @@
 
 <script setup lang="ts">
 import { TransitionRoot, TransitionChild, Dialog, DialogPanel } from '@headlessui/vue';
-import { ref, watch } from 'vue';
+import { ref, watch, onUnmounted } from 'vue';
 
 interface Props {
   open: boolean;
@@ -57,4 +57,12 @@ watch(
     }
   },
 );
+
+onUnmounted(() => {
+  const body = document.body;
+  body.style.position = '';
+  body.style.top = '';
+  body.style.width = '';
+  body.style.paddingRight = '';
+});
 </script>

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -816,7 +816,11 @@ function onAddField(type: any) {
 
 function onSelectType(type: any) {
   onAddField(type);
-  paletteOpen.value = false;
+  // Delay closing to prevent the click from propagating to the underlying
+  // "Add Field" button which would immediately reopen the palette.
+  setTimeout(() => {
+    paletteOpen.value = false;
+  }, 0);
 }
 
 function selectField(field: Field) {


### PR DESCRIPTION
## Summary
- ensure body scroll styles are cleared when Drawer unmounts
- delay field palette close and stop click propagation so it doesn't immediately reopen

## Testing
- `npm test` *(fails: 13 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c55a96888323979ab9b4a35790be