### PR TITLE
Fix task list API data parsing

### DIFF
--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -270,8 +270,9 @@ onMounted(async () => {
     api.get('/task-statuses'),
     api.get('/task-types'),
   ]);
-  statusOptions.value = statusRes.data.map((s: any) => s.name);
-  typeOptions.value = typeRes.data;
+  const statusData = statusRes.data?.data ?? statusRes.data;
+  statusOptions.value = statusData.map((s: any) => s.name);
+  typeOptions.value = typeRes.data?.data ?? typeRes.data;
   const stored = localStorage.getItem('taskViews');
   if (stored) savedViews.value = JSON.parse(stored);
 });
@@ -332,7 +333,7 @@ async function applyBulkStatus() {
 async function fetchTasks({ page, perPage, sort, search }: any) {
   if (!all.value.length) {
     const { data } = await api.get('/tasks');
-    all.value = data;
+    all.value = data?.data ?? data;
   }
   let rows = all.value.slice();
 


### PR DESCRIPTION
## Summary
- ensure task list handles wrapped API responses
- correctly unwrap nested task arrays on the board view

## Testing
- `npm test` *(fails: 14 failed, 18 skipped, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a53c4848323a43f04c42599fbe4