### PR TITLE
feat: disable impersonation on task board tenant switch

### DIFF
--- a/frontend/src/components/admin/TenantSwitcher.vue
+++ b/frontend/src/components/admin/TenantSwitcher.vue
@@ -20,6 +20,9 @@ import Select from '@dc/components/Select';
 const { t } = useI18n();
 const tenantStore = useTenantStore();
 const authStore = useAuthStore();
+const props = defineProps({
+  impersonate: { type: Boolean, default: true },
+});
 const selected = ref<string | number | null>(tenantStore.currentTenantId);
 const options = computed(() =>
   tenantStore.tenants.map((t) => ({ value: String(t.id), label: t.name })),
@@ -34,8 +37,12 @@ onMounted(async () => {
 watch(selected, async (val) => {
   const tenant = tenantStore.tenants.find((t) => String(t.id) === String(val));
   if (tenant && String(tenant.id) !== tenantStore.currentTenantId) {
-    await authStore.impersonate(tenant.id, tenant.name);
-    window.location.reload();
+    if (props.impersonate) {
+      await authStore.impersonate(tenant.id, tenant.name);
+      window.location.reload();
+    } else {
+      tenantStore.setTenant(tenant.id);
+    }
   }
 });
 </script>

--- a/frontend/src/views/tasks/BoardView.vue
+++ b/frontend/src/views/tasks/BoardView.vue
@@ -2,7 +2,7 @@
   <div class="p-4">
     <div class="flex items-center justify-between mb-4">
       <h1 class="text-xl font-semibold">{{ t('routes.taskBoard') }}</h1>
-      <TenantSwitcher v-if="auth.isSuperAdmin" />
+      <TenantSwitcher v-if="auth.isSuperAdmin" :impersonate="false" />
     </div>
     <BoardFilters v-model="prefs.filters" />
     <QuickFilterChips v-model="prefs.filters" class="mt-4" />


### PR DESCRIPTION
## Summary
- allow TenantSwitcher to optionally skip impersonation
- task board tenant dropdown now just switches data without impersonating

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c05beec66c8323a79d8b7dba74b0ca