### PR TITLE
feat: improve builder columns and drawer scroll

### DIFF
--- a/frontend/src/components/types/CanvasSection.vue
+++ b/frontend/src/components/types/CanvasSection.vue
@@ -68,7 +68,8 @@
               v-model="tab.fields"
               item-key="id"
               handle=".field-handle"
-              class="space-y-2"
+              class="grid gap-2"
+              :class="`grid-cols-${section.cols}`"
               aria-describedby="fieldReorderHint"
             >
               <template #item="{ element }">
@@ -76,6 +77,7 @@
                   bodyClass="p-2 flex items-center gap-2 cursor-pointer"
                   tabindex="0"
                   role="button"
+                  :class="`col-span-${element.cols}`"
                   @click="$emit('select', element)"
                   @keydown.enter.prevent="$emit('select', element)"
                   @keydown.space.prevent="$emit('select', element)"
@@ -121,7 +123,8 @@
         v-model="section.fields"
         item-key="id"
         handle=".field-handle"
-        class="p-2 space-y-2"
+        class="p-2 grid gap-2"
+        :class="`grid-cols-${section.cols}`"
         aria-describedby="fieldReorderHint"
       >
         <template #item="{ element }">
@@ -129,6 +132,7 @@
             bodyClass="p-2 flex items-center gap-2 cursor-pointer"
             tabindex="0"
             role="button"
+            :class="`col-span-${element.cols}`"
             @click="$emit('select', element)"
             @keydown.enter.prevent="$emit('select', element)"
             @keydown.space.prevent="$emit('select', element)"

--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -37,16 +37,11 @@ defineEmits(['close']);
 const SCROLL_LOCK_ATTR = 'data-scroll-lock-count';
 
 let locked = false;
-let scrollTop = 0;
 
 const lockBodyScroll = () => {
   const body = document.body;
   const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count === 0) {
-    scrollTop = window.scrollY;
-    body.style.top = `-${scrollTop}px`;
-    body.style.position = 'fixed';
-    body.style.width = '100%';
     body.classList.add('overflow-hidden');
   }
   body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
@@ -57,10 +52,6 @@ const unlockBodyScroll = () => {
   const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count <= 1) {
     body.classList.remove('overflow-hidden');
-    body.style.position = '';
-    body.style.top = '';
-    body.style.width = '';
-    window.scrollTo({ top: scrollTop });
     body.removeAttribute(SCROLL_LOCK_ATTR);
   } else {
     body.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));


### PR DESCRIPTION
## Summary
- display section fields in a responsive grid so items can be dragged between columns
- prevent page scroll from resetting when opening the field drawer

## Testing
- `npm test` *(fails: 14 failed, 18 skipped, 36 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68b9d60d126c832380be495191835dd6