### PR TITLE
Make task type editor panes equal width

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -190,7 +190,7 @@
           class="p-4 border-b"
         />
         <div class="h-[calc(100vh-3rem)] p-4">
-        <div class="hidden lg:grid grid-cols-[3fr_2fr_1fr] gap-4 h-full">
+        <div class="hidden lg:grid grid-cols-3 gap-4 h-full">
           <Card class="overflow-y-auto">
             <template #header>
               <div class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- ensure task type builder uses three equal-width panes

## Testing
- `npm run lint`
- `npm test` *(fails: 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7f32d46883239d8b371189fc7bcf