### PR TITLE
Handle photo roles and repeater validation

### DIFF
--- a/backend/tests/Feature/TaskPhotoRepeaterValidationTest.php
+++ b/backend/tests/Feature/TaskPhotoRepeaterValidationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\FormSchemaService;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class TaskPhotoRepeaterValidationTest extends TestCase
+{
+    private array $schema = [
+        'sections' => [
+            [
+                'key' => 'main',
+                'label' => 'Main',
+                'photos' => [
+                    [
+                        'key' => 'pr',
+                        'label' => 'Photos',
+                        'type' => 'photo_repeater',
+                        'maxCount' => 2,
+                        'validations' => [
+                            'required' => true,
+                            'mime' => ['image/jpeg'],
+                            'size' => 1024,
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    public function test_repeater_empty_throws_required(): void
+    {
+        $service = new FormSchemaService();
+        try {
+            $service->validateData($this->schema, ['pr' => []]);
+            $this->fail('Expected ValidationException not thrown');
+        } catch (ValidationException $e) {
+            $this->assertSame('required', $e->errors()['form_data.pr'][0]);
+        }
+    }
+
+    public function test_repeater_exceeds_max_count(): void
+    {
+        $service = new FormSchemaService();
+        $data = [
+            'pr' => [
+                ['mime' => 'image/jpeg', 'size' => 100],
+                ['mime' => 'image/jpeg', 'size' => 100],
+                ['mime' => 'image/jpeg', 'size' => 100],
+            ],
+        ];
+        try {
+            $service->validateData($this->schema, $data);
+            $this->fail('Expected ValidationException not thrown');
+        } catch (ValidationException $e) {
+            $this->assertSame('max_count', $e->errors()['form_data.pr'][0]);
+        }
+    }
+
+    public function test_repeater_item_validation(): void
+    {
+        $service = new FormSchemaService();
+        $data = [
+            'pr' => [
+                ['mime' => 'image/png', 'size' => 100],
+            ],
+        ];
+        try {
+            $service->validateData($this->schema, $data);
+            $this->fail('Expected ValidationException not thrown');
+        } catch (ValidationException $e) {
+            $this->assertSame('mime', $e->errors()['form_data.pr'][0]);
+        }
+
+        $service->validateData($this->schema, [
+            'pr' => [
+                ['mime' => 'image/jpeg', 'size' => 100],
+            ],
+        ]);
+        $this->assertTrue(true);
+    }
+}
+

--- a/backend/tests/Feature/TaskPhotoRolesTest.php
+++ b/backend/tests/Feature/TaskPhotoRolesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\FormSchemaService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TaskPhotoRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $schema = [
+        'roles' => ['viewer' => 'read'],
+        'sections' => [
+            [
+                'key' => 'main',
+                'label' => 'Main',
+                'photos' => [
+                    ['key' => 'secret', 'label' => 'Secret', 'type' => 'photo_single', 'roles' => ['viewer' => 'hidden']],
+                    ['key' => 'note', 'label' => 'Note', 'type' => 'photo_single'],
+                ],
+            ],
+        ],
+    ];
+
+    private function makeViewer(): User
+    {
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+        $role = Role::create([
+            'name' => 'Viewer',
+            'slug' => 'viewer',
+            'tenant_id' => $tenant->id,
+            'abilities' => ['tasks.view'],
+            'level' => 5,
+        ]);
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        Sanctum::actingAs($user);
+        return $user;
+    }
+
+    public function test_schema_and_data_filtered_for_viewer(): void
+    {
+        $user = $this->makeViewer();
+        $service = new FormSchemaService();
+
+        $filtered = $service->filterSchemaForRoles($this->schema, $user);
+        $photos = $filtered['sections'][0]['photos'];
+        $this->assertCount(1, $photos);
+        $this->assertSame('note', $photos[0]['key']);
+        $this->assertTrue($photos[0]['readOnly']);
+
+        $data = [
+            'secret' => ['mime' => 'image/jpeg'],
+            'note' => ['mime' => 'image/jpeg'],
+        ];
+        $filteredData = $service->filterDataForRoles($this->schema, $data, $user);
+        $this->assertSame(['note' => ['mime' => 'image/jpeg']], $filteredData);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Respect role-based access on schema `photos` and strip hidden photo payloads
- Enforce validation rules for `photo_repeater` fields
- Cover photo role filtering and repeater validation with new tests

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf)*
- `./vendor/bin/phpunit --filter TaskPhotoRolesTest`
- `./vendor/bin/phpunit --filter TaskPhotoRepeaterValidationTest`


------
https://chatgpt.com/codex/tasks/task_e_68bc755fd1cc83239ffea4627fa703cf