### PR TITLE
Handle tenant load forbidden

### DIFF
--- a/frontend/src/stores/tenant.ts
+++ b/frontend/src/stores/tenant.ts
@@ -37,7 +37,7 @@ export const useTenantStore = defineStore('tenant', {
 
         return data.meta;
       } catch (error: any) {
-        if (error?.response?.status === 403) {
+        if (error?.status === 403) {
           this.tenants = [];
           return { total: 0 } as any;
         }

--- a/frontend/tests/unit/stores/tenant.spec.ts
+++ b/frontend/tests/unit/stores/tenant.spec.ts
@@ -56,7 +56,7 @@ describe('tenant store', () => {
 
   it('handles 403 errors when loading tenants', async () => {
     const { useTenantStore } = await import('@/stores/tenant');
-    (api.get as any).mockRejectedValue({ response: { status: 403 } });
+    (api.get as any).mockRejectedValue({ status: 403 });
     const store = useTenantStore();
     await expect(store.loadTenants()).resolves.toEqual({ total: 0 });
     expect(store.tenants).toEqual([]);


### PR DESCRIPTION
## Summary
- handle 403 errors when loading tenants without throwing
- update tenant store tests for new error shape

## Testing
- `pnpm run lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c19facfb7883238df6a04bdfacdeb5