### PR TITLE
fix status route intercept in e2e test

### DIFF
--- a/frontend/tests/e2e/status-flow-editor.spec.ts
+++ b/frontend/tests/e2e/status-flow-editor.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('selecting a tenant loads statuses and leaves transitions empty', async ({ page }) => {
-  await page.route('**/task-statuses', (route) => {
+  await page.route(/\/task-statuses\?.*/, (route) => {
     const url = new URL(route.request().url());
     const tenantId = url.searchParams.get('tenant_id');
     const data = tenantId === '2'


### PR DESCRIPTION
## Summary
- match `/task-statuses` requests with query strings in status flow editor e2e test

## Testing
- `npx playwright test tests/e2e/status-flow-editor.spec.ts` *(fails: locator('#statuses li') expected count 2, received 0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5393600288323af7a66567c3caf4b