### PR TITLE
Expose task counts on task statuses

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskStatusController.php
+++ b/backend/app/Http/Controllers/Api/TaskStatusController.php
@@ -24,7 +24,7 @@ class TaskStatusController extends Controller
         public function index(Request $request)
     {
         $scope = $request->query('scope', $request->user()->hasRole('SuperAdmin') ? 'all' : 'tenant');
-        $query = TaskStatus::query();
+        $query = TaskStatus::query()->withCount('tasks');
 
         if ($scope === 'tenant') {
             $tenantId = $request->query('tenant_id', $request->header('X-Tenant-ID', $request->user()->tenant_id));

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1288,6 +1288,8 @@ components:
           type: string
         position:
           type: integer
+        tasks_count:
+          type: integer
         tenant_id:
           type: integer
           nullable: true

--- a/frontend/src/components/statuses/TaskStatusesTable.vue
+++ b/frontend/src/components/statuses/TaskStatusesTable.vue
@@ -136,6 +136,7 @@ interface TaskStatus {
   slug: string;
   color: string;
   position: number;
+  tasks_count: number;
   created_at: string;
   updated_at: string;
   tenant?: { id: number; name: string } | null;
@@ -178,6 +179,7 @@ const columns = [
   { label: 'Name', field: 'name' },
   { label: 'Slug', field: 'slug' },
   { label: 'Color', field: 'color' },
+  { label: 'Tasks', field: 'tasks_count', type: 'number', sortable: true },
   { label: 'Tenant', field: 'tenant' },
   { label: 'Created', field: 'created_at' },
   { label: 'Updated', field: 'updated_at' },

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -939,7 +939,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        ids: number[];
+                        ids?: number[];
                         tenant_id?: string;
                     };
                 };
@@ -947,7 +947,9 @@ export interface paths {
             responses: {
                 /** @description Task types */
                 201: {
-                    headers: { [name: string]: unknown };
+                    headers: {
+                        [name: string]: unknown;
+                    };
                     content: {
                         "application/json": components["schemas"]["TaskType"][];
                     };
@@ -980,15 +982,21 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        ids: number[];
+                        ids?: number[];
                     };
                 };
             };
             responses: {
                 /** @description Deleted */
                 200: {
-                    headers: { [name: string]: unknown };
-                    content?: never;
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message?: string;
+                        };
+                    };
                 };
             };
         };
@@ -1853,8 +1861,6 @@ export interface components {
             status_flow_json?: Record<string, never> | null;
             tenant_id?: number | null;
             abilities_json?: Record<string, never> | null;
-            tasks_count?: number;
-            require_subtasks_complete?: boolean;
         };
         TaskStatus: {
             id?: number;
@@ -1862,7 +1868,12 @@ export interface components {
             name?: string;
             color?: string;
             position?: number;
+            tasks_count?: number;
             tenant_id?: number | null;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
         };
         Employee: {
             id?: number;

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -55,6 +55,7 @@ interface TaskStatus {
   slug: string;
   color: string;
   position: number;
+  tasks_count: number;
   created_at: string;
   updated_at: string;
   tenant?: { id: number; name: string } | null;
@@ -103,6 +104,7 @@ async function load() {
     slug: s.slug,
     color: s.color,
     position: s.position,
+    tasks_count: s.tasks_count,
     created_at: s.created_at,
     updated_at: s.updated_at,
     tenant: s.tenant || tenantMap[s.tenant_id] || null,


### PR DESCRIPTION
## Summary
- include task counts on task status index
- document tasks_count in OpenAPI and regenerate TS types
- show tasks_count in task status list

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before ":class"; Form label must have an associated control, and more)*
- `php artisan test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf)*

------
https://chatgpt.com/codex/tasks/task_e_68c5744b642c832380d5726f90970af0