### PR TITLE
Preserve scroll position when opening field palette

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -35,6 +35,7 @@ const props = defineProps<Props>();
 defineEmits(['close']);
 
 const SCROLL_LOCK_ATTR = 'data-scroll-lock-count';
+const SCROLL_Y_ATTR = 'data-scroll-lock-y';
 
 let locked = false;
 
@@ -42,7 +43,11 @@ const lockBodyScroll = () => {
   const body = document.body;
   const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count === 0) {
+    const scrollY = window.scrollY;
     body.classList.add('overflow-hidden');
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.setAttribute(SCROLL_Y_ATTR, String(scrollY));
   }
   body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
 };
@@ -51,8 +56,13 @@ const unlockBodyScroll = () => {
   const body = document.body;
   const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count <= 1) {
+    const scrollY = Number(body.getAttribute(SCROLL_Y_ATTR) ?? 0);
     body.classList.remove('overflow-hidden');
+    body.style.position = '';
+    body.style.top = '';
     body.removeAttribute(SCROLL_LOCK_ATTR);
+    body.removeAttribute(SCROLL_Y_ATTR);
+    window.scrollTo({ top: scrollY });
   } else {
     body.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
   }


### PR DESCRIPTION
## Summary
- keep page scroll stable when opening Add Field drawer in task type builder
- lock body scroll at current offset when drawers are shown

## Testing
- `npm run lint`
- `npm test` *(fails: 14 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f54de51c8323a0d6724a07614d5c