### PR TITLE
feat: support tabs and columns in task type builder

### DIFF
--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -2,7 +2,201 @@
 <template>
   <div class="mb-6">
     <h3 class="font-medium mb-2">{{ tr(section.label) }}</h3>
-    <div class="grid grid-cols-2 gap-4">
+    <UiTabs v-if="section.tabs?.length">
+      <template #list>
+        <Tab v-for="tab in section.tabs" :key="tab.key" class="px-3 py-2 text-sm">
+          {{ tr(tab.label) }}
+        </Tab>
+      </template>
+      <template #panel>
+        <TabPanel v-for="tab in section.tabs" :key="tab.key">
+          <div :class="['grid', gridColsClass, 'gap-4']">
+            <template v-for="field in tab.fields" :key="field.key">
+              <div v-if="isVisible(field.key) && field.type === 'divider'" class="col-span-2">
+                <hr />
+              </div>
+              <div
+                v-else-if="isVisible(field.key) && field.type === 'headline'"
+                class="col-span-2 font-bold"
+              >
+                {{ tr(field.label) }}
+              </div>
+              <div v-else-if="isVisible(field.key)" :class="colClass(field)">
+                <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+                <label :for="field.key" class="block font-medium mb-1">
+                  {{ tr(field.label) }}<span v-if="isRequired(field)" class="text-red-600">*</span>
+                </label>
+                <input
+                  v-if="isText(field.type)"
+                  :id="field.key"
+                  v-model="local[field.key]"
+                  :type="inputType(field.type)"
+                  class="border rounded p-2 w-full"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  :placeholder="tr(field.placeholder)"
+                  @input="emitUpdate(field)"
+                />
+                <DateInput
+                  v-else-if="field.type === 'date'"
+                  v-model="local[field.key]"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <TimeInput
+                  v-else-if="field.type === 'time'"
+                  v-model="local[field.key]"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <DateTimeInput
+                  v-else-if="field.type === 'datetime'"
+                  v-model="local[field.key]"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <DurationInput
+                  v-else-if="field.type === 'duration'"
+                  v-model="local[field.key]"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <textarea
+                  v-else-if="field.type === 'textarea'"
+                  :id="field.key"
+                  v-model="local[field.key]"
+                  class="border rounded p-2 w-full"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  :placeholder="tr(field.placeholder)"
+                  @input="emitUpdate(field)"
+                />
+                <select
+                  v-else-if="field.type === 'select'"
+                  :id="field.key"
+                  v-model="local[field.key]"
+                  class="border rounded p-2 w-full"
+                  :disabled="readonly"
+                  :aria-label="tr(field.label)"
+                  @change="emitUpdate(field)"
+                >
+                  <option value="" disabled>{{ t('common.select') }}</option>
+                  <option v-for="opt in field.enum" :key="opt" :value="opt">{{ opt }}</option>
+                </select>
+                <select
+                  v-else-if="field.type === 'multiselect'"
+                  :id="field.key"
+                  v-model="local[field.key]"
+                  multiple
+                  class="border rounded p-2 w-full"
+                  :disabled="readonly"
+                  :aria-label="tr(field.label)"
+                  @change="emitUpdate(field)"
+                >
+                  <option v-for="opt in field.enum" :key="opt" :value="opt">{{ opt }}</option>
+                </select>
+                <RadioGroup
+                  v-else-if="field.type === 'radio'"
+                  v-model="local[field.key]"
+                  :name="field.key"
+                  :options="field.enum"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <CheckboxGroup
+                  v-else-if="field.type === 'checkbox'"
+                  v-model="local[field.key]"
+                  :name="field.key"
+                  :options="field.enum"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <ChipsInput
+                  v-else-if="field.type === 'chips'"
+                  v-model="local[field.key]"
+                  :options="field.enum"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <input
+                  v-else-if="field.type === 'boolean'"
+                  :id="field.key"
+                  v-model="local[field.key]"
+                  type="checkbox"
+                  :disabled="readonly"
+                  :aria-label="tr(field.label)"
+                  @change="emitUpdate(field)"
+                />
+                <AssigneePicker
+                  v-else-if="field.type === 'assignee'"
+                  v-model="local[field.key]"
+                  @change="emitUpdate(field)"
+                />
+                <ReviewerPicker
+                  v-else-if="field.type === 'reviewer'"
+                  v-model="local[field.key]"
+                  @change="emitUpdate(field)"
+                />
+                <RichText
+                  v-else-if="field.type === 'richtext'"
+                  v-model="local[field.key]"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <MarkdownInput
+                  v-else-if="field.type === 'markdown'"
+                  v-model="local[field.key]"
+                  :readonly="readonly"
+                  :aria-label="tr(field.label)"
+                  @update:modelValue="() => emitUpdate(field)"
+                />
+                <div v-else-if="field.type === 'file'">
+                  <div v-if="files[field.key]" class="mb-2 relative inline-block">
+                    <img
+                      v-if="files[field.key].preview"
+                      :src="files[field.key].preview"
+                      class="w-32 h-32 object-cover"
+                      :alt="tr(field.label)"
+                    />
+                    <span v-else>{{ files[field.key].name }}</span>
+                    <button
+                      type="button"
+                      class="absolute top-0 right-0 bg-red-600 text-white px-1"
+                      :aria-label="t('actions.delete')"
+                      @click="removeFile(field)"
+                      @keyup.enter.prevent="removeFile(field)"
+                      @keyup.space.prevent="removeFile(field)"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <input
+                    v-if="!files[field.key]"
+                    :id="field.key"
+                    type="file"
+                    :aria-label="tr(field.label)"
+                    @change="onFile(field, $event)"
+                  />
+                </div>
+                <p v-if="field.help" class="text-xs text-gray-500">{{ tr(field.help) }}</p>
+                <div v-if="errors[field.key]" class="text-red-600 text-sm mt-1" role="alert">
+                  {{ errors[field.key] }}
+                </div>
+              </div>
+            </template>
+          </div>
+        </TabPanel>
+      </template>
+    </UiTabs>
+    <div v-else :class="['grid', gridColsClass, 'gap-4']">
       <template v-for="field in section.fields" :key="field.key">
         <div v-if="isVisible(field.key) && field.type === 'divider'" class="col-span-2">
           <hr />
@@ -176,33 +370,35 @@
             />
           </div>
           <p v-if="field.help" class="text-xs text-gray-500">{{ tr(field.help) }}</p>
-          <div v-if="errors[field.key]" class="text-red-600 text-sm mt-1" role="alert">{{ errors[field.key] }}</div>
+          <div v-if="errors[field.key]" class="text-red-600 text-sm mt-1" role="alert">
+            {{ errors[field.key] }}
+          </div>
         </div>
       </template>
-      <template v-for="photo in section.photos" :key="photo.key">
-        <PhotoField
-          v-if="isVisible(photo.key) && photo.type === 'photo_single'"
-          :photo="photo"
-          :section-key="section.key"
-          :task-id="taskId"
-          :model-value="local[photo.key]"
-          @update:modelValue="(v) => updatePhoto(photo.key, v)"
-        />
-        <PhotoRepeater
-          v-else-if="isVisible(photo.key)"
-          :photo="photo"
-          :section-key="section.key"
-          :task-id="taskId"
-          :model-value="local[photo.key]"
-          @update:modelValue="(v) => updatePhoto(photo.key, v)"
-        />
-      </template>
     </div>
+    <template v-for="photo in section.photos" :key="photo.key">
+      <PhotoField
+        v-if="isVisible(photo.key) && photo.type === 'photo_single'"
+        :photo="photo"
+        :section-key="section.key"
+        :task-id="taskId"
+        :model-value="local[photo.key]"
+        @update:modelValue="(v) => updatePhoto(photo.key, v)"
+      />
+      <PhotoRepeater
+        v-else-if="isVisible(photo.key)"
+        :photo="photo"
+        :section-key="section.key"
+        :task-id="taskId"
+        :model-value="local[photo.key]"
+        @update:modelValue="(v) => updatePhoto(photo.key, v)"
+      />
+    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { reactive, computed } from 'vue';
 import AssigneePicker from '@/components/tasks/AssigneePicker.vue';
 import ReviewerPicker from '@/components/fields/ReviewerPicker.vue';
 import RichText from '@/components/fields/RichText.vue';
@@ -220,18 +416,22 @@ import { uploadFile } from '@/services/uploader';
 import { useI18n } from 'vue-i18n';
 import { validate as runValidators } from '@/utils/validators';
 import { resolveI18n } from '@/utils/i18n';
+import UiTabs from '@/components/ui/Tabs/index.vue';
+import { Tab, TabPanel } from '@headlessui/vue';
 
 const props = defineProps<{ section: any; form: any; errors: Record<string, string>; taskId: number; readonly?: boolean; visible: Set<string>; required: Set<string>; showTargets: Set<string> }>();
 const emit = defineEmits<{ (e: 'update', payload: { key: string; value: any }): void; (e: 'error', payload: { key: string; msg: string }): void }>();
 
 const { t, locale } = useI18n();
 const local = reactive<any>(props.form);
-for (const field of props.section.fields) {
+const allFields = props.section.tabs?.flatMap((t: any) => t.fields) || props.section.fields;
+for (const field of allFields) {
   if (field.type === 'time' && local[field.key] === undefined) {
     local[field.key] = null;
   }
 }
 const files = reactive<Record<string, { preview: string | null; name: string } | null>>({});
+const gridColsClass = computed(() => `grid-cols-${props.section['x-cols'] || 2}`);
 
 function tr(val: any) {
   return resolveI18n(val, locale.value);

--- a/frontend/src/components/types/CanvasSection.vue
+++ b/frontend/src/components/types/CanvasSection.vue
@@ -18,6 +18,19 @@
         class="flex-1 mx-2"
         classInput="text-sm"
       />
+      <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
+      <Select
+        v-model="section.cols"
+        :options="[
+          { value: 1, label: '1' },
+          { value: 2, label: '2' },
+          { value: 3, label: '3' },
+        ]"
+        :label="'Columns'"
+        class="w-20 mr-2"
+        classLabel="sr-only"
+        classInput="text-xs"
+      />
       <Button
         type="button"
         btnClass="btn-outline-danger text-xs px-2 py-1"
@@ -30,44 +43,119 @@
     </header>
     <span id="remove-section-desc" class="sr-only">{{ t('actions.delete') }}</span>
     <p id="fieldReorderHint" class="sr-only">{{ t('fields.reorderHint') }}</p>
-    <draggable
-      v-model="section.fields"
-      item-key="id"
-      handle=".field-handle"
-      class="p-2 space-y-2"
-      aria-describedby="fieldReorderHint"
-    >
-      <template #item="{ element }">
-        <Card
-          bodyClass="p-2 flex items-center gap-2 cursor-pointer"
-          tabindex="0"
-          role="button"
-          @click="$emit('select', element)"
-          @keydown.enter.prevent="$emit('select', element)"
-          @keydown.space.prevent="$emit('select', element)"
-        >
-          <Button
-            type="button"
-            btnClass="btn-light p-1 field-handle cursor-move"
-            aria-label="Drag field"
-            aria-describedby="fieldReorderHint"
-            @keydown.enter.prevent="noop"
-            @keydown.space.prevent="noop"
+    <div v-if="section.tabs && section.tabs.length" class="p-2">
+      <UiTabs>
+        <template #list>
+          <Tab
+            v-for="(tab, ti) in section.tabs"
+            :key="tab.id"
+            class="px-3 py-1 text-sm"
           >
-            <Icon icon="heroicons-outline:bars-3" />
-          </Button>
-          <span class="flex-1">{{ resolveI18n(element.label) }}</span>
-          <Button
-            type="button"
-            btnClass="btn-outline-danger text-xs px-1 py-1"
-            :aria-label="t('actions.delete')"
-            @click.stop="$emit('remove-field', element)"
+            <span>{{ resolveI18n(tab.label) }}</span>
+            <button
+              type="button"
+              class="ml-2 text-xs text-red-600"
+              :aria-label="t('actions.delete')"
+              @click.stop="removeTab(ti)"
+            >
+              ✕
+            </button>
+          </Tab>
+        </template>
+        <template #panel>
+          <TabPanel v-for="(tab, ti) in section.tabs" :key="tab.id">
+            <draggable
+              v-model="tab.fields"
+              item-key="id"
+              handle=".field-handle"
+              class="space-y-2"
+              aria-describedby="fieldReorderHint"
+            >
+              <template #item="{ element }">
+                <Card
+                  bodyClass="p-2 flex items-center gap-2 cursor-pointer"
+                  tabindex="0"
+                  role="button"
+                  @click="$emit('select', element)"
+                  @keydown.enter.prevent="$emit('select', element)"
+                  @keydown.space.prevent="$emit('select', element)"
+                >
+                  <Button
+                    type="button"
+                    btnClass="btn-light p-1 field-handle cursor-move"
+                    aria-label="Drag field"
+                    aria-describedby="fieldReorderHint"
+                    @keydown.enter.prevent="noop"
+                    @keydown.space.prevent="noop"
+                  >
+                    <Icon icon="heroicons-outline:bars-3" />
+                  </Button>
+                  <span class="flex-1">{{ resolveI18n(element.label) }}</span>
+                  <Button
+                    type="button"
+                    btnClass="btn-outline-danger text-xs px-1 py-1"
+                    :aria-label="t('actions.delete')"
+                    @click.stop="$emit('remove-field', { field: element, tabIndex: ti })"
+                  >
+                    ✕
+                  </Button>
+                </Card>
+              </template>
+            </draggable>
+            <div class="mt-2">
+              <Button
+                type="button"
+                btnClass="btn-primary text-xs px-2 py-1"
+                :aria-label="t('actions.addField')"
+                @click="$emit('add-field', ti)"
+              >
+                {{ t('actions.addField') }}
+              </Button>
+            </div>
+          </TabPanel>
+        </template>
+      </UiTabs>
+    </div>
+    <div v-else>
+      <draggable
+        v-model="section.fields"
+        item-key="id"
+        handle=".field-handle"
+        class="p-2 space-y-2"
+        aria-describedby="fieldReorderHint"
+      >
+        <template #item="{ element }">
+          <Card
+            bodyClass="p-2 flex items-center gap-2 cursor-pointer"
+            tabindex="0"
+            role="button"
+            @click="$emit('select', element)"
+            @keydown.enter.prevent="$emit('select', element)"
+            @keydown.space.prevent="$emit('select', element)"
           >
-            ✕
-          </Button>
-        </Card>
-      </template>
-    </draggable>
+            <Button
+              type="button"
+              btnClass="btn-light p-1 field-handle cursor-move"
+              aria-label="Drag field"
+              aria-describedby="fieldReorderHint"
+              @keydown.enter.prevent="noop"
+              @keydown.space.prevent="noop"
+            >
+              <Icon icon="heroicons-outline:bars-3" />
+            </Button>
+            <span class="flex-1">{{ resolveI18n(element.label) }}</span>
+            <Button
+              type="button"
+              btnClass="btn-outline-danger text-xs px-1 py-1"
+              :aria-label="t('actions.delete')"
+              @click.stop="$emit('remove-field', { field: element })"
+            >
+              ✕
+            </Button>
+          </Card>
+        </template>
+      </draggable>
+    </div>
     <div class="p-2">
       <Dropdown align="left">
         <template #default>
@@ -83,7 +171,7 @@
           </Button>
         </template>
         <template #menus>
-          <MenuItem #default="{ active }">
+          <MenuItem v-if="!section.tabs.length" #default="{ active }">
             <button type="button" :class="menuItemClass(active)" @click="$emit('add-field')">
               {{ t('actions.addField') }}
             </button>
@@ -91,6 +179,11 @@
           <MenuItem #default="{ active }">
             <button type="button" :class="menuItemClass(active)" @click="$emit('add-section')">
               {{ t('actions.addSection') }}
+            </button>
+          </MenuItem>
+          <MenuItem #default="{ active }">
+            <button type="button" :class="menuItemClass(active)" @click="addTab">
+              Add Tab
             </button>
           </MenuItem>
         </template>
@@ -108,19 +201,36 @@ import Textinput from '@/components/ui/Textinput/index.vue';
 import Button from '@/components/ui/Button/index.vue';
 import Card from '@/components/ui/Card/index.vue';
 import Dropdown from '@/components/ui/Dropdown/index.vue';
-import { MenuItem } from '@headlessui/vue';
+import Select from '@/components/ui/Select/index.vue';
+import UiTabs from '@/components/ui/Tabs/index.vue';
+import { MenuItem, Tab, TabPanel } from '@headlessui/vue';
 
-defineProps<{ section: any }>();
+const props = defineProps<{ section: any }>();
+const section = props.section;
 defineEmits<{
   (e: 'remove'): void;
   (e: 'select', field: any): void;
-  (e: 'add-field'): void;
+  (e: 'add-field', tabIndex?: number): void;
   (e: 'add-section'): void;
-  (e: 'remove-field', field: any): void;
+  (e: 'remove-field', payload: { field: any; tabIndex?: number }): void;
 }>();
 const { t, locale } = useI18n();
 
 const noop = () => {};
+
+function addTab() {
+  if (!section.tabs) section.tabs = [];
+  section.tabs.push({
+    id: Date.now() + Math.random(),
+    key: `tab${section.tabs.length + 1}`,
+    label: { en: `Tab ${section.tabs.length + 1}`, el: `Tab ${section.tabs.length + 1}` },
+    fields: [],
+  });
+}
+
+function removeTab(index: number) {
+  section.tabs.splice(index, 1);
+}
 
 function resolveI18n(val: any) {
   return resolveI18nUtil(val, locale.value);


### PR DESCRIPTION
## Summary
- allow configuring column counts and tabbed field groups in builder
- widen builder canvas and shrink inspector pane
- render tabbed sections with dynamic column support in preview

## Testing
- `npm run lint`
- `npm test` *(fails: 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cd42d1f08323bb1d4a9941f19458