### PR TITLE
Add permission-aware role loading in TypeForm

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -275,6 +275,7 @@
     "saveToConfigureSLA": "Αποθηκεύστε για να ρυθμίσετε τις Πολιτικές SLA",
     "saveToConfigureAutomations": "Αποθηκεύστε για να ρυθμίσετε Αυτοματισμούς",
     "selectTenantToSetPermissions": "Επιλέξτε μισθωτή για να ορίσετε δικαιώματα",
+    "noRolesPermissions": "Δεν έχετε δικαίωμα προβολής ρόλων",
     "noSLAPermissions": "Δεν έχετε δικαίωμα διαχείρισης Πολιτικών SLA",
     "noAutomationsPermissions": "Δεν έχετε δικαίωμα διαχείρισης Αυτοματισμών"
   },

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -275,6 +275,7 @@
     "saveToConfigureSLA": "Save to configure SLA policies",
     "saveToConfigureAutomations": "Save to configure automations",
     "selectTenantToSetPermissions": "Select tenant to set permissions",
+    "noRolesPermissions": "You do not have permission to view roles",
     "noSLAPermissions": "You do not have permission to manage SLA policies",
     "noAutomationsPermissions": "You do not have permission to manage automations"
   },


### PR DESCRIPTION
## Summary
- compute `canViewRoles` to gate role visibility
- show friendly message when roles are hidden
- load roles only when permitted

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aebee5a0832383fa1e22de861de0