### PR TITLE
Apply default status flow when TaskType fields omitted

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskTypeController.php
+++ b/backend/app/Http/Controllers/Api/TaskTypeController.php
@@ -7,6 +7,8 @@ use App\Http\Requests\TaskTypeRequest;
 use App\Http\Resources\TaskTypeResource;
 use App\Models\TaskType;
 use App\Services\FormSchemaService;
+use App\Services\StatusFlowService;
+use App\Support\TenantDefaults;
 use App\Support\ListQuery;
 use Illuminate\Http\Request;
 
@@ -67,6 +69,17 @@ class TaskTypeController extends Controller
             $this->formSchemaService->validate($data['schema_json']);
         }
 
+        if (! array_key_exists('statuses', $data)) {
+            $data['statuses'] = array_fill_keys(
+                array_column(TenantDefaults::TASK_STATUSES, 'slug'),
+                []
+            );
+        }
+
+        if (! array_key_exists('status_flow_json', $data)) {
+            $data['status_flow_json'] = StatusFlowService::DEFAULT_TRANSITIONS;
+        }
+
         if ($request->user()->hasRole('SuperAdmin')) {
             $data['tenant_id'] = $data['tenant_id'] ?? null;
         } else {
@@ -92,6 +105,17 @@ class TaskTypeController extends Controller
         $data = $request->validated();
         if (isset($data['schema_json'])) {
             $this->formSchemaService->validate($data['schema_json']);
+        }
+
+        if (! array_key_exists('statuses', $data)) {
+            $data['statuses'] = $taskType->statuses ?? array_fill_keys(
+                array_column(TenantDefaults::TASK_STATUSES, 'slug'),
+                []
+            );
+        }
+
+        if (! array_key_exists('status_flow_json', $data)) {
+            $data['status_flow_json'] = $taskType->status_flow_json ?? StatusFlowService::DEFAULT_TRANSITIONS;
         }
 
         if ($request->user()->hasRole('SuperAdmin')) {

--- a/backend/app/Http/Requests/TaskTypeRequest.php
+++ b/backend/app/Http/Requests/TaskTypeRequest.php
@@ -19,8 +19,8 @@ class TaskTypeRequest extends FormRequest
         return [
             'name' => [$required, 'string', 'max:255'],
             'schema_json' => ['nullable', 'json'],
-            'statuses' => [$required, 'json'],
-            'status_flow_json' => ['nullable', 'json'],
+            'statuses' => ['sometimes', 'json'],
+            'status_flow_json' => ['sometimes', 'json'],
             'tenant_id' => ['sometimes', 'integer'],
             'abilities_json' => ['nullable', 'json'],
         ];


### PR DESCRIPTION
## Summary
- Make `statuses` and `status_flow_json` optional in `TaskTypeRequest`
- Populate missing task type statuses and transitions with default slugs and transitions
- Preserve defaults during task type updates

## Testing
- `composer test` *(fails: Tests: 20 failed, 93 warnings, 6 incomplete, 7 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68bdd81f52648323b54037930839f6d8