### PR TITLE
fix: guard missing task title

### DIFF
--- a/frontend/src/views/tasks/TaskCard.vue
+++ b/frontend/src/views/tasks/TaskCard.vue
@@ -131,13 +131,16 @@ const auth = useAuthStore();
 
 const statusOptions = computed(() => props.columns.map((c) => c.status));
 
-const titleInitials = computed(() =>
-  props.task.title
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .slice(0, 2),
-);
+const titleInitials = computed(() => {
+  const title = props.task.title;
+  return title
+    ? title
+        .split(' ')
+        .map((n) => n[0])
+        .join('')
+        .slice(0, 2)
+    : '';
+});
 
 const assigneeInitials = computed(() =>
   props.task.assignee?.name


### PR DESCRIPTION
## Summary
- ensure task board cards handle missing titles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05d5772b08323b0b002357ce80a89