### PR TITLE
Fix task creation redirect for nested API response

### DIFF
--- a/frontend/src/views/tasks/TaskForm.vue
+++ b/frontend/src/views/tasks/TaskForm.vue
@@ -394,9 +394,10 @@ const submitForm = handleSubmit(async () => {
           : undefined;
       const res = await api.post('/tasks', payload, { headers });
       notify.success('Task created');
+      const taskId = res.data?.data?.id ?? res.data?.id;
       router.push({
         name: 'tasks.details',
-        params: { id: res.data.id },
+        params: { id: taskId },
       });
     }
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- read nested ID from task creation API response before redirecting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0502264408323b3b75b8457315a0f