### PR TITLE
feat: use unified table for task statuses

### DIFF
--- a/frontend/src/components/statuses/TaskStatusesTable.vue
+++ b/frontend/src/components/statuses/TaskStatusesTable.vue
@@ -1,0 +1,176 @@
+<template>
+  <Card>
+    <div class="md:flex justify-between pb-6 md:space-y-0 space-y-3 items-center">
+      <Breadcrumbs v-if="!$route.meta.hide" />
+      <div class="flex items-center gap-2">
+        <InputGroup
+          v-model="searchTerm"
+          :placeholder="t('statuses.form.search')"
+          type="text"
+          prependIcon="heroicons-outline:search"
+          merged
+          classInput="text-xs !h-8"
+        />
+        <slot name="header-actions" />
+      </div>
+    </div>
+
+    <vue-good-table
+      :columns="columns"
+      :rows="filteredRows"
+      styleClass="vgt-table bordered centered striped"
+      :pagination-options="{ enabled: true, perPage: perPage }"
+      :search-options="{ enabled: true, externalQuery: searchTerm }"
+      :select-options="selectOptions"
+      @on-selected-rows-change="onSelectedRowsChange"
+    >
+      <template #table-row="rowProps">
+        <span v-if="rowProps.column.field === 'tenant'">
+          {{ rowProps.row.tenant?.name || '—' }}
+        </span>
+        <span v-else-if="rowProps.column.field === 'actions'">
+          <Dropdown classMenuItems=" w-[140px]">
+            <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
+            <template #menus>
+              <MenuItem v-if="can('task_statuses.update') || can('task_statuses.manage')">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('edit', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:pencil-square" /></span>
+                  <span>{{ t('actions.edit') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="can('task_statuses.delete') || can('task_statuses.manage')">
+                <button
+                  type="button"
+                  class="bg-danger-500 text-danger-500 bg-opacity-30 hover:bg-opacity-100 hover:text-white w-full px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('delete', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:trash" /></span>
+                  <span>{{ t('actions.delete') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="(can('task_statuses.create') || can('task_statuses.manage')) && (auth.isSuperAdmin || !rowProps.row.tenant_id)">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('copy', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:document-duplicate" /></span>
+                  <span>{{ t(auth.isSuperAdmin ? 'actions.copy' : 'actions.duplicate') }}</span>
+                </button>
+              </MenuItem>
+            </template>
+          </Dropdown>
+        </span>
+      </template>
+      <template #selected-row-actions>
+        <button
+          v-if="can('task_statuses.delete') || can('task_statuses.manage')"
+          type="button"
+          class="ml-2 text-danger-500 hover:underline cursor-pointer"
+          @click="emit('delete-selected', selectedIds)"
+        >
+          {{ t('actions.delete') }}
+        </button>
+        <button
+          v-if="can('task_statuses.create') || can('task_statuses.manage')"
+          type="button"
+          class="ml-2 text-primary-500 hover:underline cursor-pointer"
+          @click="emit('copy-selected', selectedIds)"
+        >
+          {{ t(auth.isSuperAdmin ? 'actions.copy' : 'actions.duplicate') }}
+        </button>
+      </template>
+      <template #pagination-bottom="pagerProps">
+        <div class="py-4 px-3">
+          <Pagination
+            :total="filteredRows.length"
+            :current="current"
+            :per-page="perPage"
+            :pageRange="pageRange"
+            :pageChanged="pagerProps.pageChanged"
+            :perPageChanged="pagerProps.perPageChanged"
+            :options="perPageOptions"
+            enableSelect
+            @page-changed="current = $event"
+          />
+        </div>
+      </template>
+    </vue-good-table>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { MenuItem } from '@headlessui/vue';
+import Card from '@/components/ui/Card';
+import InputGroup from '@/components/ui/InputGroup';
+import Dropdown from '@/components/ui/Dropdown';
+import Icon from '@/components/ui/Icon';
+import Pagination from '@/components/ui/Pagination';
+import Breadcrumbs from '@/Layout/Breadcrumbs.vue';
+import { useI18n } from 'vue-i18n';
+import { useAuthStore, can } from '@/stores/auth';
+
+interface TaskStatus {
+  id: number;
+  name: string;
+  tenant?: { id: number; name: string } | null;
+  tenant_id?: number | null;
+}
+
+const props = defineProps<{ rows: TaskStatus[] }>();
+const emit = defineEmits<{
+  (e: 'edit', id: number): void;
+  (e: 'delete', id: number): void;
+  (e: 'copy', id: number): void;
+  (e: 'delete-selected', ids: number[]): void;
+  (e: 'copy-selected', ids: number[]): void;
+}>();
+
+const { t } = useI18n();
+const auth = useAuthStore();
+const searchTerm = ref('');
+const perPage = ref(10);
+const current = ref(1);
+const pageRange = ref(5);
+const perPageOptions = [
+  { value: '10', label: '10' },
+  { value: '25', label: '25' },
+  { value: '50', label: '50' },
+];
+
+const selectOptions = {
+  enabled: true,
+  selectOnCheckboxOnly: true,
+  selectionInfoClass: 'custom-class',
+  selectionText: 'rows selected',
+  clearSelectionText: 'clear',
+  selectAllByGroup: true,
+};
+
+const columns = [
+  { label: 'ID', field: 'id' },
+  { label: 'Name', field: 'name' },
+  { label: 'Tenant', field: 'tenant' },
+  { label: 'Actions', field: 'actions' },
+];
+
+const selectedIds = ref<number[]>([]);
+
+const filteredRows = computed(() => {
+  const rows = !searchTerm.value
+    ? props.rows
+    : props.rows.filter((r) =>
+        String(r.name).toLowerCase().includes(searchTerm.value.toLowerCase()),
+      );
+  return rows;
+});
+
+function onSelectedRowsChange(params: any) {
+  selectedIds.value = params.selectedRows.map((r: any) => r.id);
+}
+</script>

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -285,6 +285,12 @@
     "noSLAPermissions": "Δεν έχετε δικαίωμα διαχείρισης Πολιτικών SLA",
     "noAutomationsPermissions": "Δεν έχετε δικαίωμα διαχείρισης Αυτοματισμών"
   },
+  "statuses": {
+    "addStatus": "Προσθήκη κατάστασης",
+    "form": {
+      "search": "Αναζήτηση"
+    }
+  },
   "slaPolicies": {
     "title": "Πολιτικές SLA",
     "priority": "Προτεραιότητα",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -285,6 +285,12 @@
     "noSLAPermissions": "You do not have permission to manage SLA policies",
     "noAutomationsPermissions": "You do not have permission to manage automations"
   },
+  "statuses": {
+    "addStatus": "Add status",
+    "form": {
+      "search": "Search"
+    }
+  },
   "slaPolicies": {
     "title": "SLA Policies",
     "priority": "Priority",

--- a/frontend/src/stores/taskStatuses.ts
+++ b/frontend/src/stores/taskStatuses.ts
@@ -24,5 +24,13 @@ export const useTaskStatusesStore = defineStore('taskStatuses', {
       const { data } = await api.post(`/task-statuses/${id}/copy-to-tenant`, payload);
       return data;
     },
+    async copyManyToTenant(ids: number[], tenantId?: string | number) {
+      for (const id of ids) {
+        await this.copyToTenant(id, tenantId);
+      }
+    },
+    async deleteMany(ids: number[]) {
+      await Promise.all(ids.map((id) => api.delete(`/task-statuses/${id}`)));
+    },
   },
 });

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -1,150 +1,89 @@
 <template>
   <div>
-    <div class="flex items-center justify-between mb-4">
-      <div>
-        <select
-          id="task-statuses-scope"
-          v-model="scope"
-          class="border rounded px-2 py-1"
-          aria-label="Scope"
-          @change="changeScope"
-        >
-          <option v-for="opt in scopeOptions" :key="opt.value" :value="opt.value">
-            {{ opt.label }}
-          </option>
-        </select>
-      </div>
-      <RouterLink
-        v-if="can('task_statuses.create') || can('task_statuses.manage')"
-        class="bg-blue-600 text-white px-4 py-2 rounded flex items-center gap-2"
-        :to="{ name: 'taskStatuses.create' }"
-      >
-        <Icon icon="heroicons-outline:plus" class="w-5 h-5" />
-        Add Status
-      </RouterLink>
-    </div>
-    <DashcodeServerTable
-      :key="tableKey"
-      :columns="columns"
-      :fetcher="fetchStatuses"
+    <TaskStatusesTable
+      v-if="!loading"
+      :rows="all"
+      @edit="edit"
+      @delete="remove"
+      @copy="copy"
+      @delete-selected="removeMany"
+      @copy-selected="copyMany"
     >
-      <template
-        v-if="
-          can('task_statuses.update') ||
-          can('task_statuses.delete') ||
-          can('task_statuses.create') ||
-          can('task_statuses.manage')
-        "
-        #actions="{ row }"
-      >
-        <div class="flex gap-2">
-          <button
-            v-if="can('task_statuses.update') || can('task_statuses.manage')"
-            class="text-blue-600"
-            title="Edit"
-            @click="edit(row.id)"
-          >
-            <Icon icon="heroicons-outline:pencil-square" class="w-5 h-5" />
-          </button>
-          <button
-            v-if="can('task_statuses.delete') || can('task_statuses.manage')"
-            class="text-red-600"
-            title="Delete"
-            @click="remove(row.id)"
-          >
-            <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
-          </button>
-          <button
-            v-if="
-              (can('task_statuses.create') || can('task_statuses.manage')) &&
-              (auth.isSuperAdmin || !row.tenant_id)
-            "
-            class="text-green-600"
-            title="Copy to Tenant"
-            @click="copy(row.id)"
-          >
-            <Icon icon="heroicons-outline:document-duplicate" class="w-5 h-5" />
-          </button>
-        </div>
+      <template #header-actions>
+        <Button
+          v-if="can('task_statuses.create') || can('task_statuses.manage')"
+          link="/task-statuses/create"
+          btnClass="btn-primary btn-sm min-w-[100px]"
+          icon="heroicons-outline:plus"
+          iconClass="w-4 h-4"
+          :text="t('statuses.addStatus')"
+          :aria-label="t('statuses.addStatus')"
+        />
       </template>
-    </DashcodeServerTable>
+    </TaskStatusesTable>
+    <div v-else class="p-4">
+      <SkeletonTable :count="10" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, watch, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
-import DashcodeServerTable from '@/components/datatable/DashcodeServerTable.vue';
+import TaskStatusesTable from '@/components/statuses/TaskStatusesTable.vue';
+import SkeletonTable from '@/components/ui/Skeleton/Table.vue';
+import Button from '@/components/ui/Button';
 import Swal from 'sweetalert2';
-import Icon from '@/components/ui/Icon';
 import api from '@/services/api';
 import { useAuthStore, can } from '@/stores/auth';
 import { useTenantStore } from '@/stores/tenant';
 import { useTaskStatusesStore } from '@/stores/taskStatuses';
+import { useI18n } from 'vue-i18n';
+
+interface TaskStatus {
+  id: number;
+  name: string;
+  tenant?: { id: number; name: string } | null;
+  tenant_id?: number | null;
+}
 
 const router = useRouter();
-const tableKey = ref(0);
-const all = ref<any[]>([]);
+const all = ref<TaskStatus[]>([]);
+const loading = ref(true);
 const scope = ref<'tenant' | 'global' | 'all'>('tenant');
 const auth = useAuthStore();
 const tenantStore = useTenantStore();
 const statusesStore = useTaskStatusesStore();
+const { t } = useI18n();
 
 if (auth.isSuperAdmin) {
   scope.value = 'all';
 }
 
-const scopeOptions = computed(() => {
-  const opts = [
-    { value: 'tenant', label: 'Tenant' },
-    { value: 'all', label: 'All' },
-  ];
-  if (auth.isSuperAdmin) {
-    opts.splice(1, 0, { value: 'global', label: 'Global' });
-  }
-  return opts;
-});
-
-const columns = [
-  { label: 'ID', field: 'id', sortable: true },
-  { label: 'Name', field: 'name', sortable: true },
-];
-
-async function fetchStatuses({ page, perPage, sort, search }: any) {
-  if (!all.value.length) {
-    const tenantId =
-      auth.isSuperAdmin && scope.value !== 'all'
-        ? tenantStore.currentTenantId
-        : undefined;
-    all.value = (await statusesStore.fetch(scope.value, tenantId)).data;
-  }
-  let rows = all.value.slice();
-  if (search) {
-    const q = String(search).toLowerCase();
-    rows = rows.filter((r) => r.name.toLowerCase().includes(q));
-  }
-  if (sort && sort.field) {
-    rows.sort((a: any, b: any) => {
-      const fa = a[sort.field];
-      const fb = b[sort.field];
-      if (fa < fb) return sort.type === 'asc' ? -1 : 1;
-      if (fa > fb) return sort.type === 'asc' ? 1 : -1;
-      return 0;
-    });
-  }
-  const total = rows.length;
-  const start = (page - 1) * perPage;
-  const paged = rows.slice(start, start + perPage);
-  return { rows: paged, total };
+async function load() {
+  const tenantId =
+    auth.isSuperAdmin && scope.value !== 'all'
+      ? tenantStore.currentTenantId
+      : undefined;
+  const { data } = await statusesStore.fetch(scope.value, tenantId);
+  await tenantStore.loadTenants({ per_page: 100 });
+  const tenantMap = tenantStore.tenants.reduce(
+    (acc: Record<number, any>, t: any) => ({ ...acc, [t.id]: t }),
+    {},
+  );
+  all.value = data.map((s: any) => ({
+    ...s,
+    tenant: s.tenant || tenantMap[s.tenant_id] || null,
+  }));
+  loading.value = false;
 }
+
+onMounted(load);
 
 function reload() {
-  tableKey.value++;
-}
-
-function changeScope() {
+  loading.value = true;
   all.value = [];
-  reload();
+  load();
 }
 
 watch(
@@ -169,7 +108,6 @@ async function remove(id: number) {
   });
   if (res.isConfirmed) {
     await api.delete(`/task-statuses/${id}`);
-    all.value = [];
     reload();
   }
 }
@@ -192,7 +130,39 @@ async function copy(id: number) {
     tenantId = res.value;
   }
   await statusesStore.copyToTenant(id, tenantId);
-  all.value = [];
+  reload();
+}
+
+async function removeMany(ids: number[]) {
+  const res = await Swal.fire({
+    title: 'Delete selected statuses?',
+    icon: 'warning',
+    showCancelButton: true,
+  });
+  if (res.isConfirmed) {
+    await statusesStore.deleteMany(ids);
+    reload();
+  }
+}
+
+async function copyMany(ids: number[]) {
+  let tenantId: string | number | undefined;
+  if (auth.isSuperAdmin) {
+    await tenantStore.loadTenants();
+    const inputOptions = tenantStore.tenants.reduce(
+      (acc: any, t: any) => ({ ...acc, [t.id]: t.name }),
+      {},
+    );
+    const res = await Swal.fire({
+      title: 'Copy to tenant',
+      input: 'select',
+      inputOptions,
+      showCancelButton: true,
+    });
+    if (!res.isConfirmed || !res.value) return;
+    tenantId = res.value;
+  }
+  await statusesStore.copyManyToTenant(ids, tenantId);
   reload();
 }
 </script>


### PR DESCRIPTION
## Summary
- reuse task type list table for task statuses with search, per-row actions and bulk operations
- add bulk copy and delete helpers to task status store
- add i18n strings for task status management
- show tenant names in status table and remove scope selector

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before ":class" and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c56886978883239db4b45a43aa36c0