### PR TITLE
fix: prevent headless ui tab error

### DIFF
--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -9,17 +9,17 @@
             #default="{ selected: isSelected }"
             as="template"
           >
-            <Button
+            <button
               type="button"
               :aria-selected="isSelected"
-              :btnClass="
+              :class="
                 (isSelected
                   ? 'bg-primary-500 text-white'
                   : 'bg-gray-100') + ' px-2 py-1 text-sm rounded'
               "
             >
               {{ tab }}
-            </Button>
+            </button>
           </Tab>
         </template>
         <template #panel>
@@ -122,7 +122,6 @@ import Textinput from '@/components/ui/Textinput/index.vue';
 import Switch from '@/components/ui/Switch/index.vue';
 import FromGroup from '@/components/ui/FromGroup/index.vue';
 import Checkbox from '@/components/ui/Checkbox/index.vue';
-import Button from '@/components/ui/Button/index.vue';
 import { useAuthStore } from '@/stores/auth';
 
 interface RoleOption {


### PR DESCRIPTION
## Summary
- replace custom button with native element in inspector tabs to satisfy headlessui expectations

## Testing
- `npm test` *(fails: tests/e2e/... various fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cefec8488323845a4d00d5b980ae