### PR TITLE
feat: display status counts for task types

### DIFF
--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -117,6 +117,7 @@ interface TaskType {
   id: number;
   name: string;
   tenant?: { id: number; name: string } | null;
+  statuses?: Record<string, string[]>;
 }
 
 const props = defineProps<{ rows: TaskType[] }>();
@@ -153,16 +154,22 @@ const columns = [
   { label: 'ID', field: 'id' },
   { label: 'Name', field: 'name' },
   { label: 'Tenant', field: 'tenant' },
+  { label: 'Statuses', field: 'statusCount' },
   { label: 'Actions', field: 'actions' },
 ];
 
 const selectedIds = ref<number[]>([]);
 
 const filteredRows = computed(() => {
-  if (!searchTerm.value) return props.rows;
-  return props.rows.filter((r) =>
-    String(r.name).toLowerCase().includes(searchTerm.value.toLowerCase()),
-  );
+  const rows = !searchTerm.value
+    ? props.rows
+    : props.rows.filter((r) =>
+        String(r.name).toLowerCase().includes(searchTerm.value.toLowerCase()),
+      );
+  return rows.map((row) => ({
+    ...row,
+    statusCount: Object.keys(row.statuses ?? {}).length,
+  }));
 });
 
 function onSelectedRowsChange(params: any) {

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -56,7 +56,13 @@
   import { useI18n } from 'vue-i18n';
 
 const router = useRouter();
-const all = ref<any[]>([]);
+interface TaskType {
+  id: number;
+  name: string;
+  tenant?: { id: number; name: string } | null;
+  statuses?: Record<string, string[]>;
+}
+const all = ref<TaskType[]>([]);
 const auth = useAuthStore();
 const tenantStore = useTenantStore();
 const typesStore = useTaskTypesStore();
@@ -68,7 +74,8 @@ const scope: 'tenant' | 'all' = auth.isSuperAdmin ? 'all' : 'tenant';
 
 async function load() {
   const tenantId = auth.isSuperAdmin && scope !== 'all' ? tenantStore.currentTenantId : undefined;
-  all.value = (await typesStore.fetch(scope, tenantId)).data;
+  const { data } = await typesStore.fetch(scope, tenantId);
+  all.value = data.map((t: any) => ({ ...t, statuses: t.statuses }));
   loading.value = false;
 }
 


### PR DESCRIPTION
## Summary
- show status count column in task types table
- keep statuses when fetching types

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before ":class", etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c55f94d7048323a7f55d878991d65c