### PR TITLE
Add task type template for rapid creation

### DIFF
--- a/frontend/src/components/types/TemplatesDrawer.vue
+++ b/frontend/src/components/types/TemplatesDrawer.vue
@@ -25,6 +25,14 @@
           @input="onFile"
         />
       </div>
+      <div v-if="exampleTemplates.length">
+        <p class="mb-2">{{ t('templates.examples') }}</p>
+        <ul class="space-y-2">
+          <li v-for="tmpl in exampleTemplates" :key="tmpl.name">
+            <Button :text="tmpl.name" @click="importExample(tmpl.data)" />
+          </li>
+        </ul>
+      </div>
       <Button
         btn-class="btn-outline-secondary"
         :text="t('actions.close')"
@@ -43,6 +51,7 @@ import Button from '@/components/ui/Button/index.vue';
 import Fileinput from '@/components/ui/Fileinput/index.vue';
 import { can } from '@/stores/auth';
 import { useTaskTypesStore } from '@/stores/taskTypes';
+import fullTemplate from '../../../../task-types/templates/full-task-type.json';
 
 interface Props {
   open: boolean;
@@ -54,6 +63,7 @@ const emit = defineEmits(['close', 'imported']);
 const exportId = ref<number>();
 const typesStore = useTaskTypesStore();
 const { t } = useI18n();
+const exampleTemplates = [{ name: 'Full Task Type', data: fullTemplate }];
 
 const selectOptions = computed(() =>
   props.types.map((t: any) => ({ value: t.id, label: t.name }))
@@ -82,6 +92,11 @@ async function onFile(file: File) {
   const text = await file.text();
   const json = JSON.parse(text);
   await typesStore.import(json);
+  emit('imported');
+}
+
+async function importExample(data: any) {
+  await typesStore.import(data);
   emit('imported');
 }
 </script>

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -369,7 +369,8 @@
     "title": "Πρότυπα",
     "export": "Εξαγωγή JSON",
     "import": "Εισαγωγή JSON",
-    "selectType": "Επιλέξτε τύπο"
+    "selectType": "Επιλέξτε τύπο",
+    "examples": "Παραδείγματα"
   },
   "Section label": "Ετικέτα ενότητας",
   "Label": "Ετικέτα",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -369,7 +369,8 @@
     "title": "Templates",
     "export": "Export JSON",
     "import": "Import JSON",
-    "selectType": "Select type"
+    "selectType": "Select type",
+    "examples": "Examples"
   },
   "Section label": "Section label",
   "Label": "Label",

--- a/task-types/templates/full-task-type.json
+++ b/task-types/templates/full-task-type.json
@@ -1,0 +1,58 @@
+{
+  "name": "Example Task Type",
+  "schema_json": {
+    "sections": [
+      {
+        "key": "general",
+        "label": "General Information",
+        "fields": [
+          {
+            "key": "title",
+            "label": "Title",
+            "type": "text",
+            "required": true,
+            "help": "Short title of the task"
+          },
+          {
+            "key": "description",
+            "label": "Description",
+            "type": "textarea",
+            "required": false,
+            "help": "Detailed task description"
+          },
+          {
+            "key": "priority",
+            "label": "Priority",
+            "type": "select",
+            "options": [
+              { "value": "low", "label": "Low" },
+              { "value": "medium", "label": "Medium" },
+              { "value": "high", "label": "High" }
+            ],
+            "default": "medium"
+          }
+        ]
+      }
+    ]
+  },
+  "statuses": [
+    { "key": "draft", "label": "Draft" },
+    { "key": "in_progress", "label": "In Progress" },
+    { "key": "blocked", "label": "Blocked" },
+    { "key": "completed", "label": "Completed" }
+  ],
+  "status_flow_json": {
+    "draft": ["in_progress", "blocked"],
+    "in_progress": ["blocked", "completed"],
+    "blocked": ["in_progress"],
+    "completed": []
+  },
+  "require_subtasks_complete": false,
+  "abilities_json": {
+    "read": true,
+    "create": true,
+    "update": true,
+    "delete": false,
+    "assign": true
+  }
+}


### PR DESCRIPTION
## Summary
- add full example task type JSON template
- surface example templates in Task Types sidebar for quick import

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf. Tests: 21 failed)*
- `npm test` *(19 skipped, 55 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c069ec237483239089894dbd70c3f6