### PR TITLE
Improve task type validation feedback

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -265,6 +265,7 @@
   "preview": {
     "title": "Προεπισκόπηση",
     "runValidation": "Εκτέλεση Ελέγχου",
+    "validationSuccess": "Η επικύρωση ολοκληρώθηκε",
     "language": "Γλώσσα",
     "version": "Έκδοση",
     "theme": "Θέμα",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -265,6 +265,7 @@
   "preview": {
     "title": "Preview",
     "runValidation": "Run Validation",
+    "validationSuccess": "Validation passed",
     "language": "Language",
     "version": "Version",
     "theme": "Theme",


### PR DESCRIPTION
## Summary
- show validation success or error messages in task type builder preview
- propagate backend validation errors to form fields
- add localization for validation success message

## Testing
- `npm test` (fails: 14 failed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb149b5f3c8323b142f6979efbc271