### PR TITLE
Enforce photo role restrictions in form edits

### DIFF
--- a/backend/app/Services/FormSchemaService.php
+++ b/backend/app/Services/FormSchemaService.php
@@ -594,7 +594,7 @@ class FormSchemaService
         $defaults = $schema['roles'] ?? [];
 
         foreach ($schema['sections'] ?? [] as $section) {
-            foreach ($section['fields'] ?? [] as $field) {
+            foreach (array_merge($section['fields'] ?? [], $section['photos'] ?? []) as $field) {
                 $key = $field['key'] ?? null;
                 if (! $key || ! array_key_exists($key, $data)) {
                     continue;

--- a/backend/tests/Feature/TaskPhotoRolesTest.php
+++ b/backend/tests/Feature/TaskPhotoRolesTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Services\FormSchemaService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
@@ -67,6 +68,14 @@ class TaskPhotoRolesTest extends TestCase
         ];
         $filteredData = $service->filterDataForRoles($this->schema, $data, $user);
         $this->assertSame(['note' => ['mime' => 'image/jpeg']], $filteredData);
+    }
+
+    public function test_assert_can_edit_blocks_read_only(): void
+    {
+        $user = $this->makeViewer();
+        $service = new FormSchemaService();
+        $this->expectException(ValidationException::class);
+        $service->assertCanEdit($this->schema, ['note' => ['mime' => 'image/jpeg']], $user);
     }
 }
 


### PR DESCRIPTION
## Summary
- Allow `assertCanEdit` to inspect section photos so read-only or hidden images cannot be altered
- Add regression test ensuring viewers cannot submit data for read-only photos

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `./vendor/bin/phpunit tests/Feature/TaskPhotoRolesTest.php tests/Feature/TaskFieldRolesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bca2e2c06883238ede92a74896166d