### PR TITLE
fix: preserve scroll position when opening drawer

### DIFF
--- a/frontend/src/components/ui/Drawer/index.vue
+++ b/frontend/src/components/ui/Drawer/index.vue
@@ -29,6 +29,7 @@ import { watch, onUnmounted } from 'vue';
 
 interface Props {
   open: boolean;
+  lockTarget?: HTMLElement | null;
 }
 
 const props = defineProps<Props>();
@@ -39,32 +40,34 @@ const SCROLL_Y_ATTR = 'data-scroll-lock-y';
 
 let locked = false;
 
+const getTarget = (): HTMLElement => props.lockTarget ?? document.body;
+
 const lockBodyScroll = () => {
-  const body = document.body;
-  const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
+  const el = getTarget();
+  const count = Number(el.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count === 0) {
-    const scrollY = window.scrollY;
-    body.classList.add('overflow-hidden');
-    body.style.position = 'fixed';
-    body.style.top = `-${scrollY}px`;
-    body.setAttribute(SCROLL_Y_ATTR, String(scrollY));
+    const scrollY = el === document.body ? window.scrollY : el.scrollTop;
+    el.classList.add('overflow-hidden');
+    el.setAttribute(SCROLL_Y_ATTR, String(scrollY));
   }
-  body.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
+  el.setAttribute(SCROLL_LOCK_ATTR, String(count + 1));
 };
 
 const unlockBodyScroll = () => {
-  const body = document.body;
-  const count = Number(body.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
+  const el = getTarget();
+  const count = Number(el.getAttribute(SCROLL_LOCK_ATTR) ?? 0);
   if (count <= 1) {
-    const scrollY = Number(body.getAttribute(SCROLL_Y_ATTR) ?? 0);
-    body.classList.remove('overflow-hidden');
-    body.style.position = '';
-    body.style.top = '';
-    body.removeAttribute(SCROLL_LOCK_ATTR);
-    body.removeAttribute(SCROLL_Y_ATTR);
-    window.scrollTo({ top: scrollY });
+    const scrollY = Number(el.getAttribute(SCROLL_Y_ATTR) ?? 0);
+    el.classList.remove('overflow-hidden');
+    el.removeAttribute(SCROLL_LOCK_ATTR);
+    el.removeAttribute(SCROLL_Y_ATTR);
+    if (el === document.body) {
+      window.scrollTo({ top: scrollY });
+    } else {
+      el.scrollTop = scrollY;
+    }
   } else {
-    body.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
+    el.setAttribute(SCROLL_LOCK_ATTR, String(count - 1));
   }
 };
 

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="canAccess" class="type-builder">
+  <div v-if="canAccess" ref="builder" class="type-builder">
     <form @submit.prevent="onSubmit">
       <header
         v-if="tenantId || !isCreate"
@@ -378,7 +378,7 @@
         </p>
       </Card>
       </form>
-    <Drawer :open="paletteOpen" @close="paletteOpen = false">
+    <Drawer :open="paletteOpen" :lock-target="builder" @close="paletteOpen = false">
       <FieldPalette :groups="fieldTypeGroups" @select="onSelectType" />
     </Drawer>
   </div>
@@ -418,6 +418,7 @@ import { type I18nString } from '@/utils/i18n';
 import Swal from 'sweetalert2';
 
 const { t, locale } = useI18n();
+const builder = ref<HTMLElement | null>(null);
 const route = useRoute();
 const router = useRouter();
 const versionsStore = useTaskTypeVersionsStore();


### PR DESCRIPTION
## Summary
- allow Drawer to lock a specific scroll container instead of the document
- pass the builder element to Drawer on task type form so field palette opening doesn't reset scroll

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 14 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba819726f8832396350f8ed9525c74