### PR TITLE
Preserve scroll position when opening field palette

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -544,8 +544,10 @@ const visibleSections = computed(() => sections.value);
 function openPalette(sectionIndex?: number, tabIndex?: number) {
   const section =
     typeof sectionIndex === 'number' ? sectionIndex : sections.value.length - 1;
+  const scrollY = window.scrollY;
   paletteSectionIndex.value = { section, tab: tabIndex };
   paletteOpen.value = true;
+  nextTick(() => window.scrollTo({ top: scrollY }));
 }
 
 watch(search, async (q) => {


### PR DESCRIPTION
## Summary
- keep page scroll stable when opening Add Field drawer in task type builder

## Testing
- `npm run lint`
- `npm test` *(fails: 13 failed, 18 skipped, 1 did not run, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f54de51c8323a0d6724a07614d5c