### PR TITLE
Fix task type edit form to load base data when no versions

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -620,6 +620,8 @@ const canAccess = computed(
       (isEdit.value ? can('task_types.view') : can('task_types.create'))),
 );
 
+const skipTenantWatch = ref(isEdit.value);
+
 watch(previewLang, (lang) => {
   locale.value = lang;
 });
@@ -734,6 +736,10 @@ onMounted(async () => {
       if ((versionsList as any[]).length) {
         selectedVersionId.value = (versionsList as any[])[0].id;
         loadVersion((versionsList as any[])[0]);
+      } else {
+        // If no versions exist yet, load the data directly from the task type
+        // so previously saved schema and statuses are rendered when editing.
+        loadVersion(typeData);
       }
     } else {
       tenantStore.setTenant('');
@@ -746,6 +752,10 @@ onMounted(async () => {
 });
 
 watch(tenantId, (id, oldId) => {
+  if (skipTenantWatch.value) {
+    skipTenantWatch.value = false;
+    return;
+  }
   refreshTenant(id, oldId);
 });
 


### PR DESCRIPTION
## Summary
- render saved task type schema and statuses when editing a type without versions
- prevent tenant watcher from wiping loaded data on initial load

## Testing
- `cd frontend && npm test` *(fails: SectionCard design settings applies font size to label)*


------
https://chatgpt.com/codex/tasks/task_e_68bd5078f6b48323b51e79a9cf7b2141