### PR TITLE
fix: preserve fields when enabling CanvasSection tabs

### DIFF
--- a/frontend/src/components/types/CanvasSection.vue
+++ b/frontend/src/components/types/CanvasSection.vue
@@ -220,11 +220,16 @@ const noop = () => {};
 
 function addTab() {
   if (!section.tabs) section.tabs = [];
+  const newTabIndex = section.tabs.length + 1;
+  const fields =
+    section.tabs.length === 0 && section.fields && section.fields.length
+      ? section.fields.splice(0)
+      : [];
   section.tabs.push({
     id: Date.now() + Math.random(),
-    key: `tab${section.tabs.length + 1}`,
-    label: { en: `Tab ${section.tabs.length + 1}`, el: `Tab ${section.tabs.length + 1}` },
-    fields: [],
+    key: `tab${newTabIndex}`,
+    label: { en: `Tab ${newTabIndex}`, el: `Tab ${newTabIndex}` },
+    fields,
   });
 }
 

--- a/frontend/tests/unit/CanvasSection.addTab.test.ts
+++ b/frontend/tests/unit/CanvasSection.addTab.test.ts
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { createApp } from 'vue';
+import { createI18n } from 'vue-i18n';
+import CanvasSection from '@/components/types/CanvasSection.vue';
+
+vi.mock('vuedraggable', () => ({
+  default: { name: 'draggable', template: '<div><slot /></div>' },
+}));
+vi.mock('@/components/ui/Icon/index.vue', () => ({
+  default: { name: 'Icon', template: '<i />' },
+}));
+vi.mock('@/components/ui/Textinput/index.vue', () => ({
+  default: { name: 'Textinput', template: '<input />' },
+}));
+vi.mock('@/components/ui/Button/index.vue', () => ({
+  default: { name: 'Button', template: '<button><slot /></button>' },
+}));
+vi.mock('@/components/ui/Card/index.vue', () => ({
+  default: { name: 'Card', template: '<div><slot /></div>' },
+}));
+vi.mock('@/components/ui/Dropdown/index.vue', () => ({
+  default: { name: 'Dropdown', template: '<div><slot /><slot name="menus" /></div>' },
+}));
+vi.mock('@/components/ui/Select/index.vue', () => ({
+  default: { name: 'Select', template: '<select><slot /></select>' },
+}));
+vi.mock('@/components/ui/Tabs/index.vue', () => ({
+  default: { name: 'UiTabs', template: '<div><slot name="list" /><slot name="panel" /></div>' },
+}));
+vi.mock('@headlessui/vue', () => ({
+  MenuItem: { name: 'MenuItem', template: '<div><slot /></div>' },
+  Tab: { name: 'Tab', template: '<div><slot /></div>' },
+  TabPanel: { name: 'TabPanel', template: '<div><slot /></div>' },
+}));
+
+describe('CanvasSection addTab', () => {
+  it('moves existing fields into first tab', () => {
+    const section = {
+      label: { en: 'Section', el: 'Section' },
+      cols: 1,
+      fields: [{ id: 1, key: 'a', label: { en: 'A', el: 'A' } }],
+      tabs: [],
+    } as any;
+    const i18n = createI18n({ locale: 'en', messages: { en: {}, el: {} } });
+    const app = createApp(CanvasSection, { section });
+    app.use(i18n);
+    const div = document.createElement('div');
+    const vm = app.mount(div) as any;
+    vm.$.setupState.addTab();
+    expect(section.tabs).toHaveLength(1);
+    expect(section.tabs[0].fields).toHaveLength(1);
+    expect(section.fields).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid losing existing section fields when adding first tab
- add unit test verifying tab creation migrates fields

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d1717e488323a4c51a16db4ad955