### PR TITLE
Expand role and task type ability mappings

### DIFF
--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -36,6 +36,9 @@ return [
         'label' => 'Roles & Permissions',
         'abilities' => [
             'roles.view',
+            'roles.create',
+            'roles.update',
+            'roles.delete',
             'roles.manage',
         ],
     ],
@@ -47,6 +50,7 @@ return [
             'task_types.update',
             'task_types.delete',
             'task_types.manage',
+            'task_sla_policies.manage',
             'task_automations.manage',
             'task_field_snippets.manage',
         ],

--- a/frontend/src/constants/featureMap.ts
+++ b/frontend/src/constants/featureMap.ts
@@ -26,12 +26,23 @@ export const featureMap: Record<string, { label: string; abilities: string[] }> 
   },
   roles: {
     label: 'Roles & Permissions',
-    abilities: ['roles.view', 'roles.manage'],
+    abilities: [
+      'roles.view',
+      'roles.create',
+      'roles.update',
+      'roles.delete',
+      'roles.manage',
+    ],
   },
   task_types: {
     label: 'Task Types',
     abilities: [
+      'task_types.view',
+      'task_types.create',
+      'task_types.update',
+      'task_types.delete',
       'task_types.manage',
+      'task_sla_policies.manage',
       'task_automations.manage',
       'task_field_snippets.manage',
     ],


### PR DESCRIPTION
## Summary
- include create/update/delete abilities in roles feature map
- expose full task-type abilities including SLA policies

## Testing
- `composer test` *(fails: file_get_contents(/workspace/asbuild/backend/.env): Failed to open stream: No such file or directory)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1a49e99fc8323a0703210465776e7