### PR TITLE
Guard TaskForm version fetch for non-managers

### DIFF
--- a/frontend/src/views/tasks/TaskForm.vue
+++ b/frontend/src/views/tasks/TaskForm.vue
@@ -194,13 +194,17 @@ async function onTypeChange() {
   dueAt.value = null;
   priority.value = '';
   if (taskTypeId.value) {
-    const { data } = await api.get('/task-type-versions', {
-      params: { task_type_id: taskTypeId.value },
-    });
-    const list = data.data || [];
-    versions.value = can('task_type_versions.manage')
-      ? list
-      : list.filter((v: any) => v.published_at);
+    let list: any[] = [];
+    const manageVersions = can('task_type_versions.manage');
+    if (manageVersions) {
+      const { data } = await api.get('/task-type-versions', {
+        params: { task_type_id: taskTypeId.value },
+      });
+      list = data.data || [];
+    } else if (t?.current_version) {
+      list = [t.current_version];
+    }
+    versions.value = manageVersions ? list : list.filter((v: any) => v.published_at);
     taskTypeVersionId.value = versions.value[0]?.id ?? null;
   }
 }


### PR DESCRIPTION
## Summary
- Fetch task type versions only for users with manage permission and fall back to current published version for others.

## Testing
- `npm test` *(fails: SectionCard design settings > applies font size to label)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc254f5e388323ad46874a308bd9b7