### PR TITLE
Register ability middleware alias

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -27,6 +27,7 @@ return Application::configure(
         $middleware->alias([
             'tenant' => \App\Http\Middleware\ResolveTenant::class,
             'signed.url' => \App\Http\Middleware\SignedUrl::class,
+            'ability' => \App\Http\Middleware\Ability::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {


### PR DESCRIPTION
## Summary
- register ability middleware alias in bootstrap configuration to prevent container resolution error

## Testing
- `composer test` *(fails: Script @php artisan test handling the test event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6e5fca188323951a5d8d27901443