### PR TITLE
Expose task counts for task types

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskTypeController.php
+++ b/backend/app/Http/Controllers/Api/TaskTypeController.php
@@ -35,7 +35,8 @@ class TaskTypeController extends Controller
     public function index(Request $request)
     {
         // Task types are no longer versioned, so we only eager load the tenant
-        $query = TaskType::query()->with(['tenant']);
+        // and append a count of related tasks
+        $query = TaskType::query()->with(['tenant'])->withCount('tasks');
 
         if ($request->user()->hasRole('SuperAdmin')) {
             $scope = $request->query('scope', 'all');

--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -118,6 +118,7 @@ interface TaskType {
   name: string;
   tenant?: { id: number; name: string } | null;
   statuses?: Record<string, string[]>;
+  tasks_count?: number;
 }
 
 const props = defineProps<{ rows: TaskType[] }>();
@@ -154,6 +155,7 @@ const columns = [
   { label: 'ID', field: 'id' },
   { label: 'Name', field: 'name' },
   { label: 'Tenant', field: 'tenant' },
+  { label: 'Tasks', field: 'tasks_count' },
   { label: 'Statuses', field: 'statusCount' },
   { label: 'Actions', field: 'actions' },
 ];

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1853,6 +1853,7 @@ export interface components {
             status_flow_json?: Record<string, never> | null;
             tenant_id?: number | null;
             abilities_json?: Record<string, never> | null;
+            tasks_count?: number;
         };
         TaskStatus: {
             id?: number;

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -61,6 +61,7 @@ interface TaskType {
   name: string;
   tenant?: { id: number; name: string } | null;
   statuses?: Record<string, string[]>;
+  tasks_count?: number;
 }
 const all = ref<TaskType[]>([]);
 const auth = useAuthStore();
@@ -75,7 +76,11 @@ const scope: 'tenant' | 'all' = auth.isSuperAdmin ? 'all' : 'tenant';
 async function load() {
   const tenantId = auth.isSuperAdmin && scope !== 'all' ? tenantStore.currentTenantId : undefined;
   const { data } = await typesStore.fetch(scope, tenantId);
-  all.value = data.map((t: any) => ({ ...t, statuses: t.statuses }));
+  all.value = data.map((t: any) => ({
+    ...t,
+    statuses: t.statuses,
+    tasks_count: t.tasks_count,
+  }));
   loading.value = false;
 }
 


### PR DESCRIPTION
## Summary
- include tasks count in task type index endpoint
- surface `tasks_count` in API types and table columns
- propagate `tasks_count` through types list view

## Testing
- `composer test` *(fails: The following errors occurred during the last request: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c560b91c608323a0f409bc68e5fdf6