### PR TITLE
fix TypeForm photos mapping and streamline tippy styles

### DIFF
--- a/dashcode-full-source-code/src/components/Tooltip/index.vue
+++ b/dashcode-full-source-code/src/components/Tooltip/index.vue
@@ -49,18 +49,11 @@
   </tippy>
 </template>
 <script>
-import "tippy.js/animations/perspective-extreme.css";
-import "tippy.js/animations/perspective-subtle.css";
-import "tippy.js/animations/perspective.css";
-import "tippy.js/animations/scale-extreme.css";
-import "tippy.js/animations/scale-subtle.css";
-import "tippy.js/animations/scale.css";
-import "tippy.js/animations/shift-away-extreme.css";
-import "tippy.js/animations/shift-away-subtle.css";
-import "tippy.js/animations/shift-away.css";
-import "tippy.js/animations/shift-toward-extreme.css";
-import "tippy.js/animations/shift-toward-subtle.css";
-import "tippy.js/animations/shift-toward.css";
+// animation styles from tippy.js are optional and can cause
+// resolution issues when the component is consumed outside of the
+// package's own build pipeline.  The default stylesheet still ships
+// with the core animation definitions, so we only pull in the base
+// and theme styles here.
 import "tippy.js/dist/tippy.css";
 import "tippy.js/themes/light.css";
 

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -1096,19 +1096,23 @@ async function onSubmit() {
                 'x-styles': f.styles,
               })),
             }
-        ),
-        photos: s.photos.map((p) => ({
-          key: p.name,
-          label: p.label,
-          type: p.typeKey,
-          validations: p.validations,
-          maxCount: p.maxCount,
-          help: p.help,
-          'x-roles': p.roles,
-          'x-styles': p.styles,
+          ),
+          ...(s.photos.length
+            ? {
+                photos: s.photos.map((p) => ({
+                  key: p.name,
+                  label: p.label,
+                  type: p.typeKey,
+                  validations: p.validations,
+                  maxCount: p.maxCount,
+                  help: p.help,
+                  'x-roles': p.roles,
+                  'x-styles': p.styles,
+                })),
+              }
+            : {}),
+          'x-cols': s.cols,
         })),
-        'x-cols': s.cols,
-      })),
       ...(logicRules.length ? { logic: logicRules } : {}),
     }),
     statuses: JSON.stringify(statuses.value.reduce((acc: any, s) => ({ ...acc, [s]: [] }), {})),
@@ -1258,19 +1262,23 @@ const previewSchema = computed(() => ({
             'x-cols': f.cols,
           })),
         }
-    ),
-    photos: s.photos.map((p) => ({
-      key: p.name,
-      label: p.label,
-      type: p.typeKey,
-      validations: p.validations,
-      maxCount: p.maxCount,
-      help: p.help,
-      'x-roles': p.roles,
-      'x-styles': p.styles,
+      ),
+      ...(s.photos.length
+        ? {
+            photos: s.photos.map((p) => ({
+              key: p.name,
+              label: p.label,
+              type: p.typeKey,
+              validations: p.validations,
+              maxCount: p.maxCount,
+              help: p.help,
+              'x-roles': p.roles,
+              'x-styles': p.styles,
+            })),
+          }
+        : {}),
+      'x-cols': s.cols,
     })),
-    'x-cols': s.cols,
-  })),
   ...(sections.value
     .flatMap((s) =>
       sectionAllFields(s).flatMap((f) =>


### PR DESCRIPTION
## Summary
- avoid parser errors by conditionally spreading section `photos` in TypeForm
- drop tippy animation CSS imports to prevent missing-file errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd48bbcd5483239fb4aba3fc0ed6d3