### PR TITLE
fix: preserve scroll position when opening drawer

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -45,10 +45,9 @@ const lockBodyScroll = () => {
   if (count === 0) {
     const scrollY = window.scrollY;
     body.classList.add('overflow-hidden');
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
     body.setAttribute(SCROLL_Y_ATTR, String(scrollY));
-    // Restore scroll position after the drawer steals focus
-    setTimeout(() => window.scrollTo({ top: scrollY }), 0);
-
   }
   body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
 };


### PR DESCRIPTION
## Summary
- keep page scroll position when opening a Drawer by fixing body position and restoring on close

## Testing
- `npm run lint`
- `npm test` *(fails: tests/e2e/addMenu.spec.ts:3:1 › add button has accessible label and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7dde1c048323aae9a42e24b5140b