### PR TITLE
fix: ensure inspector defaults appear in preview

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -1059,7 +1059,10 @@ const previewSchema = computed(() => ({
               placeholder: f.placeholder,
               help: f.help,
               fields: f.fields,
-              default: f.data.default || undefined,
+              default:
+                f.data.default === '' || f.data.default === undefined || f.data.default === null
+                  ? undefined
+                  : f.data.default,
               enum: f.data.enum.length ? f.data.enum : undefined,
               'x-roles': f.roles,
               'x-cols': f.cols,
@@ -1075,7 +1078,10 @@ const previewSchema = computed(() => ({
             placeholder: f.placeholder,
             help: f.help,
             fields: f.fields,
-            default: f.data.default || undefined,
+            default:
+              f.data.default === '' || f.data.default === undefined || f.data.default === null
+                ? undefined
+                : f.data.default,
             enum: f.data.enum.length ? f.data.enum : undefined,
             'x-roles': f.roles,
             'x-cols': f.cols,


### PR DESCRIPTION
## Summary
- ensure inspector default values like 0 or false appear in preview

## Testing
- `pnpm lint`
- `pnpm test` *(fails: add button has accessible label; field palette filters groups by search query; sla policy editor has accessible fields; task filters tests; task-type-create-ui tests; tenant-role-switch; upload; etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9f27bfd54832385a802359b3ceb61