### PR TITLE
feat: allow super admins to choose tenant when creating tasks

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskController.php
@@ -78,7 +78,11 @@ class TaskController extends Controller
             unset($data['sla_start_at'], $data['sla_end_at']);
         }
 
-        $data['tenant_id'] = $request->user()->tenant_id;
+        $tenantId = $request->user()->tenant_id;
+        if ($request->user()->isSuperAdmin()) {
+            $tenantId = $request->attributes->get('tenant_id', $tenantId);
+        }
+        $data['tenant_id'] = $tenantId;
 
         $type = null;
         $version = null;


### PR DESCRIPTION
## Summary
- allow backend to accept selected tenant when creating a task
- let super admins choose tenant on task creation form
- add test covering super admin task creation for selected tenant

## Testing
- `npm test`
- `composer test` *(fails: Tests: 32 failed, 6 incomplete, 128 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd89fa5c288323ad2cb33cdf456a3d