### PR TITLE
fix: default time field value

### DIFF
--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -226,6 +226,11 @@ const emit = defineEmits<{ (e: 'update', payload: { key: string; value: any }): 
 
 const { t, locale } = useI18n();
 const local = reactive<any>(props.form);
+for (const field of props.section.fields) {
+  if (field.type === 'time' && local[field.key] === undefined) {
+    local[field.key] = null;
+  }
+}
 const files = reactive<Record<string, { preview: string | null; name: string } | null>>({});
 
 function tr(val: any) {


### PR DESCRIPTION
## Summary
- avoid undefined modelValue for time fields by defaulting to null

## Testing
- `npm run lint`
- `npm test` *(fails: 12 failed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ded0986c83238c3db9ea0ad68441