### PR TITLE
feat: guard privileged API calls with ability checks

### DIFF
--- a/frontend/src/utils/ability.ts
+++ b/frontend/src/utils/ability.ts
@@ -1,0 +1,11 @@
+import { useAuthStore } from '@/stores/auth';
+
+/**
+ * Check if the current user has the given ability.
+ * Components should consult this before calling privileged endpoints.
+ */
+export function hasAbility(ability: string): boolean {
+  return useAuthStore().can(ability);
+}
+
+export default hasAbility;

--- a/frontend/src/views/tenants/TenantDetails.vue
+++ b/frontend/src/views/tenants/TenantDetails.vue
@@ -24,11 +24,13 @@ import { useRoute } from 'vue-router';
 import api from '@/services/api';
 import Button from '@/components/ui/Button/index.vue';
 import { can } from '@/stores/auth';
+import hasAbility from '@/utils/ability';
 
 const route = useRoute();
 const tenant = ref<any>(null);
 
 onMounted(async () => {
+  if (!hasAbility('tenants.view') && !hasAbility('tenants.manage')) return;
   const { data } = await api.get(`/tenants/${route.params.id}`);
   tenant.value = data;
 });

--- a/frontend/src/views/tenants/TenantForm.vue
+++ b/frontend/src/views/tenants/TenantForm.vue
@@ -64,7 +64,7 @@ import VueSelect from '@/components/ui/Select/VueSelect.vue';
 import vSelect from 'vue-select';
 import { useForm } from 'vee-validate';
 import { useTenantStore } from '@/stores/tenant';
-import { can } from '@/stores/auth';
+import hasAbility from '@/utils/ability';
 import { featureMap } from '@/constants/featureMap';
 
 const route = useRoute();
@@ -73,7 +73,10 @@ const isEdit = computed(() => route.name === 'tenants.edit');
 const tenantStore = useTenantStore();
 
 const canAccess = computed(
-  () => can('tenants.create') || can('tenants.update') || can('tenants.manage'),
+  () =>
+    hasAbility('tenants.create') ||
+    hasAbility('tenants.update') ||
+    hasAbility('tenants.manage'),
 );
 
 const form = ref({
@@ -93,6 +96,7 @@ const serverError = ref('');
 const { handleSubmit, setErrors, errors } = useForm();
 
 onMounted(async () => {
+  if (!canAccess.value) return;
   try {
     const { data: features } = await api.get('/lookups/features');
     featureOptions.value = features.map((f: any) => ({
@@ -126,6 +130,7 @@ onMounted(async () => {
 
 const onSubmit = handleSubmit(async () => {
   serverError.value = '';
+  if (!canAccess.value) return;
   if (!isEdit.value && form.value.features.length === 0) {
     form.value.features = ['tasks'];
   }

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -52,6 +52,7 @@ import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue'
 import Button from '@/components/ui/Button/index.vue';
 import api from '@/services/api';
 import { useAuthStore, can } from '@/stores/auth';
+import hasAbility from '@/utils/ability';
 
 const auth = useAuthStore();
 const router = useRouter();
@@ -67,6 +68,9 @@ const columns = [
 ];
 
 async function fetchTenants({ page, perPage, sort, search }: any) {
+  if (!hasAbility('tenants.view') && !hasAbility('tenants.manage')) {
+    return { rows: [], total: 0 };
+  }
   if (!all.value.length) {
     // The tenants API responds with an object containing
     // `{ data: Tenant[], meta: PaginationMeta }`. We only need the
@@ -102,6 +106,7 @@ function reload() {
 }
 
 async function impersonate(t: any) {
+  if (!hasAbility('tenants.manage')) return;
   await auth.impersonate(t.id, t.name);
   window.location.reload();
 }
@@ -111,6 +116,7 @@ function view(id: number) {
 }
 
 async function remove(id: number) {
+  if (!hasAbility('tenants.delete') && !hasAbility('tenants.manage')) return;
   const result = await swal?.fire({
     title: 'Delete tenant?',
     icon: 'warning',


### PR DESCRIPTION
## Summary
- add hasAbility utility to check abilities
- skip tenant and task type API calls when lacking required permissions

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68c1a24335ec83239889a6a5ffeb2a84