### PR TITLE
feat: filter abilities by tenant features

### DIFF
--- a/frontend/src/constants/featureMap.ts
+++ b/frontend/src/constants/featureMap.ts
@@ -1,0 +1,69 @@
+export const featureMap: Record<string, { label: string; abilities: string[] }> = {
+  tasks: {
+    label: 'Tasks',
+    abilities: [
+      'tasks.view',
+      'tasks.create',
+      'tasks.update',
+      'tasks.delete',
+      'tasks.assign',
+      'tasks.status.update',
+      'tasks.comment.create',
+      'tasks.attach.upload',
+      'tasks.board.view',
+      'tasks.list.view',
+      'tasks.watch',
+      'tasks.manage',
+    ],
+  },
+  notifications: {
+    label: 'Notifications',
+    abilities: ['notifications.view', 'notifications.manage'],
+  },
+  reports: {
+    label: 'Reports',
+    abilities: ['reports.view', 'reports.manage'],
+  },
+  roles: {
+    label: 'Roles & Permissions',
+    abilities: ['roles.view', 'roles.manage'],
+  },
+  task_types: {
+    label: 'Task Types',
+    abilities: [
+      'task_types.manage',
+      'task_type_versions.manage',
+      'task_automations.manage',
+      'task_field_snippets.manage',
+    ],
+  },
+  teams: {
+    label: 'Teams',
+    abilities: ['teams.view', 'teams.create', 'teams.update', 'teams.delete', 'teams.manage'],
+  },
+  task_statuses: {
+    label: 'Task Statuses',
+    abilities: ['task_statuses.manage'],
+  },
+  employees: {
+    label: 'Employees',
+    abilities: ['employees.view', 'employees.create', 'employees.update', 'employees.delete', 'employees.manage'],
+  },
+  themes: {
+    label: 'Theme Customizer',
+    abilities: ['themes.view', 'themes.manage'],
+  },
+  tenants: {
+    label: 'Tenants',
+    abilities: ['tenants.view', 'tenants.create', 'tenants.update', 'tenants.delete', 'tenants.manage'],
+  },
+  branding: {
+    label: 'Branding & Footer',
+    abilities: ['branding.manage'],
+  },
+  gdpr: {
+    label: 'GDPR',
+    abilities: ['gdpr.view', 'gdpr.manage', 'gdpr.export', 'gdpr.delete'],
+  },
+};
+export type FeatureSlug = keyof typeof featureMap;

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -194,6 +194,7 @@
           :roles="tenantRoles"
           :can-manage="canManage"
           :status-count="statuses.length"
+          :features="tenantFeatures"
           class="p-4 border-b"
         />
         <div class="h-[calc(100vh-3rem)] p-4">
@@ -502,6 +503,12 @@ interface Permission {
 
 const name = ref('');
 const tenantId = ref<number | ''>('');
+const tenantFeatures = computed(() => {
+  const tenant = tenantStore.tenants.find(
+    (t: any) => String(t.id) === String(tenantId.value),
+  );
+  return tenant?.features || [];
+});
 const transitionsEditor = ref<any>(null);
 const automationsEditor = ref<any>(null);
 const slaPolicyEditor = ref<any>(null);

--- a/frontend/tests/unit/permissions-matrix.spec.ts
+++ b/frontend/tests/unit/permissions-matrix.spec.ts
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import { createApp, ref, nextTick } from 'vue';
+import { createI18n } from 'vue-i18n';
+import PermissionsMatrix from '@/components/types/PermissionsMatrix.vue';
+import en from '@/i18n/en.json';
+
+const TestWrapper = {
+  components: { PermissionsMatrix },
+  template: '<PermissionsMatrix ref="pm" v-model="perms" :roles="roles" :can-manage="true" :status-count="0" :features="features" />',
+  setup() {
+    const perms = ref({});
+    const roles = ref([] as any[]);
+    const features = ref<string[]>(['tasks']);
+    const pm = ref();
+    return { perms, roles, features, pm };
+  },
+};
+
+describe('PermissionsMatrix', () => {
+  it('filters abilities when features change', async () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const app = createApp(TestWrapper);
+    const i18n = createI18n({ locale: 'en', messages: { en } });
+    app.use(i18n);
+    const vm: any = app.mount(el);
+    const pm: any = vm.pm;
+    await nextTick();
+    const headerCount = pm.$el.querySelectorAll('thead th').length - 1;
+    expect(headerCount).toBeGreaterThan(0);
+    vm.features = [];
+    await nextTick();
+    const newCount = pm.$el.querySelectorAll('thead th').length - 1;
+    expect(newCount).toBe(0);
+    app.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- add static feature-to-ability map
- filter permissions matrix and editors by tenant features
- limit role ability options to selected tenant features
- cover ability filtering with unit test

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `npx vitest run tests/unit/permissions-matrix.spec.ts`
- `npm run lint` *(fails: Each form element must have a label)*

------
https://chatgpt.com/codex/tasks/task_e_68bc12934e348323a39036a292a4e1ae