### PR TITLE
Add missing i18n keys for workflow statuses and roles

### DIFF
--- a/frontend/src/components/types/PermissionsMatrix.vue
+++ b/frontend/src/components/types/PermissionsMatrix.vue
@@ -10,7 +10,7 @@
         <thead class="sticky top-0 z-10 bg-white">
           <tr>
             <th scope="col" class="px-4 py-2 text-left">
-              {{ t('roles') }}
+              {{ t('roles.label') }}
             </th>
             <th
               v-for="ability in abilityList"

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -207,6 +207,7 @@
   "types": {
     "workflow": {
       "title": "Ροή εργασίας",
+      "statuses": "Καταστάσεις",
       "addStatus": "Προσθήκη κατάστασης",
       "transitions": "Μεταβάσεις",
       "addTransition": "Προσθήκη μετάβασης",
@@ -298,8 +299,12 @@
     "placeholder": "Υπόδειξη",
     "help": "Βοήθεια",
     "reorderHint": "Χρησιμοποιήστε Alt+βέλη για αναδιάταξη"
-  }
-  ,
+  },
+  "roles": {
+    "label": "Ρόλοι",
+    "view": "Προβολή ρόλων",
+    "edit": "Επεξεργασία ρόλων"
+  },
   "templates": {
     "title": "Πρότυπα",
     "export": "Εξαγωγή JSON",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -207,6 +207,7 @@
   "types": {
     "workflow": {
       "title": "Workflow",
+      "statuses": "Statuses",
       "addStatus": "Add status",
       "transitions": "Transitions",
       "addTransition": "Add transition",


### PR DESCRIPTION
## Summary
- add missing `statuses` translation for workflow editor
- add Greek translations for roles and update header binding

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 13 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d7b6de4c8323b062935f4a1d2aa3