### PR TITLE
Fix tenant impersonation from header

### DIFF
--- a/frontend/src/components/admin/TenantSwitcher.vue
+++ b/frontend/src/components/admin/TenantSwitcher.vue
@@ -14,10 +14,12 @@
 import { onMounted, ref, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useTenantStore } from '@/stores/tenant';
+import { useAuthStore } from '@/stores/auth';
 import Select from '@dc/components/Select';
 
 const { t } = useI18n();
 const tenantStore = useTenantStore();
+const authStore = useAuthStore();
 const selected = ref<string | number | null>(tenantStore.currentTenantId);
 const options = computed(() =>
   tenantStore.tenants.map((t) => ({ value: String(t.id), label: t.name })),
@@ -29,10 +31,11 @@ onMounted(async () => {
   }
 });
 
-watch(selected, (val) => {
+watch(selected, async (val) => {
   const tenant = tenantStore.tenants.find((t) => String(t.id) === String(val));
-  if (tenant) {
-    tenantStore.setTenant(tenant.id);
+  if (tenant && String(tenant.id) !== tenantStore.currentTenantId) {
+    await authStore.impersonate(tenant.id, tenant.name);
+    window.location.reload();
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- trigger tenant impersonation when selecting from header dropdown

## Testing
- `npm run lint`
- `npm test`
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c058e9bac48323a5cbc80845895513