### PR TITLE
Fix automation editor status options and save

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -151,6 +151,7 @@
             ref="automationsEditor"
             :task-type-id="taskTypeId"
             :tenant-id="tenantId"
+            :statuses="statuses"
             class="p-4 border-b"
           />
         </template>


### PR DESCRIPTION
## Summary
- filter automation status options by selected statuses
- mark automations as saved after API calls
- pass task type statuses to automation editor

## Testing
- `npm run lint`
- `npm test` *(fails: add button has accessible label, field palette filters groups by search query, sla policy editor has accessible fields, task filters save and load filter view, bulk status change respects allowed actions, task type create UI tests, tenant role switch happy path, file input is accessible)*


------
https://chatgpt.com/codex/tasks/task_e_68b5dd453fbc8323873bc5bdd8dfb03b