### PR TITLE
Add missing form label translations

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -311,5 +311,8 @@
     "import": "Εισαγωγή JSON",
     "selectType": "Επιλέξτε τύπο"
   },
+  "Section label": "Ετικέτα ενότητας",
+  "Label": "Ετικέτα",
+  "Required": "Υποχρεωτικό",
   "Select a field": "Επιλέξτε πεδίο"
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -311,5 +311,8 @@
     "import": "Import JSON",
     "selectType": "Select type"
   },
+  "Section label": "Section label",
+  "Label": "Label",
+  "Required": "Required",
   "Select a field": "Select a field"
 }


### PR DESCRIPTION
## Summary
- add English and Greek translations for Section label, Label, and Required

## Testing
- `npm test` *(fails: 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dc64b0f48323904560a66f9b4750