### PR TITLE
Include global task statuses in tenant scope

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskStatusController.php
+++ b/backend/app/Http/Controllers/Api/TaskStatusController.php
@@ -27,8 +27,10 @@ class TaskStatusController extends Controller
         $query = TaskStatus::query();
 
         if ($scope === 'tenant') {
-            $tenantId = $request->query('tenant_id', $request->user()->tenant_id);
-            $query->where('tenant_id', $tenantId);
+            $tenantId = $request->query('tenant_id', $request->header('X-Tenant-ID', $request->user()->tenant_id));
+            $query->where(function ($q) use ($tenantId) {
+                $q->whereNull('tenant_id')->orWhere('tenant_id', $tenantId);
+            });
         } elseif ($scope === 'global') {
             $query->whereNull('tenant_id');
         } else {

--- a/backend/tests/Feature/TaskStatusTenantVisibilityTest.php
+++ b/backend/tests/Feature/TaskStatusTenantVisibilityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\TaskStatus;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskStatusTenantVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_global_and_tenant_statuses_for_tenant_scope(): void
+    {
+        Tenant::create(['id' => 1, 'name' => 'T1', 'features' => ['tasks']]);
+        Tenant::create(['id' => 2, 'name' => 'T2', 'features' => ['tasks']]);
+
+        TaskStatus::create(['slug' => 'global', 'name' => 'Global', 'tenant_id' => null]);
+        TaskStatus::create(['slug' => 't1', 'name' => 'Tenant One', 'tenant_id' => 1]);
+        TaskStatus::create(['slug' => 't2', 'name' => 'Tenant Two', 'tenant_id' => 2]);
+
+        $role = Role::create([
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'tenant_id' => 1,
+            'abilities' => ['task_statuses.manage'],
+            'level' => 1,
+        ]);
+
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => 1,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => 1]);
+        Sanctum::actingAs($user);
+
+        $response = $this->withHeader('X-Tenant-ID', 1)->getJson('/api/task-statuses');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data'))->pluck('name')->sort()->values()->all();
+        $this->assertEquals(['Global', 'Tenant One'], $names);
+    }
+
+    public function test_super_admin_sees_global_and_tenant_statuses_with_header(): void
+    {
+        Tenant::create(['id' => 1, 'name' => 'T1', 'features' => ['tasks']]);
+        Tenant::create(['id' => 2, 'name' => 'T2', 'features' => ['tasks']]);
+
+        TaskStatus::create(['slug' => 'global', 'name' => 'Global', 'tenant_id' => null]);
+        TaskStatus::create(['slug' => 't1', 'name' => 'Tenant One', 'tenant_id' => 1]);
+        TaskStatus::create(['slug' => 't2', 'name' => 'Tenant Two', 'tenant_id' => 2]);
+
+        $root = Tenant::create(['id' => 999, 'name' => 'Root']);
+        $role = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'tenant_id' => $root->id,
+            'abilities' => ['*'],
+            'level' => 0,
+        ]);
+
+        $user = User::create([
+            'name' => 'Super',
+            'email' => 'super@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $root->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $root->id]);
+        Sanctum::actingAs($user);
+
+        $response = $this->withHeader('X-Tenant-ID', 1)
+            ->getJson('/api/task-statuses?scope=tenant');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data'))->pluck('name')->sort()->values()->all();
+        $this->assertEquals(['Global', 'Tenant One'], $names);
+    }
+}


### PR DESCRIPTION
## Summary
- show tenant-specific and global statuses when listing task statuses for a tenant
- honor X-Tenant-ID header so super admins can view tenant statuses
- add feature tests for tenant and super-admin status visibility

## Testing
- `php artisan test --filter=TaskStatusTenantVisibilityTest`
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc3bb49d288323938be6b71e3ad0c7