### PR TITLE
feat: enhance task type management

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskTypeController.php
+++ b/backend/app/Http/Controllers/Api/TaskTypeController.php
@@ -28,7 +28,7 @@ class TaskTypeController extends Controller
     public function index(Request $request)
     {
         $scope = $request->query('scope', $request->user()->hasRole('SuperAdmin') ? 'all' : 'tenant');
-        $query = TaskType::query();
+        $query = TaskType::query()->with(['currentVersion', 'tenant']);
 
         if ($scope === 'tenant') {
             $tenantId = $request->query('tenant_id', $request->user()->tenant_id);

--- a/backend/app/Models/TaskType.php
+++ b/backend/app/Models/TaskType.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Services\FormSchemaService;
+use App\Models\Tenant;
 
 /**
  * @property array|null $schema_json Schema definition
@@ -57,6 +58,11 @@ class TaskType extends Model
     public function automations(): HasMany
     {
         return $this->hasMany(TaskAutomation::class);
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 
     protected function schemaJson(): Attribute

--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -1,32 +1,58 @@
 <template>
-  <Card noborder>
+  <Card>
     <div class="md:flex justify-between pb-6 md:space-y-0 space-y-3 items-center">
       <h5>Task Types</h5>
-      <InputGroup
-        v-model="searchTerm"
-        placeholder="Search"
-        type="text"
-        prependIcon="heroicons-outline:search"
-        merged
-      />
+      <div class="flex items-center gap-2">
+        <InputGroup
+          v-model="searchTerm"
+          placeholder="Search"
+          type="text"
+          prependIcon="heroicons-outline:search"
+          merged
+        />
+        <slot name="header-actions" />
+      </div>
     </div>
 
       <vue-good-table
         :columns="columns"
         :rows="filteredRows"
-        styleClass="vgt-table bordered centered"
+        styleClass="vgt-table bordered centered striped"
         :pagination-options="{ enabled: true, perPage: perPage }"
         :search-options="{ enabled: true, externalQuery: searchTerm }"
         :select-options="selectOptions"
       >
         <template #table-row="rowProps">
-          <span v-if="rowProps.column.field === 'tenant_id'">
-            {{ rowProps.row.tenant_id || '—' }}
+          <span v-if="rowProps.column.field === 'tenant'">
+            {{ rowProps.row.tenant?.name || '—' }}
+          </span>
+          <span v-else-if="rowProps.column.field === 'published'">
+            {{ rowProps.row.current_version?.published_at ? 'Yes' : 'No' }}
           </span>
           <span v-else-if="rowProps.column.field === 'actions'">
             <Dropdown classMenuItems=" w-[140px]">
               <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
               <template #menus>
+                <MenuItem v-if="!rowProps.row.current_version?.published_at">
+                  <button
+                    type="button"
+                    class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                    @click="$emit('publish', rowProps.row.id)"
+                  >
+                    <span class="text-base"><Icon icon="heroicons-outline:check" /></span>
+                    <span>Publish</span>
+                  </button>
+                </MenuItem>
+                <MenuItem v-else>
+                  <button
+                    type="button"
+                    class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                    @click="$emit('deprecate', rowProps.row.id)"
+                  >
+                    <span class="text-base"><Icon icon="heroicons-outline:x-mark" /></span>
+                    <span>Unpublish</span>
+                  </button>
+                </MenuItem>
                 <MenuItem>
                   <button
                     type="button"
@@ -92,7 +118,8 @@ import Pagination from '@/components/ui/Pagination';
 interface TaskType {
   id: number;
   name: string;
-  tenant_id?: number | null;
+  tenant?: { id: number; name: string } | null;
+  current_version?: { id: number; published_at?: string | null } | null;
 }
 
 const props = defineProps<{ rows: TaskType[] }>();
@@ -100,6 +127,8 @@ const emit = defineEmits<{
   (e: 'edit', id: number): void;
   (e: 'delete', id: number): void;
   (e: 'copy', id: number): void;
+  (e: 'publish', id: number): void;
+  (e: 'deprecate', id: number): void;
 }>();
 
 const searchTerm = ref('');
@@ -125,7 +154,8 @@ const selectOptions = {
 const columns = [
   { label: 'ID', field: 'id' },
   { label: 'Name', field: 'name' },
-  { label: 'Tenant', field: 'tenant_id' },
+  { label: 'Tenant', field: 'tenant' },
+  { label: 'Published', field: 'published' },
   { label: 'Actions', field: 'actions' },
 ];
 

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -1,20 +1,28 @@
 <template>
   <div>
-      <div class="flex items-center justify-between mb-4">
-        <div>
-          <select
-            id="task-types-scope"
-            v-model="scope"
-            class="border rounded px-2 py-1"
-            aria-label="Scope"
-            @change="changeScope"
-          >
-            <option v-for="opt in scopeOptions" :key="opt.value" :value="opt.value">
-              {{ opt.label }}
-            </option>
-          </select>
-        </div>
-        <div class="flex gap-2">
+      <div class="mb-4">
+        <select
+          id="task-types-scope"
+          v-model="scope"
+          class="border rounded px-2 py-1"
+          aria-label="Scope"
+          @change="changeScope"
+        >
+          <option v-for="opt in scopeOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+      <TaskTypesTable
+        v-if="!loading"
+        :rows="all"
+        @edit="edit"
+        @delete="remove"
+        @copy="copy"
+        @publish="publish"
+        @deprecate="deprecate"
+      >
+        <template #header-actions>
           <button
             v-if="can('task_field_snippets.manage')"
             class="bg-gray-200 px-4 py-2 rounded"
@@ -31,15 +39,8 @@
             <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
             Add Type
           </RouterLink>
-        </div>
-      </div>
-      <TaskTypesTable
-        v-if="!loading"
-        :rows="all"
-        @edit="edit"
-        @delete="remove"
-        @copy="copy"
-      />
+        </template>
+      </TaskTypesTable>
       <div v-else class="p-4">
         <SkeletonTable :count="10" />
       </div>
@@ -64,6 +65,7 @@
   import { useAuthStore, can } from '@/stores/auth';
   import { useTenantStore } from '@/stores/tenant';
   import { useTaskTypesStore } from '@/stores/taskTypes';
+  import { useTaskTypeVersionsStore } from '@/stores/taskTypeVersions';
   import TemplatesDrawer from '@/components/types/TemplatesDrawer.vue';
 
 const router = useRouter();
@@ -72,6 +74,7 @@ const scope = ref<'tenant' | 'global' | 'all'>("tenant");
 const auth = useAuthStore();
 const tenantStore = useTenantStore();
 const typesStore = useTaskTypesStore();
+const versionsStore = useTaskTypeVersionsStore();
 const templatesOpen = ref(false);
 const loading = ref(true);
 
@@ -91,7 +94,7 @@ const scopeOptions = computed(() => {
 });
 
 async function load() {
-  const tenantId = auth.isSuperAdmin ? tenantStore.currentTenantId : undefined;
+  const tenantId = auth.isSuperAdmin && scope.value !== 'all' ? tenantStore.currentTenantId : undefined;
   all.value = (await typesStore.fetch(scope.value, tenantId)).data;
   loading.value = false;
 }
@@ -124,7 +127,7 @@ async function remove(id: number) {
     }
   }
 
-async function copy(id: number) {
+  async function copy(id: number) {
   let tenantId: string | number | undefined;
   if (auth.isSuperAdmin) {
     await tenantStore.loadTenants();
@@ -147,6 +150,22 @@ async function copy(id: number) {
 
 function onImported() {
   templatesOpen.value = false;
+  reload();
+}
+
+async function publish(id: number) {
+  const type = all.value.find((t) => t.id === id);
+  const versionId = type?.current_version?.id;
+  if (!versionId) return;
+  await versionsStore.publish(versionId);
+  reload();
+}
+
+async function deprecate(id: number) {
+  const type = all.value.find((t) => t.id === id);
+  const versionId = type?.current_version?.id;
+  if (!versionId) return;
+  await versionsStore.deprecate(versionId);
   reload();
 }
 </script>


### PR DESCRIPTION
## Summary
- show task type tenant names and publication state
- allow publishing or unpublishing from task type list
- restyle task type table and move template/add buttons next to search

## Testing
- `npm test` *(fails: 14 failed, 36 passed)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2308e348832392fd598fde7b3031