### PR TITLE
Fix publish/unpublish controls for task types

### DIFF
--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -47,7 +47,7 @@
                   <button
                     type="button"
                     class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
-                    @click="$emit('deprecate', rowProps.row.id)"
+                    @click="$emit('unpublish', rowProps.row.id)"
                   >
                     <span class="text-base"><Icon icon="heroicons-outline:x-mark" /></span>
                     <span>Unpublish</span>
@@ -128,7 +128,7 @@ const emit = defineEmits<{
   (e: 'delete', id: number): void;
   (e: 'copy', id: number): void;
   (e: 'publish', id: number): void;
-  (e: 'deprecate', id: number): void;
+  (e: 'unpublish', id: number): void;
 }>();
 
 const searchTerm = ref('');

--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -948,7 +948,8 @@ async function duplicateVersion() {
 }
 
 async function publishVersion() {
-  if (!selectedVersionId.value) return;
+  const versionId = selectedVersionId.value ?? versions.value[0]?.id;
+  if (!versionId) return;
   const result = await Swal.fire({
     title: 'Publish this version?',
     icon: 'warning',
@@ -956,12 +957,14 @@ async function publishVersion() {
     confirmButtonText: 'Yes, publish',
   });
   if (!result.isConfirmed) return;
-  await versionsStore.publish(selectedVersionId.value);
+  await versionsStore.publish(versionId);
   versions.value = await versionsStore.list(taskTypeId.value);
+  selectedVersionId.value = versionId;
 }
 
 async function unpublishVersion() {
-  if (!selectedVersionId.value) return;
+  const versionId = selectedVersionId.value ?? versions.value[0]?.id;
+  if (!versionId) return;
   const result = await Swal.fire({
     title: 'Unpublish this version?',
     icon: 'warning',
@@ -969,8 +972,9 @@ async function unpublishVersion() {
     confirmButtonText: 'Yes, unpublish',
   });
   if (!result.isConfirmed) return;
-  await versionsStore.unpublish(selectedVersionId.value);
+  await versionsStore.unpublish(versionId);
   versions.value = await versionsStore.list(taskTypeId.value);
+  selectedVersionId.value = versionId;
 }
 
 async function deleteVersion() {

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -20,7 +20,7 @@
         @delete="remove"
         @copy="copy"
         @publish="publish"
-        @deprecate="deprecate"
+        @unpublish="unpublish"
       >
         <template #header-actions>
           <button
@@ -167,11 +167,17 @@ async function publish(id: number) {
   reload();
 }
 
-async function deprecate(id: number) {
+async function unpublish(id: number) {
   const type = all.value.find((t) => t.id === id);
   const versionId = type?.current_version?.id;
   if (!versionId) return;
-  await versionsStore.deprecate(versionId);
+  const res = await Swal.fire({
+    title: 'Unpublish type?',
+    icon: 'warning',
+    showCancelButton: true,
+  });
+  if (!res.isConfirmed) return;
+  await versionsStore.unpublish(versionId);
   reload();
 }
 </script>


### PR DESCRIPTION
## Summary
- fix publish button to show unpublish option in task type table
- wire types list to call unpublish action
- refresh version controls after publishing or unpublishing

## Testing
- `npm run lint` *(fails: Form label must have an associated control, Attribute "class" should go before "@click", Each form element must have a programmatically associated label element)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd7c53af508323beff3d8986ac5c5c