### PR TITLE
Set initial status slug on task creation

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskController.php
@@ -86,6 +86,7 @@ class TaskController extends Controller
             }
         }
         $data['status'] = $version && $version->statuses ? array_key_first($version->statuses) : Task::STATUS_DRAFT;
+        $data['status_slug'] = $data['status'];
         $this->validateAgainstSchema($version, $data['form_data'] ?? [], null);
         $this->formSchemaService->mapAssignee($version->schema_json ?? [], $data);
         $this->formSchemaService->mapReviewer($version->schema_json ?? [], $data);

--- a/backend/tests/Feature/TaskCreationTest.php
+++ b/backend/tests/Feature/TaskCreationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskCreationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_new_task_has_status_and_slug(): void
+    {
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create([
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'tenant_id' => $tenant->id,
+            'abilities' => ['tasks.manage'],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+
+        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/tasks', ['title' => 'A']);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'draft')
+            ->assertJsonPath('data.status_slug', 'draft');
+
+        $taskId = $response->json('data.id');
+
+        $this->assertDatabaseHas('tasks', [
+            'id' => $taskId,
+            'status' => 'draft',
+            'status_slug' => 'draft',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- populate `status_slug` when creating tasks so board and automation logic receive it
- cover task creation with test ensuring both `status` and `status_slug` are set

## Testing
- `php artisan test --filter=TaskCreationTest`


------
https://chatgpt.com/codex/tasks/task_e_68bc43ec257c83238d6980c6827b24fd