### PR TITLE
Fix board filter priority key and remove store warning

### DIFF
--- a/frontend/src/components/Board/BoardFilters.vue
+++ b/frontend/src/components/Board/BoardFilters.vue
@@ -95,7 +95,7 @@ const assigneeOptions = ref<Option[]>([]);
 const taskTypeOptions = ref<Option[]>([]);
 const priorityOptions: Option[] = [
   { value: 'low', label: t('tasks.priority.low') },
-  { value: 'medium', label: t('tasks.priority.medium') },
+  { value: 'normal', label: t('tasks.priority.normal') },
   { value: 'high', label: t('tasks.priority.high') },
 ];
 const slaOptions: Option[] = [

--- a/frontend/src/components/ui/Card/index.vue
+++ b/frontend/src/components/ui/Card/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     v-if="!overlay"
-    v-bind="attrs"
     :class="cn('card rounded-md bg-white dark:bg-slate-800 shadow-base', props.class)"
   >
     <div :class="cn('card-body flex flex-col', bodyClass)">
@@ -51,7 +50,6 @@
   </div>
   <div
     v-else
-    v-bind="attrs"
     :class="cn('rounded-md overlay bg-no-repeat bg-center bg-cover card', customClass)"
     :style="{
       backgroundImage: 'url(' + `${img}` + ')',
@@ -78,7 +76,6 @@
   </div>
 </template>
 <script setup>
-import { useAttrs } from 'vue';
 import { cn } from "@/lib/utils";
 const props = defineProps({
   class: {
@@ -138,8 +135,6 @@ const props = defineProps({
     default: "",
   },
 });
-const attrs = useAttrs();
-defineOptions({ inheritAttrs: false });
 </script>
 <style lang="scss" scoped>
 .card-title {


### PR DESCRIPTION
## Summary
- use existing `normal` priority key in board filters
- drop attrs binding from Card component to avoid `$store` template warnings

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68c05772da4483238299a5ed4f7228e0