### PR TITLE
fix: add tenant i18n key

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -371,5 +371,6 @@
   "Label": "Ετικέτα",
   "Required": "Υποχρεωτικό",
   "Columns": "Στήλες",
-  "Select a field": "Επιλέξτε πεδίο"
+  "Select a field": "Επιλέξτε πεδίο",
+  "tenant": "Μισθωτής"
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -371,5 +371,6 @@
   "Label": "Label",
   "Required": "Required",
   "Columns": "Columns",
-  "Select a field": "Select a field"
+  "Select a field": "Select a field",
+  "tenant": "Tenant"
 }


### PR DESCRIPTION
## Summary
- add missing `tenant` key to English and Greek locale files to fix runtime warning on dashboard

## Testing
- `pnpm lint` *(fails: Form label must have an associated control, Attribute "class" should go before "@click", etc.)*
- `pnpm test` *(fails: Playwright browsers missing, multiple e2e tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd79c690a88323b8eb80e67ec22af9