### PR TITLE
fix: align add buttons and dropdown

### DIFF
--- a/frontend/src/components/types/CanvasSection.vue
+++ b/frontend/src/components/types/CanvasSection.vue
@@ -69,15 +69,17 @@
       </template>
     </draggable>
     <div class="p-2">
-      <Dropdown>
+      <Dropdown align="left">
         <template #default>
           <Button
             type="button"
-            btnClass="btn-primary text-xs px-2 py-1 flex items-center gap-1"
+            btnClass="btn-primary text-xs items-center px-2 py-1"
             :aria-label="t('actions.add')"
           >
-            {{ t('actions.add') }}
-            <Icon icon="heroicons-outline:chevron-down" />
+            <span class="inline-flex items-center gap-1">
+              {{ t('actions.add') }}
+              <Icon icon="heroicons-outline:chevron-down" />
+            </span>
           </Button>
         </template>
         <template #menus>

--- a/frontend/src/components/ui/Dropdown/index.vue
+++ b/frontend/src/components/ui/Dropdown/index.vue
@@ -15,8 +15,8 @@
       leave-to-class="transform scale-95 opacity-0"
     >
       <MenuItems
-        :class="classMenuItems"
-        class="absolute ltr:right-0 rtl:left-0 origin-top-right rounded bg-white dark:bg-slate-800 dark:border dark:border-slate-700 shadow-dropdown z-[9999]"
+        :class="[classMenuItems, align === 'left' ? 'ltr:left-0 rtl:right-0 origin-top-left' : 'ltr:right-0 rtl:left-0 origin-top-right']"
+        class="absolute rounded bg-white dark:bg-slate-800 dark:border dark:border-slate-700 shadow-dropdown z-[9999]"
       >
         <div v-if="!$slots.menus">
           <MenuItem v-for="(item, i) in items" #default="{ active }" :key="i">
@@ -98,6 +98,10 @@ export default {
     parentClass: {
       type: String,
       default: "inline-block",
+    },
+    align: {
+      type: String,
+      default: "right",
     },
     items: {
       type: Array,

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -209,11 +209,13 @@
                   <template #default>
                     <Button
                       type="button"
-                      btnClass="btn-primary text-xs flex items-center gap-1"
+                      btnClass="btn-primary text-xs items-center px-2 py-1"
                       :aria-label="t('actions.add')"
                     >
-                      {{ t('actions.add') }}
-                      <Icon icon="heroicons-outline:chevron-down" />
+                      <span class="inline-flex items-center gap-1">
+                        {{ t('actions.add') }}
+                        <Icon icon="heroicons-outline:chevron-down" />
+                      </span>
                     </Button>
                   </template>
                   <template #menus>
@@ -299,11 +301,13 @@
                     <template #default>
                       <Button
                         type="button"
-                        btnClass="btn-primary text-xs flex items-center gap-1"
+                        btnClass="btn-primary text-xs items-center px-2 py-1"
                         :aria-label="t('actions.add')"
                       >
-                        {{ t('actions.add') }}
-                        <Icon icon="heroicons-outline:chevron-down" />
+                        <span class="inline-flex items-center gap-1">
+                          {{ t('actions.add') }}
+                          <Icon icon="heroicons-outline:chevron-down" />
+                        </span>
                       </Button>
                     </template>
                     <template #menus>


### PR DESCRIPTION
## Summary
- keep chevron icons inline with "Add" text in form builder buttons
- allow Dropdown alignment customization and open actions menu to the right

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5d47719688323a42c6741aefc97f4