### PR TITLE
fix: respect existing body scroll locks in Drawer

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -34,20 +34,46 @@ interface Props {
 const props = defineProps<Props>();
 defineEmits(['close']);
 
+const SCROLL_LOCK_ATTR = 'data-scroll-lock-count';
+
+const lockBodyScroll = () => {
+  const body = document.body;
+  const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
+  if (count === 0) {
+    body.classList.add('overflow-hidden');
+  }
+  body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
+};
+
+const unlockBodyScroll = () => {
+  const body = document.body;
+  const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
+  if (count <= 1) {
+    body.classList.remove('overflow-hidden');
+    body.removeAttribute(SCROLL_LOCK_ATTR);
+  } else {
+    body.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
+  }
+};
+
+let locked = false;
+
 watch(
   () => props.open,
   (isOpen) => {
-    const body = document.body;
     if (isOpen) {
-      body.classList.add('overflow-hidden');
-    } else {
-      body.classList.remove('overflow-hidden');
+      lockBodyScroll();
+      locked = true;
+    } else if (locked) {
+      unlockBodyScroll();
+      locked = false;
     }
   },
 );
 
 onUnmounted(() => {
-  document.body.classList.remove('overflow-hidden');
-});
+  if (locked) {
+    unlockBodyScroll();
+  }
 });
 </script>


### PR DESCRIPTION
## Summary
- track drawer-induced scroll locks and only remove when none remain

## Testing
- `npm test` *(fails: 13 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cdd965708323a309bd18aad33493