### PR TITLE
Align tests and docs with new task status workflow

### DIFF
--- a/backend/tests/Feature/TaskReportsTest.php
+++ b/backend/tests/Feature/TaskReportsTest.php
@@ -42,7 +42,7 @@ class TaskReportsTest extends TestCase
         Sanctum::actingAs($user);
 
         $type = TaskType::create(['name' => 'Type', 'tenant_id' => $tenant->id]);
-        $status = TaskStatus::create(['slug' => 'done', 'name' => 'Done', 'tenant_id' => $tenant->id]);
+        $status = TaskStatus::create(['slug' => 'completed', 'name' => 'Completed', 'tenant_id' => $tenant->id]);
 
         Task::create([
             'tenant_id' => $tenant->id,

--- a/backend/tests/Feature/TaskStatusFlowTest.php
+++ b/backend/tests/Feature/TaskStatusFlowTest.php
@@ -49,10 +49,11 @@ class TaskStatusFlowTest extends TestCase
         $type = TaskType::create([
             'name' => 'Type',
             'tenant_id' => 1,
-            'statuses' => ['draft' => [], 'assigned' => [], 'completed' => []],
+            'statuses' => ['draft' => [], 'assigned' => [], 'in_progress' => [], 'completed' => []],
             'status_flow_json' => [
                 ['draft', 'assigned'],
-                ['assigned', 'completed'],
+                ['assigned', 'in_progress'],
+                ['in_progress', 'completed'],
             ],
         ]);
 
@@ -93,7 +94,7 @@ class TaskStatusFlowTest extends TestCase
         $type = TaskType::create([
             'name' => 'Type',
             'tenant_id' => 1,
-            'statuses' => ['draft' => [], 'assigned' => [], 'completed' => []],
+            'statuses' => ['draft' => [], 'assigned' => [], 'in_progress' => [], 'completed' => []],
             'status_flow_json' => null,
         ]);
         $task = Task::create([
@@ -121,11 +122,13 @@ class TaskStatusFlowTest extends TestCase
             'statuses' => [
                 ['slug' => 'draft'],
                 ['slug' => 'assigned'],
+                ['slug' => 'in_progress'],
                 ['slug' => 'completed'],
             ],
             'status_flow_json' => [
                 [ ['slug' => 'draft'], ['slug' => 'assigned'] ],
-                [ ['slug' => 'assigned'], ['slug' => 'completed'] ],
+                [ ['slug' => 'assigned'], ['slug' => 'in_progress'] ],
+                [ ['slug' => 'in_progress'], ['slug' => 'completed'] ],
             ],
         ]);
         $task = Task::create([

--- a/backend/tests/Feature/TaskSubtaskTest.php
+++ b/backend/tests/Feature/TaskSubtaskTest.php
@@ -43,15 +43,20 @@ class TaskSubtaskTest extends TestCase
         $type = TaskType::create([
             'name' => 'T',
             'tenant_id' => 1,
-            'statuses' => ['draft' => [], 'completed' => []],
-            'status_flow_json' => [ ['draft', 'completed'] ],
+            'statuses' => ['draft' => [], 'assigned' => [], 'in_progress' => [], 'completed' => []],
+            'status_flow_json' => [
+                ['draft', 'assigned'],
+                ['assigned', 'in_progress'],
+                ['in_progress', 'completed'],
+            ],
             'require_subtasks_complete' => true,
         ]);
         $this->task = Task::create([
             'tenant_id' => 1,
             'user_id' => $user->id,
             'task_type_id' => $type->id,
-            'status' => 'draft',
+            'status' => 'in_progress',
+            'assigned_user_id' => $user->id,
         ]);
     }
 

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -261,7 +261,7 @@
       "noCondition": "Πάντα",
       "transition": "Μετάβαση",
       "quickPresets": "Γρήγορες προεπιλογές",
-      "presetBasic": "Βασικό: todo → in_progress → completed"
+      "presetBasic": "Βασικό: draft → assigned → in_progress → completed"
     },
     "form": {
       "name": "Όνομα",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -261,7 +261,7 @@
       "noCondition": "Always",
       "transition": "Transition",
       "quickPresets": "Quick presets",
-      "presetBasic": "Basic: todo → in_progress → completed"
+      "presetBasic": "Basic: draft → assigned → in_progress → completed"
     },
     "form": {
       "name": "Name",


### PR DESCRIPTION
## Summary
- update feature tests to use draft → assigned → in_progress → completed workflow
- replace 'done' status with 'completed' in reports and automations
- refresh i18n snippets to describe new four-step workflow

## Testing
- `composer test` *(fails: TaskTypeBuilderTest > store task type with abilities, TaskTypeBuilderTest > store task type with role permissions, TaskTypeBuilderTest > permissions persist on edit, TaskTypeOptionsTest > tasks create user can create task, TaskTypePreviewValidationTest > preview validation endpoint, TypePermissionsI18nTest > select tenant message translations exist, UploadControllerTest > chunk validates mime and size, etc.)*
- `npm test` *(fails: playwright browsers missing and 8 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bddff877588323908b04239c29fe50