### PR TITLE
feat(frontend): show task status slugs

### DIFF
--- a/frontend/src/components/statuses/TaskStatusesTable.vue
+++ b/frontend/src/components/statuses/TaskStatusesTable.vue
@@ -28,6 +28,9 @@
         <span v-if="rowProps.column.field === 'tenant'">
           {{ rowProps.row.tenant?.name || '—' }}
         </span>
+        <span v-else-if="rowProps.column.field === 'slug'">
+          {{ rowProps.row.slug }}
+        </span>
         <span v-else-if="rowProps.column.field === 'actions'">
           <Dropdown classMenuItems=" w-[140px]">
             <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
@@ -118,6 +121,7 @@ import { useAuthStore, can } from '@/stores/auth';
 interface TaskStatus {
   id: number;
   name: string;
+  slug: string;
   tenant?: { id: number; name: string } | null;
   tenant_id?: number | null;
 }
@@ -155,6 +159,7 @@ const selectOptions = {
 const columns = [
   { label: 'ID', field: 'id' },
   { label: 'Name', field: 'name' },
+  { label: 'Slug', field: 'slug' },
   { label: 'Tenant', field: 'tenant' },
   { label: 'Actions', field: 'actions' },
 ];

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -16,6 +16,7 @@
           :options="tenantOptions"
           class="w-40"
           classInput="text-xs !h-8"
+          aria-label="Tenant filter"
         />
         <Button
           v-if="can('task_statuses.create') || can('task_statuses.manage')"
@@ -51,6 +52,7 @@ import { useI18n } from 'vue-i18n';
 interface TaskStatus {
   id: number;
   name: string;
+  slug: string;
   tenant?: { id: number; name: string } | null;
   tenant_id?: number | null;
 }
@@ -92,8 +94,11 @@ async function load() {
     {},
   );
   all.value = data.map((s: any) => ({
-    ...s,
+    id: s.id,
+    name: s.name,
+    slug: s.slug,
     tenant: s.tenant || tenantMap[s.tenant_id] || null,
+    tenant_id: s.tenant_id,
   }));
   loading.value = false;
 }


### PR DESCRIPTION
## Summary
- display slug column in task statuses table
- include slug when loading statuses

## Testing
- `npm test`
- `npm run lint` *(fails: form-control-has-label and other accessibility warnings)*
- `npx eslint src/components/statuses/TaskStatusesTable.vue src/views/statuses/StatusesList.vue`


------
https://chatgpt.com/codex/tasks/task_e_68c56fb601448323affa4343c773c837