### PR TITLE
fix: preserve scroll position when drawer opens

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -36,10 +36,17 @@ defineEmits(['close']);
 
 const SCROLL_LOCK_ATTR = 'data-scroll-lock-count';
 
+let locked = false;
+let scrollTop = 0;
+
 const lockBodyScroll = () => {
   const body = document.body;
   const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count === 0) {
+    scrollTop = window.scrollY;
+    body.style.top = `-${scrollTop}px`;
+    body.style.position = 'fixed';
+    body.style.width = '100%';
     body.classList.add('overflow-hidden');
   }
   body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
@@ -50,13 +57,15 @@ const unlockBodyScroll = () => {
   const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count <= 1) {
     body.classList.remove('overflow-hidden');
+    body.style.position = '';
+    body.style.top = '';
+    body.style.width = '';
+    window.scrollTo({ top: scrollTop });
     body.removeAttribute(SCROLL_LOCK_ATTR);
   } else {
     body.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
   }
 };
-
-let locked = false;
 
 watch(
   () => props.open,


### PR DESCRIPTION
## Summary
- avoid page jumping when opening Drawer by fixing body scroll position

## Testing
- `npm test` (fails: 14 failed, 18 skipped, 36 passed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d36614ec8323ba86af5295e8917c