### PR TITLE
feat: enforce task status transition constraints

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskBoardController.php
+++ b/backend/app/Http/Controllers/Api/TaskBoardController.php
@@ -72,9 +72,7 @@ class TaskBoardController extends Controller
         if (! $flow->canTransition($task->status_slug, $status->slug, $task->type)) {
             return response()->json(['message' => 'invalid_transition'], 422);
         }
-        if ($reason = $flow->checkConstraints($task, $status->slug)) {
-            return response()->json(['message' => $reason], 422);
-        }
+        $flow->checkConstraints($task, $status->slug);
 
         $positions->move($task, $status->slug, $data['index']);
 

--- a/backend/app/Http/Controllers/Api/TaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskController.php
@@ -175,10 +175,7 @@ class TaskController extends Controller
             return response()->json(['message' => 'invalid_transition'], 422);
         }
 
-        $reason = $this->statusFlow->checkConstraints($task, $next);
-        if ($reason) {
-            return response()->json(['message' => 'constraint_failed', 'reason' => $reason], 422);
-        }
+        $this->statusFlow->checkConstraints($task, $next);
 
         $task->status = $next;
         if ($next === Task::STATUS_IN_PROGRESS && ! $task->started_at) {

--- a/backend/lang/el.json
+++ b/backend/lang/el.json
@@ -1,0 +1,5 @@
+{
+    "Assignee is required to leave the initial status.": "Απαιτείται ανάθεση για να φύγετε από την αρχική κατάσταση.",
+    "Complete required subtasks before finishing.": "Ολοκληρώστε τις υποχρεωτικές υποεργασίες πριν την ολοκλήρωση.",
+    "Required photos are missing.": "Λείπουν οι απαιτούμενες φωτογραφίες."
+}

--- a/backend/lang/en.json
+++ b/backend/lang/en.json
@@ -1,0 +1,5 @@
+{
+    "Assignee is required to leave the initial status.": "Assignee is required to leave the initial status.",
+    "Complete required subtasks before finishing.": "Complete required subtasks before finishing.",
+    "Required photos are missing.": "Required photos are missing."
+}

--- a/backend/tests/Feature/TaskStatusConstraintsTest.php
+++ b/backend/tests/Feature/TaskStatusConstraintsTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Task;
+use App\Models\TaskSubtask;
+use App\Models\TaskType;
+use App\Models\TaskTypeVersion;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskStatusConstraintsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Tenant::create(['id' => 1, 'name' => 'T', 'features' => ['tasks']]);
+    }
+
+    protected function authUser(): User
+    {
+        $role = Role::create([
+            'name' => 'User',
+            'slug' => 'user',
+            'tenant_id' => 1,
+            'abilities' => ['tasks.status.update', 'tasks.update'],
+            'level' => 1,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => 1,
+            'phone' => '123',
+            'address' => 'Street',
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => 1]);
+        Sanctum::actingAs($user);
+        return $user;
+    }
+
+    protected function makeType(array $schema = []): TaskTypeVersion
+    {
+        $type = TaskType::create([
+            'name' => 'Type',
+            'tenant_id' => 1,
+        ]);
+        $version = TaskTypeVersion::create([
+            'task_type_id' => $type->id,
+            'semver' => '1.0.0',
+            'schema_json' => $schema,
+            'statuses' => [
+                ['slug' => 'initial'],
+                ['slug' => 'final'],
+            ],
+            'status_flow_json' => [
+                ['initial', 'final'],
+            ],
+            'created_by' => 1,
+        ]);
+        $type->current_version_id = $version->id;
+        $type->save();
+        return $version;
+    }
+
+    public function test_assignee_required_to_leave_initial(): void
+    {
+        $user = $this->authUser();
+        $version = $this->makeType();
+
+        $task = Task::create([
+            'tenant_id' => 1,
+            'user_id' => $user->id,
+            'task_type_id' => $version->task_type_id,
+            'task_type_version_id' => $version->id,
+            'status' => 'initial',
+            'status_slug' => 'initial',
+        ]);
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$task->id}/status", ['status' => 'final'])
+            ->assertStatus(422)
+            ->assertJsonPath('code', 'assignee_required');
+    }
+
+    public function test_required_subtasks_must_be_complete_before_final(): void
+    {
+        $user = $this->authUser();
+        $version = $this->makeType();
+
+        $task = Task::create([
+            'tenant_id' => 1,
+            'user_id' => $user->id,
+            'task_type_id' => $version->task_type_id,
+            'task_type_version_id' => $version->id,
+            'status' => 'initial',
+            'status_slug' => 'initial',
+            'assigned_user_id' => $user->id,
+        ]);
+
+        TaskSubtask::create([
+            'task_id' => $task->id,
+            'title' => 'S',
+            'is_required' => true,
+            'is_completed' => false,
+        ]);
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$task->id}/status", ['status' => 'final'])
+            ->assertStatus(422)
+            ->assertJsonPath('code', 'subtasks_incomplete');
+    }
+
+    public function test_required_photos_must_be_attached_before_final(): void
+    {
+        $user = $this->authUser();
+        $version = $this->makeType([
+            'sections' => [
+                ['photos' => [
+                    ['key' => 'p1', 'required' => true],
+                ]],
+            ],
+        ]);
+
+        $task = Task::create([
+            'tenant_id' => 1,
+            'user_id' => $user->id,
+            'task_type_id' => $version->task_type_id,
+            'task_type_version_id' => $version->id,
+            'status' => 'initial',
+            'status_slug' => 'initial',
+            'assigned_user_id' => $user->id,
+        ]);
+
+        $this->withHeader('X-Tenant-ID', 1)
+            ->postJson("/api/tasks/{$task->id}/status", ['status' => 'final'])
+            ->assertStatus(422)
+            ->assertJsonPath('code', 'photos_required');
+    }
+}
+

--- a/frontend/tests/e2e/task-board.spec.ts
+++ b/frontend/tests/e2e/task-board.spec.ts
@@ -10,3 +10,18 @@ test('task board shows error on forbidden transition', async () => {
   // In real test, backend would return 422 and toast error is shown.
   expect(true).toBe(true);
 });
+
+test('task board blocks move without assignee', async () => {
+  // Would show toast with assignee_required code.
+  expect(true).toBe(true);
+});
+
+test('task board blocks move with incomplete required subtasks', async () => {
+  // Would show toast with subtasks_incomplete code.
+  expect(true).toBe(true);
+});
+
+test('task board blocks move when required photos missing', async () => {
+  // Would show toast with photos_required code.
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- enforce assignee, subtask, and photo constraints when moving task statuses
- surface constraint violations through API controllers
- cover new rules with backend feature/unit tests and Playwright placeholders
- add i18n strings for new validation messages

## Testing
- `php artisan test tests/Feature/TaskStatusConstraintsTest.php tests/Unit/StatusFlowServiceTest.php`
- `npx playwright test tests/e2e/task-board.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e1a28e08323835b50212f897207