### PR TITLE
feat: allow sorting task statuses by order

### DIFF
--- a/frontend/src/components/statuses/TaskStatusesTable.vue
+++ b/frontend/src/components/statuses/TaskStatusesTable.vue
@@ -129,6 +129,7 @@ interface TaskStatus {
   name: string;
   slug: string;
   color: string;
+  position: number;
   tenant?: { id: number; name: string } | null;
   tenant_id?: number | null;
 }
@@ -165,6 +166,7 @@ const selectOptions = {
 
 const columns = [
   { label: 'ID', field: 'id' },
+  { label: 'Order', field: 'position', type: 'number', sortable: true },
   { label: 'Name', field: 'name' },
   { label: 'Slug', field: 'slug' },
   { label: 'Color', field: 'color' },

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -53,6 +53,8 @@ interface TaskStatus {
   id: number;
   name: string;
   slug: string;
+  color: string;
+  position: number;
   tenant?: { id: number; name: string } | null;
   tenant_id?: number | null;
 }
@@ -97,6 +99,8 @@ async function load() {
     id: s.id,
     name: s.name,
     slug: s.slug,
+    color: s.color,
+    position: s.position,
     tenant: s.tenant || tenantMap[s.tenant_id] || null,
     tenant_id: s.tenant_id,
   }));


### PR DESCRIPTION
## Summary
- add `position` to TaskStatus interface
- show and sort statuses by new Order column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5726db13083239cd363d89840c0c7