### PR TITLE
Check team permissions before loading automations

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -500,7 +500,7 @@ const canManageSLA = computed(
   () => auth.isSuperAdmin || can('task_sla_policies.manage'),
 );
 const canManageAutomations = computed(
-  () => auth.isSuperAdmin || can('task_automations.manage'),
+  () => auth.isSuperAdmin || (can('task_automations.manage') && can('teams.view')),
 );
 const isFormValid = computed(() => name.value.trim().length > 0 && tenantId.value !== '');
 


### PR DESCRIPTION
## Summary
- Guard automations editor against missing team view permission and load teams conditionally
- Require `teams.view` to access automations editor in TypeForm

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1af90e5a08323b073a2443512508a