### PR TITLE
fix: require single ability for task board

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -108,9 +108,9 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         ->whereNumber('subtask');
 
     Route::get('task-board', [TaskBoardController::class, 'index'])
-        ->middleware(Ability::class . ':tasks.view|tasks.manage');
+        ->middleware(Ability::class . ':tasks.view');
     Route::get('task-board/column', [TaskBoardController::class, 'column'])
-        ->middleware(Ability::class . ':tasks.view|tasks.manage');
+        ->middleware(Ability::class . ':tasks.view');
     Route::patch('task-board/move', [TaskBoardController::class, 'move'])
         ->middleware(Ability::class . ':tasks.update');
 

--- a/backend/tests/Feature/TaskBoardTest.php
+++ b/backend/tests/Feature/TaskBoardTest.php
@@ -34,7 +34,7 @@ class TaskBoardTest extends TestCase
             'name' => 'User',
             'slug' => 'user',
             'tenant_id' => 1,
-            'abilities' => ['tasks.view|tasks.manage', 'tasks.update'],
+            'abilities' => ['tasks.view', 'tasks.update'],
             'level' => 1,
         ]);
         $user = User::create([

--- a/backend/tests/Feature/TaskBoardUnionTest.php
+++ b/backend/tests/Feature/TaskBoardUnionTest.php
@@ -35,7 +35,7 @@ class TaskBoardUnionTest extends TestCase
             'name' => 'User',
             'slug' => 'user',
             'tenant_id' => 1,
-            'abilities' => ['tasks.view|tasks.manage', 'tasks.update'],
+            'abilities' => ['tasks.view', 'tasks.update'],
             'level' => 1,
         ]);
         $user = User::create([


### PR DESCRIPTION
## Summary
- require only `tasks.view` ability for task board routes
- update task board tests to use `tasks.view` ability

## Testing
- `composer test` *(fails: comment with attachment saves file relation, cross tenant mention fails, conditional required field, status update requires ability, sla override requires ability on update, unique validation enforced, regex validation fails, migrations run and rollback, tasks overview returns metrics, sanitize rich text, override fields ignored without ability on create, override fields respected with ability on create, policy applies sla end at for non override user, override user can set sla fields, cannot create status without ability, can create status with ability, allows valid transition, rejects invalid transition, defaults when no custom flow, tasks create user can create task, missing ability cannot fetch options, preview validation endpoint, default watchers added, select tenant message translations exist, chunk validates mime and size)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9ca0270c8323acd079f17aa615be