### PR TITLE
Fix task type edit form to load base data when no versions

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -734,6 +734,10 @@ onMounted(async () => {
       if ((versionsList as any[]).length) {
         selectedVersionId.value = (versionsList as any[])[0].id;
         loadVersion((versionsList as any[])[0]);
+      } else {
+        // If no versions exist yet, load the data directly from the task type
+        // so previously saved schema and statuses are rendered when editing.
+        loadVersion(typeData);
       }
     } else {
       tenantStore.setTenant('');


### PR DESCRIPTION
## Summary
- render saved task type schema and statuses when editing a type without versions

## Testing
- `npm test` *(fails: SectionCard design settings applies font size to label)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5078f6b48323b51e79a9cf7b2141