### PR TITLE
fix: preserve scroll position when opening drawer

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -40,31 +40,35 @@ const SCROLL_Y_ATTR = 'data-scroll-lock-y';
 let locked = false;
 
 const lockBodyScroll = () => {
+  const el = document.documentElement;
   const body = document.body;
-  const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
+  const count = Number(el.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count === 0) {
-    const scrollY = window.scrollY;
+    const scrollY = window.scrollY || el.scrollTop || body.scrollTop;
     body.classList.add('overflow-hidden');
-    body.style.position = 'fixed';
-    body.style.top = `-${scrollY}px`;
-    body.setAttribute(SCROLL_Y_ATTR, String(scrollY));
+    el.classList.add('overflow-hidden');
+    el.style.position = 'fixed';
+    el.style.top = `-${scrollY}px`;
+    el.setAttribute(SCROLL_Y_ATTR, String(scrollY));
   }
-  body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
+  el.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
 };
 
 const unlockBodyScroll = () => {
+  const el = document.documentElement;
   const body = document.body;
-  const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
+  const count = Number(el.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count <= 1) {
-    const scrollY = Number(body.getAttribute(SCROLL_Y_ATTR) ?? 0);
+    const scrollY = Number(el.getAttribute(SCROLL_Y_ATTR) ?? 0);
     body.classList.remove('overflow-hidden');
-    body.style.position = '';
-    body.style.top = '';
-    body.removeAttribute(SCROLL_LOCK_ATTR);
-    body.removeAttribute(SCROLL_Y_ATTR);
+    el.classList.remove('overflow-hidden');
+    el.style.position = '';
+    el.style.top = '';
+    el.removeAttribute(SCROLL_LOCK_ATTR);
+    el.removeAttribute(SCROLL_Y_ATTR);
     window.scrollTo({ top: scrollY });
   } else {
-    body.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
+    el.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure body scroll position is preserved when drawer opens

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 14 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba819726f8832396350f8ed9525c74