### PR TITLE
fix(frontend): add @dc alias to tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,8 @@
     "lib": ["ESNext", "DOM"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@dc/*": ["../dashcode-full-source-code/src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "tests/**/*.ts"],

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -3,7 +3,12 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@dc/*": ["../dashcode-full-source-code/src/*"]
+    }
   },
   "include": ["vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary
- map `@dc` alias in frontend TypeScript configs to match Vite alias

## Testing
- `npm run lint` *(fails: Form label must have an associated control; Attribute "class" should go before "@click"; Each form element must have a programmatically associated label element)*
- `npm test` *(fails: SectionCard design settings > applies font size to label)*

------
https://chatgpt.com/codex/tasks/task_e_68bc74af45988323aae47ee5ef1d1f30