### PR TITLE
Fix infinite redirect on unauthorized access

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -604,18 +604,18 @@ router.beforeEach(async (to, from, next) => {
   }
 
   if (to.meta.admin && !auth.isSuperAdmin) {
-    return next('/');
+    return next('/not-found');
   }
 
   if (to.meta.requiredAbilities?.length && !auth.hasAny(to.meta.requiredAbilities)) {
-    return next('/');
+    return next('/not-found');
   }
 
   if (
     to.meta.requiredFeatures?.length &&
     !to.meta.requiredFeatures.every((f) => auth.features.includes(f))
   ) {
-    return next('/');
+    return next('/not-found');
   }
 
   if (to.path === '/auth/login' && auth.isAuthenticated) {


### PR DESCRIPTION
## Summary
- Avoid infinite redirect loop by sending unauthorized users to `/not-found`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b2d6cc9c83238329e8742c7b4c98