### PR TITLE
Seed default task statuses for tenants

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\TenantUpsertRequest;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Models\AuditLog;
+use App\Services\TenantSetupService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
@@ -67,6 +68,8 @@ class TenantController extends Controller
 
             return $tenant;
         });
+
+        app(TenantSetupService::class)->createDefaultTaskStatuses($tenant);
 
         return response()->json($tenant->load('roles'), 201);
     }

--- a/backend/app/Services/TenantSetupService.php
+++ b/backend/app/Services/TenantSetupService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TaskStatus;
+use App\Models\Tenant;
+use App\Support\TenantDefaults;
+
+class TenantSetupService
+{
+    public function createDefaultTaskStatuses(Tenant $tenant): void
+    {
+        foreach (TenantDefaults::TASK_STATUSES as $index => $status) {
+            TaskStatus::create([
+                'tenant_id' => $tenant->id,
+                'slug' => $status['slug'],
+                'name' => $status['name'],
+                'color' => $status['color'],
+                'position' => $index + 1,
+            ]);
+        }
+    }
+}

--- a/backend/app/Support/TenantDefaults.php
+++ b/backend/app/Support/TenantDefaults.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Support;
+
+class TenantDefaults
+{
+    public const TASK_STATUSES = [
+        ['slug' => 'draft', 'name' => 'Draft', 'color' => '#9ca3af'],
+        ['slug' => 'assigned', 'name' => 'Assigned', 'color' => '#3b82f6'],
+        ['slug' => 'in_progress', 'name' => 'In Progress', 'color' => '#f59e0b'],
+        ['slug' => 'completed', 'name' => 'Completed', 'color' => '#10b981'],
+    ];
+}

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use App\Models\TaskStatus;
 use App\Models\TaskType;
+use App\Support\TenantDefaults;
 
 class TenantBootstrapSeeder extends Seeder
 {
@@ -148,12 +149,7 @@ class TenantBootstrapSeeder extends Seeder
         }
 
         // Default task statuses
-        $defaultStatuses = [
-            ['slug' => 'todo', 'name' => 'To Do', 'color' => '#9ca3af'],
-            ['slug' => 'in_progress', 'name' => 'In Progress', 'color' => '#3b82f6'],
-            ['slug' => 'qa', 'name' => 'QA', 'color' => '#f59e0b'],
-            ['slug' => 'done', 'name' => 'Done', 'color' => '#10b981'],
-        ];
+        $defaultStatuses = TenantDefaults::TASK_STATUSES;
 
         foreach ($defaultStatuses as $index => $status) {
             DB::table('task_statuses')->updateOrInsert(
@@ -189,18 +185,13 @@ class TenantBootstrapSeeder extends Seeder
             ],
         ];
 
-        $typeStatuses = [
-            'todo' => [],
-            'in_progress' => [],
-            'qa' => [],
-            'done' => [],
-        ];
+        $typeStatuses = array_fill_keys(array_column($defaultStatuses, 'slug'), []);
 
-        $transitions = [
-            ['todo', 'in_progress'],
-            ['in_progress', 'qa'],
-            ['qa', 'done'],
-        ];
+        $slugs = array_column($defaultStatuses, 'slug');
+        $transitions = [];
+        for ($i = 0; $i < count($slugs) - 1; $i++) {
+            $transitions[] = [$slugs[$i], $slugs[$i + 1]];
+        }
 
         DB::table('task_types')->updateOrInsert(
             ['tenant_id' => $tenantId, 'name' => 'General Task'],

--- a/backend/tests/Feature/TaskBoardTenantVisibilityTest.php
+++ b/backend/tests/Feature/TaskBoardTenantVisibilityTest.php
@@ -8,6 +8,7 @@ use App\Models\TaskStatus;
 use App\Models\TaskType;
 use App\Models\Tenant;
 use App\Models\User;
+use App\Support\TenantDefaults;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Sanctum\Sanctum;
@@ -22,10 +23,11 @@ class TaskBoardTenantVisibilityTest extends TestCase
         $tenant1 = Tenant::create(['id' => 1, 'name' => 'T1', 'features' => ['tasks']]);
         $tenant2 = Tenant::create(['id' => 2, 'name' => 'T2', 'features' => ['tasks']]);
 
-        TaskStatus::create(['slug' => 'todo', 'name' => 'To Do', 'position' => 1]);
+        $status = TenantDefaults::TASK_STATUSES[0];
+        TaskStatus::create(['slug' => $status['slug'], 'name' => $status['name'], 'position' => 1]);
 
-        $type1 = TaskType::create(['tenant_id' => $tenant1->id, 'name' => 'Type1', 'statuses' => ['todo' => []]]);
-        $type2 = TaskType::create(['tenant_id' => $tenant2->id, 'name' => 'Type2', 'statuses' => ['todo' => []]]);
+        $type1 = TaskType::create(['tenant_id' => $tenant1->id, 'name' => 'Type1', 'statuses' => [$status['slug'] => []]]);
+        $type2 = TaskType::create(['tenant_id' => $tenant2->id, 'name' => 'Type2', 'statuses' => [$status['slug'] => []]]);
 
         $u1 = User::create([
             'name' => 'U1',
@@ -44,8 +46,22 @@ class TaskBoardTenantVisibilityTest extends TestCase
             'address' => 'A',
         ]);
 
-        Task::create(['tenant_id' => $tenant1->id, 'user_id' => $u1->id, 'task_type_id' => $type1->id, 'status' => 'todo', 'status_slug' => 'todo', 'title' => 'T1 Task']);
-        Task::create(['tenant_id' => $tenant2->id, 'user_id' => $u2->id, 'task_type_id' => $type2->id, 'status' => 'todo', 'status_slug' => 'todo', 'title' => 'T2 Task']);
+        Task::create([
+            'tenant_id' => $tenant1->id,
+            'user_id' => $u1->id,
+            'task_type_id' => $type1->id,
+            'status' => $status['name'],
+            'status_slug' => $status['slug'],
+            'title' => 'T1 Task'
+        ]);
+        Task::create([
+            'tenant_id' => $tenant2->id,
+            'user_id' => $u2->id,
+            'task_type_id' => $type2->id,
+            'status' => $status['name'],
+            'status_slug' => $status['slug'],
+            'title' => 'T2 Task'
+        ]);
 
         $root = Tenant::create(['id' => 999, 'name' => 'Root']);
         $role = Role::create([

--- a/backend/tests/Feature/TenantBootstrapSeederTest.php
+++ b/backend/tests/Feature/TenantBootstrapSeederTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use App\Support\TenantDefaults;
 use Tests\TestCase;
 
 class TenantBootstrapSeederTest extends TestCase
@@ -15,9 +16,10 @@ class TenantBootstrapSeederTest extends TestCase
         Artisan::call('db:seed', ['--class' => \Database\Seeders\TenantBootstrapSeeder::class]);
 
         $this->assertDatabaseCount('task_statuses', 4);
+        $first = TenantDefaults::TASK_STATUSES[0];
         $this->assertDatabaseHas('task_statuses', [
-            'slug' => 'todo',
-            'color' => '#9ca3af',
+            'slug' => $first['slug'],
+            'color' => $first['color'],
             'position' => 1,
         ]);
         $this->assertDatabaseHas('task_types', ['name' => 'General Task']);


### PR DESCRIPTION
## Summary
- Add `TenantDefaults::TASK_STATUSES` constant with default task statuses
- Create `TenantSetupService` for seeding default task statuses
- Seed task statuses on tenant creation and in `TenantBootstrapSeeder`
- Update tests to reference shared task status defaults

## Testing
- `composer test` *(fails: file_get_contents(/workspace/asbuild/backend/.env): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd310c43c8323a0e3c4a1d9a4d972