### PR TITLE
chore(frontend): integrate dashcode source

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,7 @@ import { createApp, watch } from "vue";
 import "simplebar-vue/dist/simplebar.min.css";
 import "tippy.js/dist/tippy.css";
 import "tippy.js/themes/light.css";
+import "@dc/assets/scss/tailwind.scss"; // DC base/components/utilities
 import VueGoodTablePlugin from "vue-good-table-next";
 import "vue-good-table-next/dist/vue-good-table-next.css";
 import VueSweetalert2 from "vue-sweetalert2";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,7 +21,10 @@ export default defineConfig(({ command }) => ({
   },
   preview: { cors: { origin: '*' } },
   resolve: {
-    alias: { '@': path.resolve(__dirname, 'src') },
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '@dc': path.resolve(__dirname, '../dashcode-full-source-code/src'),
+    },
     extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },
   css: {


### PR DESCRIPTION
## Summary
- add @dc path alias to Vite config
- load Dashcode Tailwind layer in app entry

## Testing
- `pnpm lint`
- `pnpm test` *(fails: SectionCard design settings > applies font size to label)*

------
https://chatgpt.com/codex/tasks/task_e_68bc560496608323b26626121909d02e