### PR TITLE
feat(task-types): auto-select tenant

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -595,6 +595,8 @@ onMounted(async () => {
       selectedVersionId.value = list[0].id;
       loadVersion(list[0]);
     }
+  } else if (tenantStore.tenantId) {
+    tenantId.value = Number(tenantStore.tenantId);
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure task type builder panes display when a tenant is pre-selected

## Testing
- `npm run lint`
- `npm test` *(fails: 14 failed tests, see logs for details)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ec918e28832380733d5133f0c422