### PR TITLE
Add tenant feature ability mapping

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -38,6 +38,7 @@ class TenantController extends Controller
             'name' => 'required|string',
             'quota_storage_mb' => 'integer',
             'features' => 'array',
+            'feature_abilities' => 'array',
             'phone' => 'nullable|string',
             'address' => 'nullable|string',
             'user_name' => 'required|string',
@@ -48,6 +49,7 @@ class TenantController extends Controller
                 'name' => $data['name'],
                 'quota_storage_mb' => $data['quota_storage_mb'] ?? null,
                 'features' => $data['features'] ?? ['tasks'],
+                'feature_abilities' => $data['feature_abilities'] ?? [],
                 'phone' => $data['phone'] ?? null,
                 'address' => $data['address'] ?? null,
             ]);
@@ -85,6 +87,7 @@ class TenantController extends Controller
             'name' => 'sometimes|string',
             'quota_storage_mb' => 'integer',
             'features' => 'array',
+            'feature_abilities' => 'array',
             'phone' => 'sometimes|nullable|string',
             'address' => 'sometimes|nullable|string',
         ]);

--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -14,12 +14,14 @@ class Tenant extends Model
         'name',
         'quota_storage_mb',
         'features',
+        'feature_abilities',
         'phone',
         'address',
     ];
 
     protected $casts = [
         'features' => 'array',
+        'feature_abilities' => 'array',
     ];
 
     protected static function booted(): void
@@ -38,9 +40,15 @@ class Tenant extends Model
     {
         $map = config('feature_map', []);
         $abilities = [];
+        $selected = $this->feature_abilities ?? [];
 
         foreach ($this->features ?? [] as $feature) {
-            $abilities = array_merge($abilities, $map[$feature]['abilities'] ?? []);
+            $featureAbilities = $map[$feature]['abilities'] ?? [];
+            $chosen = $selected[$feature] ?? [];
+            $abilities = array_merge(
+                $abilities,
+                array_intersect($featureAbilities, $chosen)
+            );
         }
 
         return array_values(array_unique($abilities));

--- a/backend/app/Observers/TenantObserver.php
+++ b/backend/app/Observers/TenantObserver.php
@@ -9,13 +9,13 @@ class TenantObserver
 {
     public function created(Tenant $tenant): void
     {
-        DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant);
+        DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant, $tenant->feature_abilities ?? []);
     }
 
     public function updated(Tenant $tenant): void
     {
-        if ($tenant->wasChanged('features')) {
-            DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant);
+        if ($tenant->wasChanged(['features', 'feature_abilities'])) {
+            DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant, $tenant->feature_abilities ?? []);
         }
     }
 }

--- a/backend/database/migrations/2025_01_01_100300_add_feature_abilities_to_tenants_table.php
+++ b/backend/database/migrations/2025_01_01_100300_add_feature_abilities_to_tenants_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->json('feature_abilities')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn('feature_abilities');
+        });
+    }
+};

--- a/frontend/src/views/tenants/TenantForm.vue
+++ b/frontend/src/views/tenants/TenantForm.vue
@@ -113,8 +113,7 @@ onMounted(async () => {
       user_name: '',
       user_email: '',
     };
-    const stored = tenantStore.tenantAllowedAbilities(route.params.id as string);
-    featureAbilities.value = { ...stored };
+    featureAbilities.value = { ...(data.feature_abilities || {}) };
     form.value.features.forEach((f: string) => {
       if (!featureAbilities.value[f]) {
         featureAbilities.value[f] = [...(featureMap[f]?.abilities || [])];
@@ -136,6 +135,7 @@ const onSubmit = handleSubmit(async () => {
     phone: form.value.phone,
     address: form.value.address,
     features: form.value.features,
+    feature_abilities: featureAbilities.value,
   };
   if (!isEdit.value) {
     payload.user_name = form.value.user_name;


### PR DESCRIPTION
## Summary
- store selected feature abilities for each tenant
- seed default roles based on stored feature abilities
- include ability selections in tenant form requests

## Testing
- `composer test` (fails: The chunk field must be a file of type: jpg, jpeg, png, pdf. Tests: 24 failed)
- `npm test` (fails: SectionCard design settings > applies font size to label)


------
https://chatgpt.com/codex/tasks/task_e_68bc2cdf919c83238d8b57df607d36ff