### PR TITLE
fix: prevent field palette re-open on selection

### DIFF
--- a/frontend/src/components/types/FieldPalette.vue
+++ b/frontend/src/components/types/FieldPalette.vue
@@ -16,7 +16,7 @@
             type="button"
             btnClass="w-full text-left px-2 py-1 rounded hover:bg-gray-100"
             :aria-label="`${t('actions.add')} ${item.label}`"
-            @click="$emit('select', item)"
+            @click.stop.prevent="$emit('select', item)"
           >
             {{ item.label }}
           </Button>

--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -25,7 +25,7 @@
 
 <script setup lang="ts">
 import { TransitionRoot, TransitionChild, Dialog, DialogPanel } from '@headlessui/vue';
-import { ref, watch } from 'vue';
+import { watch, onUnmounted } from 'vue';
 
 interface Props {
   open: boolean;
@@ -34,27 +34,19 @@ interface Props {
 const props = defineProps<Props>();
 defineEmits(['close']);
 
-const scrollY = ref(0);
-
 watch(
   () => props.open,
   (isOpen) => {
+    const body = document.body;
     if (isOpen) {
-      scrollY.value = window.scrollY;
-      const body = document.body;
-      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
-      body.style.top = `-${scrollY.value}px`;
-      body.style.position = 'fixed';
-      body.style.width = '100%';
-      body.style.paddingRight = `${scrollbarWidth}px`;
+      body.classList.add('overflow-hidden');
     } else {
-      const body = document.body;
-      body.style.position = '';
-      body.style.top = '';
-      body.style.width = '';
-      body.style.paddingRight = '';
-      window.scrollTo(0, scrollY.value);
+      body.classList.remove('overflow-hidden');
     }
   },
 );
+
+onUnmounted(() => {
+  document.body.classList.remove('overflow-hidden');
+});
 </script>


### PR DESCRIPTION
## Summary
- close field palette immediately after field selection
- simplify drawer scroll lock so body styles are cleaned up on unmount

## Testing
- `npm test` *(fails: 13 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c55a96888323979ab9b4a35790be