### PR TITLE
feat(types): restrict copy to super admin

### DIFF
--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -59,7 +59,7 @@
                     @click="$emit('copy', rowProps.row.id)"
                   >
                     <span class="text-base"><Icon icon="heroicons-outline:document-duplicate" /></span>
-                    <span>{{ t('actions.copy') }}</span>
+                    <span>{{ t(auth.isSuperAdmin ? 'actions.copy' : 'actions.duplicate') }}</span>
                   </button>
                 </MenuItem>
               </template>
@@ -79,7 +79,7 @@
             class="ml-2 text-primary-500 hover:underline cursor-pointer"
             @click="emit('copy-selected', selectedIds)"
           >
-            {{ t('actions.copy') }}
+            {{ t(auth.isSuperAdmin ? 'actions.copy' : 'actions.duplicate') }}
           </button>
         </template>
         <template #pagination-bottom="pagerProps">
@@ -111,6 +111,7 @@ import Icon from '@/components/ui/Icon';
 import Pagination from '@/components/ui/Pagination';
 import Breadcrumbs from "@/Layout/Breadcrumbs.vue";
 import { useI18n } from 'vue-i18n';
+import { useAuthStore } from '@/stores/auth';
 
 interface TaskType {
   id: number;
@@ -128,6 +129,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+const auth = useAuthStore();
 const searchTerm = ref('');
 const perPage = ref(10);
 const current = ref(1);


### PR DESCRIPTION
## Summary
- show "Copy to tenant" only to super admins; others see "Duplicate"

## Testing
- `pnpm exec eslint src/components/types/TaskTypesTable.vue`
- `pnpm lint` (fails: Attribute order issues)
- `pnpm test` (fails: test command reported failure)
- `composer test` (fails: missing vendor autoload)


------
https://chatgpt.com/codex/tasks/task_e_68c53b5ae0d883239b002236fdb7a9c7