### PR TITLE
feat: localize tenant filter label

### DIFF
--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -62,6 +62,7 @@
   "Version": "Έκδοση",
   "Section": "Ενότητα",
   "tenants": "Μισθωτές",
+  "allTenants": "Όλοι οι μισθωτές",
   "routes": {
     "dashboard": "Πίνακας ελέγχου",
     "tasks": "Εργασίες",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -62,6 +62,7 @@
   "Version": "Version",
   "Section": "Section",
   "tenants": "Tenants",
+  "allTenants": "All tenants",
   "routes": {
     "dashboard": "Dashboard",
     "tasks": "Tasks",

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -77,7 +77,7 @@ if (auth.isSuperAdmin) {
 }
 
 const tenantOptions = computed(() => [
-  { value: '', label: 'All tenants' },
+  { value: '', label: t('allTenants') },
   ...tenantStore.tenants.map((t: any) => ({ value: t.id, label: t.name })),
 ]);
 


### PR DESCRIPTION
## Summary
- localize "All tenants" label in task statuses list header
- add English and Greek translations for shared tenant option

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute order & accessibility warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c5797009c88323871af1abd3e6d219