### PR TITLE
Fix column configuration in task type builder

### DIFF
--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -40,6 +40,18 @@
                   :aria-labelledby="labelId"
                 />
               </FromGroup>
+              <FromGroup #default="{ inputId, labelId }" :label="t('Columns')">
+                <Select
+                  :id="inputId"
+                  v-model.number="cols"
+                  :options="[
+                    { value: 1, label: '1' },
+                    { value: 2, label: '2' },
+                  ]"
+                  :aria-labelledby="labelId"
+                  classInput="text-sm"
+                />
+              </FromGroup>
             </div>
           </TabPanel>
           <TabPanel>
@@ -122,6 +134,7 @@ import Textinput from '@/components/ui/Textinput/index.vue';
 import Switch from '@/components/ui/Switch/index.vue';
 import FromGroup from '@/components/ui/FromGroup/index.vue';
 import Checkbox from '@/components/ui/Checkbox/index.vue';
+import Select from '@/components/ui/Select/index.vue';
 import { useAuthStore } from '@/stores/auth';
 
 interface RoleOption {
@@ -151,12 +164,19 @@ const label = computed({
 
 const validations = computed(() => props.selected?.validations ?? {});
 const roles = computed(() => props.selected?.roles ?? { view: [], edit: [] });
+const cols = computed({
+  get: () => props.selected?.cols ?? 2,
+  set: (val: number) => {
+    if (props.selected) props.selected.cols = val;
+  },
+});
 watch(
   () => props.selected,
   (val) => {
     if (val) {
       if (!val.validations) val.validations = {};
       if (!val.roles) val.roles = { view: ['super_admin'], edit: ['super_admin'] };
+      if (val.cols === undefined) val.cols = 2;
     }
   },
   { immediate: true },

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -1062,6 +1062,7 @@ const previewSchema = computed(() => ({
               default: f.data.default || undefined,
               enum: f.data.enum.length ? f.data.enum : undefined,
               'x-roles': f.roles,
+              'x-cols': f.cols,
             })),
           })),
         }
@@ -1077,6 +1078,7 @@ const previewSchema = computed(() => ({
             default: f.data.default || undefined,
             enum: f.data.enum.length ? f.data.enum : undefined,
             'x-roles': f.roles,
+            'x-cols': f.cols,
           })),
         }),
     'x-cols': s.cols,


### PR DESCRIPTION
## Summary
- allow editing field columns in task type builder inspector
- include field column metadata in preview schema so preview reflects widths

## Testing
- `npm run lint`
- `npm test` *(fails: 14 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d474fbe48323a2495c40bf86751f