### PR TITLE
Add request validation for tenant feature abilities

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\TenantUpsertRequest;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Models\AuditLog;
@@ -36,19 +37,10 @@ class TenantController extends Controller
         return response()->json($result);
     }
 
-    public function store(Request $request)
+    public function store(TenantUpsertRequest $request)
     {
         $this->ensureSuperAdmin($request);
-        $data = $request->validate([
-            'name' => 'required|string',
-            'quota_storage_mb' => 'integer',
-            'features' => 'array',
-            'feature_abilities' => 'array',
-            'phone' => 'nullable|string',
-            'address' => 'nullable|string',
-            'user_name' => 'required|string',
-            'user_email' => 'required|email',
-        ]);
+        $data = $request->validated();
         $tenant = DB::transaction(function () use ($data) {
             $tenant = Tenant::create([
                 'name' => $data['name'],
@@ -85,17 +77,10 @@ class TenantController extends Controller
         return $tenant->makeVisible('feature_abilities');
     }
 
-    public function update(Request $request, Tenant $tenant)
+    public function update(TenantUpsertRequest $request, Tenant $tenant)
     {
         $this->ensureSuperAdmin($request);
-        $data = $request->validate([
-            'name' => 'sometimes|string',
-            'quota_storage_mb' => 'integer',
-            'features' => 'array',
-            'feature_abilities' => 'array',
-            'phone' => 'sometimes|nullable|string',
-            'address' => 'sometimes|nullable|string',
-        ]);
+        $data = $request->validated();
         $tenant->update($data);
         return $tenant->load('roles');
     }

--- a/backend/app/Http/Requests/TenantUpsertRequest.php
+++ b/backend/app/Http/Requests/TenantUpsertRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TenantUpsertRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $featureSlugs = config('features');
+
+        $rules = [
+            'name' => [$this->isMethod('POST') ? 'required' : 'sometimes', 'string'],
+            'quota_storage_mb' => ['integer'],
+            'features' => ['array'],
+            'features.*' => ['string', Rule::in($featureSlugs)],
+            'feature_abilities' => ['array'],
+            'feature_abilities.*' => ['array'],
+            'feature_abilities.*.*' => ['string'],
+            'phone' => [$this->isMethod('POST') ? 'nullable|string' : 'sometimes|nullable|string'],
+            'address' => [$this->isMethod('POST') ? 'nullable|string' : 'sometimes|nullable|string'],
+        ];
+
+        if ($this->isMethod('POST')) {
+            $rules['user_name'] = ['required', 'string'];
+            $rules['user_email'] = ['required', 'email'];
+        }
+
+        return $rules;
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $features = $this->input('features', []);
+            $featureAbilities = $this->input('feature_abilities', []);
+            $featureMap = config('feature_map');
+
+            foreach ($featureAbilities as $feature => $abilities) {
+                if (! in_array($feature, $features, true)) {
+                    $validator->errors()->add("feature_abilities.$feature", 'Abilities provided for unselected feature.');
+                    continue;
+                }
+
+                $allowed = $featureMap[$feature]['abilities'] ?? [];
+                foreach ((array) $abilities as $ability) {
+                    if (! in_array($ability, $allowed, true)) {
+                        $validator->errors()->add("feature_abilities.$feature", "The ability $ability is not allowed.");
+                    }
+                }
+            }
+        });
+    }
+
+    protected function passedValidation(): void
+    {
+        $features = $this->input('features', []);
+        $featureMap = config('feature_map');
+        $sanitizedFeatures = array_values(array_intersect($features, config('features')));
+
+        $sanitizedAbilities = [];
+        $featureAbilities = $this->input('feature_abilities', []);
+        foreach ($featureAbilities as $feature => $abilities) {
+            if (! in_array($feature, $sanitizedFeatures, true)) {
+                continue;
+            }
+            $allowed = $featureMap[$feature]['abilities'] ?? [];
+            $sanitized = array_values(array_intersect((array) $abilities, $allowed));
+            if ($sanitized) {
+                $sanitizedAbilities[$feature] = $sanitized;
+            }
+        }
+
+        $this->merge([
+            'features' => $sanitizedFeatures,
+            'feature_abilities' => $sanitizedAbilities,
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate tenant features and abilities via new `TenantUpsertRequest`
- use `TenantUpsertRequest` in TenantController to sanitize ability selections

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc30798bf48323ac490d58d5107822