### PR TITLE
Style preview as dashcode-like popup in task type builder

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -255,8 +255,18 @@
                   {{ t('preview.runValidation') }}
                 </Button>
               </div>
-              <div :class="[{ dark: previewTheme === 'dark' }, viewportClass]" class="border p-2 overflow-auto">
-                <JsonSchemaForm ref="formRef" v-model="previewData" :schema="previewSchema" :task-id="0" />
+              <div class="bg-slate-900/50 p-4 flex items-center justify-center">
+                <div
+                  :class="[{ dark: previewTheme === 'dark' }, viewportClass]"
+                  class="bg-white dark:bg-slate-800 rounded-md shadow p-4 overflow-auto"
+                >
+                  <JsonSchemaForm
+                    ref="formRef"
+                    v-model="previewData"
+                    :schema="previewSchema"
+                    :task-id="0"
+                  />
+                </div>
               </div>
               <div v-if="Object.keys(validationErrors).length" class="mt-2 text-red-600" role="alert" aria-live="assertive">
                 <ul>


### PR DESCRIPTION
## Summary
- style preview pane to simulate dashcode modal popup used for Add Task form

## Testing
- `npm run lint`
- `npm test` *(fails: 14 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb107a442c8323b1babb8b965c305b