### PR TITLE
feat(types): show updated date

### DIFF
--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -112,6 +112,7 @@ import Pagination from '@/components/ui/Pagination';
 import Breadcrumbs from "@/Layout/Breadcrumbs.vue";
 import { useI18n } from 'vue-i18n';
 import { useAuthStore } from '@/stores/auth';
+import { formatDisplay } from '@/utils/datetime';
 
 interface TaskType {
   id: number;
@@ -119,6 +120,7 @@ interface TaskType {
   tenant?: { id: number; name: string } | null;
   statuses?: Record<string, string[]>;
   tasks_count?: number;
+  updated_at?: string;
 }
 
 const props = defineProps<{ rows: TaskType[] }>();
@@ -157,6 +159,7 @@ const columns = [
   { label: 'Tenant', field: 'tenant' },
   { label: 'Tasks', field: 'tasks_count' },
   { label: 'Statuses', field: 'statusCount' },
+  { label: 'Updated', field: 'updated_at' },
   { label: 'Actions', field: 'actions' },
 ];
 
@@ -171,6 +174,7 @@ const filteredRows = computed(() => {
   return rows.map((row) => ({
     ...row,
     statusCount: Object.keys(row.statuses ?? {}).length,
+    updated_at: row.updated_at ? formatDisplay(row.updated_at) : '',
   }));
 });
 

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -62,6 +62,7 @@ interface TaskType {
   tenant?: { id: number; name: string } | null;
   statuses?: Record<string, string[]>;
   tasks_count?: number;
+  updated_at?: string;
 }
 const all = ref<TaskType[]>([]);
 const auth = useAuthStore();
@@ -80,6 +81,7 @@ async function load() {
     ...t,
     statuses: t.statuses,
     tasks_count: t.tasks_count,
+    updated_at: t.updated_at,
   }));
   loading.value = false;
 }


### PR DESCRIPTION
## Summary
- show updated timestamp in task type table
- keep updated_at from API in types list

## Testing
- `npm run lint` (fails: Attribute order and other existing issues)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5626f16388323a53b6d3565d35d2d