### PR TITLE
Restrict tenant selection to super admins

### DIFF
--- a/frontend/src/components/types/TypeMetaBar.vue
+++ b/frontend/src/components/types/TypeMetaBar.vue
@@ -9,6 +9,7 @@
         classInput="text-sm"
       />
       <VueSelect
+        v-if="props.showTenantSelect"
         class="flex-1 min-w-[150px]"
         :label="t('types.form.tenant')"
       >
@@ -42,7 +43,10 @@ interface Option {
   label: string;
 }
 
-const props = defineProps<{ name: string; tenantId: number | '' }>();
+const props = withDefaults(
+  defineProps<{ name: string; tenantId: number | ''; showTenantSelect?: boolean }>(),
+  { showTenantSelect: true },
+);
 const emit = defineEmits<{
   (e: 'update:name', value: string): void;
   (e: 'update:tenantId', value: number | ''): void;


### PR DESCRIPTION
## Summary
- Allow only super administrators to load tenant list and choose tenants in type builder
- Default tenant ID for non-super administrators to their own tenant
- Hide tenant selector for non-super administrators

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a13621688323b2ebd9b7f0a82a64