### PR TITLE
Scope automation status options to tenant

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -147,7 +147,11 @@
           </Card>
         </template>
         <template v-if="canManageAutomations">
-          <AutomationsEditor :task-type-id="taskTypeId" class="p-4 border-b" />
+          <AutomationsEditor
+            :task-type-id="taskTypeId"
+            :tenant-id="tenantId"
+            class="p-4 border-b"
+          />
         </template>
         <template v-else>
           <Card class="p-4 border-b flex flex-col items-center text-center gap-2">


### PR DESCRIPTION
## Summary
- filter AutomationsEditor status choices to current tenant
- pass tenant id from task type form

## Testing
- `npm test` *(fails: 13 failing tests)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5d93a9b3c832392ab6fdb6083561b