### PR TITLE
Handle tenant load errors and fix task list status

### DIFF
--- a/frontend/src/stores/tenant.ts
+++ b/frontend/src/stores/tenant.ts
@@ -19,22 +19,30 @@ export const useTenantStore = defineStore('tenant', {
   },
   actions: {
     async loadTenants(params: ListParams = {}) {
-      const { data } = await api.get('/tenants', {
-        params: withListParams(params),
-      });
-      this.tenants = data.data;
-      data.data.forEach((t: any) => {
-        this.setAllowedAbilities(t.id, t.feature_abilities || {});
-      });
+      try {
+        const { data } = await api.get('/tenants', {
+          params: withListParams(params),
+        });
+        this.tenants = data.data;
+        data.data.forEach((t: any) => {
+          this.setAllowedAbilities(t.id, t.feature_abilities || {});
+        });
 
-      if (
-        this.currentTenantId &&
-        !this.tenants.some((t) => String(t.id) === this.currentTenantId)
-      ) {
-        this.setTenant('');
+        if (
+          this.currentTenantId &&
+          !this.tenants.some((t) => String(t.id) === this.currentTenantId)
+        ) {
+          this.setTenant('');
+        }
+
+        return data.meta;
+      } catch (error: any) {
+        if (error?.response?.status === 403) {
+          this.tenants = [];
+          return { total: 0 } as any;
+        }
+        throw error;
       }
-
-      return data.meta;
     },
     async searchTenants(search: string) {
       return this.loadTenants({ search, per_page: 100 });

--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -3,7 +3,7 @@
       <div class="flex items-center justify-end mb-4">
         <Button
           v-if="hasAny(['tasks.create', 'tasks.manage'])"
-          :link="{ name: 'tasks.create' }"
+          link="/tasks/create"
           btnClass="btn-primary flex items-center gap-2"
           icon="heroicons-outline:plus"
           :text="t('tasks.new')"
@@ -386,20 +386,25 @@ async function fetchTasks({ page, perPage, sort, search }: any) {
   }
   const total = rows.length;
   const start = (page - 1) * perPage;
-  const paged = rows.slice(start, start + perPage).map((r) => ({
-    id: r.id,
-    type: r.type?.name || '—',
-    priority: r.priority
-      ? `<span class="badge ${priorityClasses[r.priority] || ''}">${t(`tasks.priority.${r.priority}`)}</span>`
-      : '',
-    status: `<span class="px-2 py-1 rounded-full text-xs font-semibold ${statusClasses[r.status] ?? ''}">${r.status.replace(/_/g, ' ')}</span>`,
-    scheduled_at: r.scheduled_at ? formatDisplay(r.scheduled_at) : '',
-    sla_end_at: r.sla_end_at
-      ? `<span class="badge ${slaBadgeClass(r.sla_end_at)}">${formatDisplay(r.sla_end_at)}</span>`
-      : '',
-    started_at: r.started_at ? formatDisplay(r.started_at) : '',
-    completed_at: r.completed_at ? formatDisplay(r.completed_at) : '',
-  }));
+  const paged = rows.slice(start, start + perPage).map((r) => {
+    const statusKey = typeof r.status === 'string' ? r.status : r.status?.slug || '';
+    const statusLabel =
+      typeof r.status === 'string' ? r.status : r.status?.name || '';
+    return {
+      id: r.id,
+      type: r.type?.name || '—',
+      priority: r.priority
+        ? `<span class="badge ${priorityClasses[r.priority] || ''}">${t(`tasks.priority.${r.priority}`)}</span>`
+        : '',
+      status: `<span class="px-2 py-1 rounded-full text-xs font-semibold ${statusClasses[statusKey] ?? ''}">${statusLabel.replace(/_/g, ' ')}</span>`,
+      scheduled_at: r.scheduled_at ? formatDisplay(r.scheduled_at) : '',
+      sla_end_at: r.sla_end_at
+        ? `<span class="badge ${slaBadgeClass(r.sla_end_at)}">${formatDisplay(r.sla_end_at)}</span>`
+        : '',
+      started_at: r.started_at ? formatDisplay(r.started_at) : '',
+      completed_at: r.completed_at ? formatDisplay(r.completed_at) : '',
+    };
+  });
   return { rows: paged, total };
 }
 

--- a/frontend/tests/unit/stores/tenant.spec.ts
+++ b/frontend/tests/unit/stores/tenant.spec.ts
@@ -53,4 +53,12 @@ describe('tenant store', () => {
     expect(store.setTenant('123')).toBe(true);
     expect(store.setTenant('123')).toBe(false);
   });
+
+  it('handles 403 errors when loading tenants', async () => {
+    const { useTenantStore } = await import('@/stores/tenant');
+    (api.get as any).mockRejectedValue({ response: { status: 403 } });
+    const store = useTenantStore();
+    await expect(store.loadTenants()).resolves.toEqual({ total: 0 });
+    expect(store.tenants).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- Avoid failing when tenant list request returns 403 so tenants can edit types
- Fix task list status rendering for object responses and make new task link valid
- Add unit test for tenant store 403 handling

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c19b04c76c832387c9a1fd1dd91bda