### PR TITLE
Fix task type builder column handling

### DIFF
--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -438,7 +438,8 @@ function tr(val: any) {
 }
 
 function colClass(field: any) {
-  return field['x-cols'] === 1 ? 'col-span-1' : 'col-span-2';
+  const span = field['x-cols'] || 1;
+  return `col-span-${span}`;
 }
 
 function isVisible(key: string) {

--- a/frontend/src/components/types/Inspector/InspectorTabs.vue
+++ b/frontend/src/components/types/Inspector/InspectorTabs.vue
@@ -47,6 +47,7 @@
                   :options="[
                     { value: 1, label: '1' },
                     { value: 2, label: '2' },
+                    { value: 3, label: '3' },
                   ]"
                   :aria-labelledby="labelId"
                   classInput="text-sm"

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -879,7 +879,7 @@ function onAddField(type: any) {
     name: `field${sectionFields(section).length + 1}`,
     label: { en: type.label, el: type.label },
     typeKey: type.key,
-    cols: 2,
+    cols: 1,
     validations: {},
     fields: type.key === 'repeater' ? [] : undefined,
     placeholder: { en: '', el: '' },

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -8,6 +8,14 @@ module.exports = {
     "./node_modules/vue-tailwind-datepicker/**/*.js",
   ],
   darkMode: "class",
+  safelist: [
+    "grid-cols-1",
+    "grid-cols-2",
+    "grid-cols-3",
+    "col-span-1",
+    "col-span-2",
+    "col-span-3",
+  ],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
## Summary
- generate Tailwind utilities for builder grid layouts
- allow fields to span up to three columns in builder and preview
- let inspector configure field columns 1-3 and default new fields to single-column

## Testing
- `npm test` *(fails: 14 failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9d78a28348323994c617c2b53ca7f