### PR TITLE
feat(frontend): show require-subtasks flag

### DIFF
--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -28,6 +28,14 @@
           <span v-if="rowProps.column.field === 'tenant'">
             {{ rowProps.row.tenant?.name || '—' }}
           </span>
+          <span v-else-if="rowProps.column.field === 'require_subtasks_complete'">
+            <Icon
+              v-if="rowProps.row.require_subtasks_complete"
+              icon="heroicons-outline:check"
+              class="text-success-500"
+            />
+            <span v-else>—</span>
+          </span>
           <span v-else-if="rowProps.column.field === 'actions'">
             <Dropdown classMenuItems=" w-[140px]">
               <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
@@ -121,6 +129,7 @@ interface TaskType {
   statuses?: Record<string, string[]>;
   tasks_count?: number;
   updated_at?: string;
+  require_subtasks_complete?: boolean;
 }
 
 const props = defineProps<{ rows: TaskType[] }>();
@@ -159,6 +168,7 @@ const columns = [
   { label: 'Tenant', field: 'tenant' },
   { label: 'Tasks', field: 'tasks_count' },
   { label: 'Statuses', field: 'statusCount' },
+  { label: 'Subtasks Required', field: 'require_subtasks_complete' },
   { label: 'Updated', field: 'updated_at' },
   { label: 'Actions', field: 'actions' },
 ];

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1854,6 +1854,7 @@ export interface components {
             tenant_id?: number | null;
             abilities_json?: Record<string, never> | null;
             tasks_count?: number;
+            require_subtasks_complete?: boolean;
         };
         TaskStatus: {
             id?: number;

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -63,6 +63,7 @@ interface TaskType {
   statuses?: Record<string, string[]>;
   tasks_count?: number;
   updated_at?: string;
+  require_subtasks_complete?: boolean;
 }
 const all = ref<TaskType[]>([]);
 const auth = useAuthStore();
@@ -82,6 +83,7 @@ async function load() {
     statuses: t.statuses,
     tasks_count: t.tasks_count,
     updated_at: t.updated_at,
+    require_subtasks_complete: t.require_subtasks_complete,
   }));
   loading.value = false;
 }


### PR DESCRIPTION
## Summary
- support `require_subtasks_complete` in frontend TaskType types
- expose "Subtasks Required" column in task types table with checkmark
- include `require_subtasks_complete` when fetching task types list

## Testing
- `pnpm lint` *(fails: Attribute order and accessibility errors in unrelated dashcode components)*
- `pnpm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c563288cd08323a77c567f31d97777