### PR TITLE
fix: add missing tenants translation

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -61,6 +61,7 @@
   },
   "Version": "Έκδοση",
   "Section": "Ενότητα",
+  "tenants": "Μισθωτές",
   "routes": {
     "dashboard": "Πίνακας ελέγχου",
     "tasks": "Εργασίες",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -61,6 +61,7 @@
   },
   "Version": "Version",
   "Section": "Section",
+  "tenants": "Tenants",
   "routes": {
     "dashboard": "Dashboard",
     "tasks": "Tasks",


### PR DESCRIPTION
## Summary
- add top-level `tenants` translation for English and Greek locales to fix i18n warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5780620748323b0c5faf18d8f8f6f