### PR TITLE
Restrict task type bulk copy to authorized tenants

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskTypeController.php
+++ b/backend/app/Http/Controllers/Api/TaskTypeController.php
@@ -8,8 +8,8 @@ use App\Http\Resources\TaskTypeResource;
 use App\Models\TaskType;
 use App\Services\FormSchemaService;
 use App\Services\StatusFlowService;
-use App\Support\TenantDefaults;
 use App\Support\ListQuery;
+use App\Support\TenantDefaults;
 use Illuminate\Http\Request;
 
 class TaskTypeController extends Controller
@@ -206,6 +206,14 @@ class TaskTypeController extends Controller
 
         if (! $tenantId) {
             abort(400, 'tenant_id required');
+        }
+
+        if (! $request->user()->hasRole('SuperAdmin') && $tenantId !== $request->user()->tenant_id) {
+            abort(403);
+        }
+
+        if (! $request->user()->hasRole('SuperAdmin') && $request->user()->rolesForTenant($tenantId)->isEmpty()) {
+            abort(403);
         }
 
         $types = TaskType::query()->whereIn('id', $data['ids'])->get();


### PR DESCRIPTION
## Summary
- ensure `bulkCopyToTenant` only copies task types into the caller's tenant unless SuperAdmin
- block copy unless user has a role in the target tenant
- test tenant admins blocked from copying to other tenants while SuperAdmins can copy anywhere

## Testing
- `php artisan test --filter=TaskTypeBulkActionsTest`
- `php artisan test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*

------
https://chatgpt.com/codex/tasks/task_e_68c53d9a3118832393e87bbd973b206b