### PR TITLE
Normalize task board response and add feature tests

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskBoardController.php
+++ b/backend/app/Http/Controllers/Api/TaskBoardController.php
@@ -29,21 +29,22 @@ class TaskBoardController extends Controller
             ->orderBy('position')
             ->get();
 
-        $columns = $statuses->map(function (TaskStatus $status) use ($tenantId, $typeId) {
+        $columns = $statuses->map(function (TaskStatus $status) use ($tenantId, $typeId, $request) {
             $query = Task::where('tenant_id', $tenantId)
                 ->where('status_slug', $status->slug)
                 ->orderBy('board_position');
             if ($typeId) {
                 $query->where('task_type_id', $typeId);
             }
-            $tasks = $query->paginate(50);
+            $tasks = $query->limit(50)->get();
 
             return [
-                'status' => new TaskStatusResource($status),
-                'tasks' => TaskResource::collection($tasks),
-                'meta' => ['total' => $tasks->total()],
+                'status' => TaskStatusResource::make($status)->toArray($request),
+                'tasks' => TaskResource::collection($tasks)->toArray($request),
             ];
-        });
+        })
+            ->values()
+            ->all();
 
         return response()->json(['data' => $columns]);
     }


### PR DESCRIPTION
## Summary
- Return plain arrays for task board columns instead of paginator objects
- Add feature tests covering board structure and board_position updates

## Testing
- `./vendor/bin/phpunit` (fails: Tests: 125, Assertions: 330, Errors: 1, Failures: 19)
- `./vendor/bin/phpunit --filter TaskBoardTest`


------
https://chatgpt.com/codex/tasks/task_e_68bc21594da48323973c9166c3e9750a