### PR TITLE
Apply design font size to field labels

### DIFF
--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -23,7 +23,7 @@
               </div>
               <div v-else-if="isVisible(field.key)" :class="colClass(field)">
                 <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-                <label :for="field.key" class="block font-medium mb-1">
+                <label :for="field.key" :class="labelClass(field)">
                   {{ tr(field.label) }}<span v-if="isRequired(field)" class="text-red-600">*</span>
                 </label>
                 <input
@@ -224,7 +224,7 @@
         </div>
         <div v-else-if="isVisible(field.key)" :class="colClass(field)">
           <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-          <label :for="field.key" class="block font-medium mb-1">
+          <label :for="field.key" :class="labelClass(field)">
             {{ tr(field.label) }}<span v-if="isRequired(field)" class="text-red-600">*</span>
           </label>
           <input
@@ -496,6 +496,12 @@ function inputType(type: string) {
   if (type === 'phone') return 'tel';
   if (type === 'url') return 'url';
   return 'text';
+}
+
+function labelClass(field: any) {
+  const base = 'block font-medium mb-1';
+  const cls = field['x-styles']?.fontSize;
+  return cls ? `${base} ${cls}` : base;
 }
 
 function inputClass(field: any) {

--- a/frontend/tests/unit/SectionCard.design.test.ts
+++ b/frontend/tests/unit/SectionCard.design.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest';
+import { createApp } from 'vue';
+import { createI18n } from 'vue-i18n';
+import SectionCard from '@/components/tasks/SectionCard.vue';
+
+vi.mock('@/components/tasks/AssigneePicker.vue', () => ({
+  default: { name: 'AssigneePicker', template: '<div />' },
+}));
+vi.mock('@/components/fields/ReviewerPicker.vue', () => ({
+  default: { name: 'ReviewerPicker', template: '<div />' },
+}));
+vi.mock('@/components/fields/RichText.vue', () => ({
+  default: { name: 'RichText', template: '<div />' },
+}));
+vi.mock('@/components/fields/MarkdownInput.vue', () => ({
+  default: { name: 'MarkdownInput', template: '<div />' },
+}));
+vi.mock('@/components/tasks/PhotoField.vue', () => ({
+  default: { name: 'PhotoField', template: '<div />' },
+}));
+vi.mock('@/components/tasks/PhotoRepeater.vue', () => ({
+  default: { name: 'PhotoRepeater', template: '<div />' },
+}));
+vi.mock('@/components/fields/ChipsInput.vue', () => ({
+  default: { name: 'ChipsInput', template: '<div />' },
+}));
+vi.mock('@/components/fields/RadioGroup.vue', () => ({
+  default: { name: 'RadioGroup', template: '<div />' },
+}));
+vi.mock('@/components/fields/CheckboxGroup.vue', () => ({
+  default: { name: 'CheckboxGroup', template: '<div />' },
+}));
+vi.mock('@/components/fields/DateInput.vue', () => ({
+  default: { name: 'DateInput', template: '<div />' },
+}));
+vi.mock('@/components/fields/TimeInput.vue', () => ({
+  default: { name: 'TimeInput', template: '<div />' },
+}));
+vi.mock('@/components/fields/DateTimeInput.vue', () => ({
+  default: { name: 'DateTimeInput', template: '<div />' },
+}));
+vi.mock('@/components/fields/DurationInput.vue', () => ({
+  default: { name: 'DurationInput', template: '<div />' },
+}));
+vi.mock('@/components/ui/Tabs/index.vue', () => ({
+  default: { name: 'UiTabs', template: '<div><slot name="list" /><slot name="panel" /></div>' },
+}));
+vi.mock('@headlessui/vue', () => ({
+  Tab: { name: 'Tab', template: '<div><slot /></div>' },
+  TabPanel: { name: 'TabPanel', template: '<div><slot /></div>' },
+}));
+vi.mock('@/services/uploader', () => ({
+  uploadFile: vi.fn(),
+}));
+
+const i18n = createI18n({ locale: 'en', messages: { en: {}, el: {} } });
+
+describe('SectionCard design settings', () => {
+  it('applies font size to label', () => {
+    const section = {
+      label: { en: 'Section', el: 'Section' },
+      fields: [
+        {
+          key: 'name',
+          label: { en: 'Name', el: 'Name' },
+          type: 'text',
+          'x-styles': { fontSize: 'text-lg' },
+        },
+      ],
+    } as any;
+
+    const app = createApp(SectionCard, {
+      section,
+      form: {},
+      errors: {},
+      taskId: 1,
+      readonly: false,
+      visible: new Set(),
+      required: new Set(),
+      showTargets: new Set(),
+    });
+    app.use(i18n);
+    const div = document.createElement('div');
+    app.mount(div);
+
+    const label = div.querySelector('label');
+    expect(label?.className).toContain('text-lg');
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure field label in task-type builder uses design font size
- add tests for label font size styling

## Testing
- `npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1602833883238bb776beba0ffabf