### PR TITLE
Fix task type edit data loading

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -621,7 +621,8 @@ const viewportClass = computed(() => {
 onMounted(async () => {
   await tenantStore.loadTenants({ per_page: 100 });
   if (isEdit.value) {
-    const { data: typeData } = await api.get(`/task-types/${route.params.id}`);
+    const { data } = await api.get(`/task-types/${route.params.id}`);
+    const typeData = data.data ?? data;
     name.value = typeData.name || '';
     tenantId.value =
       typeData.tenant_id !== null && typeData.tenant_id !== undefined


### PR DESCRIPTION
## Summary
- ensure Task Type edit form loads existing data correctly

## Testing
- `npm test` *(fails: 12 failing tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb1aa25d948323a1c8366eca64748c