### PR TITLE
feat(frontend): confirm publishing task type

### DIFF
--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -157,6 +157,12 @@ async function publish(id: number) {
   const type = all.value.find((t) => t.id === id);
   const versionId = type?.current_version?.id;
   if (!versionId) return;
+  const res = await Swal.fire({
+    title: 'Publish type?',
+    icon: 'warning',
+    showCancelButton: true,
+  });
+  if (!res.isConfirmed) return;
   await versionsStore.publish(versionId);
   reload();
 }


### PR DESCRIPTION
## Summary
- add confirmation before publishing a task type version

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 14 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2511780483239b68f360691e4bb8