### PR TITLE
feat(task-board): honor task-type transitions

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskBoardController.php
+++ b/backend/app/Http/Controllers/Api/TaskBoardController.php
@@ -72,7 +72,10 @@ class TaskBoardController extends Controller
             $filters->apply($query, $request);
 
             $total = (clone $query)->count();
-            $tasks = $query->orderBy('board_position')->limit($limit + 1)->get();
+            $tasks = $query->with('type')
+                ->orderBy('board_position')
+                ->limit($limit + 1)
+                ->get();
 
             $hasMore = $tasks->count() > $limit;
             $tasks = $tasks->take($limit);
@@ -124,7 +127,8 @@ class TaskBoardController extends Controller
         $filters->apply($query, $request);
 
         $total = (clone $query)->count();
-        $tasks = $query->orderBy('board_position')
+        $tasks = $query->with('type')
+            ->orderBy('board_position')
             ->offset($offset)
             ->limit($limit + 1)
             ->get();
@@ -163,6 +167,6 @@ class TaskBoardController extends Controller
 
         $positions->move($task, $status->slug, $data['index']);
 
-        return new TaskResource($task->fresh());
+        return new TaskResource($task->fresh(['type']));
     }
 }


### PR DESCRIPTION
## Summary
- allow dropping tasks into empty columns
- show only permitted transitions and block disallowed moves
- expose task types on board API

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browsers missing)*
- `composer test` *(fails: 20 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c060cfc7d48323a5a13c56668d0bf0