### PR TITLE
Add task type template for rapid creation

### DIFF
--- a/frontend/src/components/types/TemplatesDrawer.vue
+++ b/frontend/src/components/types/TemplatesDrawer.vue
@@ -25,6 +25,14 @@
           @input="onFile"
         />
       </div>
+      <div v-if="exampleTemplates.length">
+        <p class="mb-2">{{ t('templates.examples') }}</p>
+        <ul class="space-y-2">
+          <li v-for="tmpl in exampleTemplates" :key="tmpl.name">
+            <Button :text="tmpl.name" @click="importExample(tmpl.data)" />
+          </li>
+        </ul>
+      </div>
       <Button
         btn-class="btn-outline-secondary"
         :text="t('actions.close')"
@@ -43,6 +51,7 @@ import Button from '@/components/ui/Button/index.vue';
 import Fileinput from '@/components/ui/Fileinput/index.vue';
 import { can } from '@/stores/auth';
 import { useTaskTypesStore } from '@/stores/taskTypes';
+import fullTemplate from '../../../../task-types/templates/full-task-type.json';
 
 interface Props {
   open: boolean;
@@ -54,6 +63,7 @@ const emit = defineEmits(['close', 'imported']);
 const exportId = ref<number>();
 const typesStore = useTaskTypesStore();
 const { t } = useI18n();
+const exampleTemplates = [{ name: 'Full Task Type', data: fullTemplate }];
 
 const selectOptions = computed(() =>
   props.types.map((t: any) => ({ value: t.id, label: t.name }))
@@ -82,6 +92,11 @@ async function onFile(file: File) {
   const text = await file.text();
   const json = JSON.parse(text);
   await typesStore.import(json);
+  emit('imported');
+}
+
+async function importExample(data: any) {
+  await typesStore.import(data);
   emit('imported');
 }
 </script>

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -369,7 +369,8 @@
     "title": "Πρότυπα",
     "export": "Εξαγωγή JSON",
     "import": "Εισαγωγή JSON",
-    "selectType": "Επιλέξτε τύπο"
+    "selectType": "Επιλέξτε τύπο",
+    "examples": "Παραδείγματα"
   },
   "Section label": "Ετικέτα ενότητας",
   "Label": "Ετικέτα",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -369,7 +369,8 @@
     "title": "Templates",
     "export": "Export JSON",
     "import": "Import JSON",
-    "selectType": "Select type"
+    "selectType": "Select type",
+    "examples": "Examples"
   },
   "Section label": "Section label",
   "Label": "Label",

--- a/task-types/templates/full-task-type.json
+++ b/task-types/templates/full-task-type.json
@@ -1,0 +1,157 @@
+{
+  "name": "Example Task Type",
+  "schema_json": {
+    "sections": [
+      {
+        "key": "general",
+        "label": "General Information",
+        "fields": [
+          {
+            "key": "title",
+            "label": "Title",
+            "type": "text",
+            "required": true,
+            "help": "Short title of the task",
+            "validations": { "min": 3, "max": 100 }
+          },
+          {
+            "key": "description",
+            "label": "Description",
+            "type": "textarea",
+            "required": true,
+            "help": "Detailed task description",
+            "validations": { "max": 1000 }
+          },
+          {
+            "key": "priority",
+            "label": "Priority",
+            "type": "select",
+            "enum": ["low", "medium", "high", "urgent"],
+            "options": [
+              { "value": "low", "label": "Low" },
+              { "value": "medium", "label": "Medium" },
+              { "value": "high", "label": "High" },
+              { "value": "urgent", "label": "Urgent" }
+            ],
+            "default": "medium",
+            "required": true
+          },
+          {
+            "key": "due_date",
+            "label": "Due Date",
+            "type": "date",
+            "required": true
+          },
+          {
+            "key": "start_time",
+            "label": "Start Time",
+            "type": "time",
+            "required": false
+          },
+          {
+            "key": "estimate_hours",
+            "label": "Estimated Hours",
+            "type": "number",
+            "required": true,
+            "validations": { "min": 1, "max": 100 }
+          },
+          {
+            "key": "approved",
+            "label": "Approved",
+            "type": "boolean",
+            "required": false,
+            "default": false
+          },
+          {
+            "key": "assignee",
+            "label": "Assignee",
+            "type": "assignee",
+            "required": true
+          },
+          {
+            "key": "serial_number",
+            "label": "Serial Number",
+            "type": "text",
+            "required": true,
+            "help": "Unique identifier",
+            "validations": { "unique": true, "regex": "^[A-Z0-9-]+$" }
+          }
+        ]
+      },
+      {
+        "key": "photos",
+        "label": "Photos",
+        "fields": [
+          {
+            "key": "before_photo",
+            "label": "Before Photo",
+            "type": "photo_single",
+            "required": false
+          },
+          {
+            "key": "after_photos",
+            "label": "After Photos",
+            "type": "photo_repeater",
+            "required": false,
+            "validations": { "max": 5 }
+          }
+        ]
+      }
+    ]
+  },
+  "statuses": {
+    "draft": [],
+    "assigned": [],
+    "in_progress": [],
+    "blocked": [],
+    "review": [],
+    "completed": [],
+    "rejected": [],
+    "redo": []
+  },
+  "status_flow_json": {
+    "draft": ["assigned", "blocked"],
+    "assigned": ["in_progress", "blocked"],
+    "in_progress": ["review", "blocked"],
+    "blocked": ["assigned"],
+    "review": ["completed", "redo", "rejected"],
+    "redo": ["in_progress"],
+    "rejected": [],
+    "completed": []
+  },
+  "require_subtasks_complete": true,
+  "abilities_json": {
+    "tenant": {
+      "read": true,
+      "edit": true,
+      "delete": true,
+      "export": true,
+      "assign": true,
+      "transition": true
+    },
+    "manager": {
+      "read": true,
+      "edit": true,
+      "delete": true,
+      "export": true,
+      "assign": true,
+      "transition": true
+    },
+    "agent": {
+      "read": true,
+      "edit": true,
+      "delete": false,
+      "export": false,
+      "assign": false,
+      "transition": true
+    },
+    "viewer": {
+      "read": true,
+      "edit": false,
+      "delete": false,
+      "export": false,
+      "assign": false,
+      "transition": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand example task type template with diverse fields and validations
- enumerate full status flow and enable subtask enforcement
- detail role-based permissions for tenant, manager, agent, and viewer

## Testing
- `npm test`
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c069ec237483239089894dbd70c3f6