### PR TITLE
feat: add role descriptions

### DIFF
--- a/backend/app/Http/Resources/RoleResource.php
+++ b/backend/app/Http/Resources/RoleResource.php
@@ -14,6 +14,7 @@ class RoleResource extends JsonResource
         return $this->formatDates([
             'id' => $this->id,
             'name' => $this->name,
+            'description' => $this->description,
             'slug' => $this->slug,
             'abilities' => $this->abilities,
             'tenant_id' => $this->tenant_id,

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -12,6 +12,7 @@ class Role extends Model
     protected $fillable = [
         'tenant_id',
         'name',
+        'description',
         'slug',
         'abilities',
         'level',
@@ -19,6 +20,7 @@ class Role extends Model
 
     protected $casts = [
         'abilities' => 'array',
+        'description' => 'string',
     ];
 
     protected static function booted(): void

--- a/backend/database/migrations/2025_10_16_000011_add_description_to_roles_table.php
+++ b/backend/database/migrations/2025_10_16_000011_add_description_to_roles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->string('description')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('roles', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/backend/tests/Feature/RoleRoutesTest.php
+++ b/backend/tests/Feature/RoleRoutesTest.php
@@ -45,14 +45,15 @@ class RoleRoutesTest extends TestCase
             ->getJson('/api/roles')
             ->assertStatus(200);
 
-        $payload = ['name' => 'Tester', 'slug' => 'tester', 'level' => 1];
+        $payload = ['name' => 'Tester', 'slug' => 'tester', 'level' => 1, 'description' => 'Test role'];
         $roleId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
             ->assertJsonStructure([
-                'data' => ['id', 'name', 'slug', 'abilities', 'tenant_id', 'level'],
+                'data' => ['id', 'name', 'description', 'slug', 'abilities', 'tenant_id', 'level'],
             ])
             ->assertJsonPath('data.level', 1)
+            ->assertJsonPath('data.description', 'Test role')
             ->assertJsonPath('data.tenant_id', $this->tenant->id)
             ->assertJsonMissingPath('data.created_at')
             ->assertJsonMissingPath('data.updated_at')
@@ -62,21 +63,23 @@ class RoleRoutesTest extends TestCase
             ->getJson("/api/roles/{$roleId}")
             ->assertStatus(200)
             ->assertJsonStructure([
-                'data' => ['id', 'name', 'slug', 'abilities', 'tenant_id', 'level'],
+                'data' => ['id', 'name', 'description', 'slug', 'abilities', 'tenant_id', 'level'],
             ])
+            ->assertJsonPath('data.description', 'Test role')
             ->assertJsonMissingPath('data.created_at')
             ->assertJsonMissingPath('data.updated_at');
 
-        $update = ['name' => 'Updated', 'slug' => 'updated', 'level' => 2];
+        $update = ['name' => 'Updated', 'slug' => 'updated', 'level' => 2, 'description' => 'Updated role'];
         $this->withHeader('X-Tenant-ID', $this->tenant->id)
             ->putJson("/api/roles/{$roleId}", $update)
             ->assertStatus(200)
             ->assertJsonStructure([
-                'data' => ['id', 'name', 'slug', 'abilities', 'tenant_id', 'level'],
+                'data' => ['id', 'name', 'description', 'slug', 'abilities', 'tenant_id', 'level'],
             ])
             ->assertJsonPath('data.name', 'Updated')
             ->assertJsonPath('data.slug', 'updated')
             ->assertJsonPath('data.level', 2)
+            ->assertJsonPath('data.description', 'Updated role')
             ->assertJsonMissingPath('data.created_at')
             ->assertJsonMissingPath('data.updated_at');
 

--- a/frontend/src/components/roles/RolesTable.vue
+++ b/frontend/src/components/roles/RolesTable.vue
@@ -28,6 +28,9 @@
         <span v-if="rowProps.column.field === 'tenant'">
           {{ rowProps.row.tenant?.name || '—' }}
         </span>
+        <span v-else-if="rowProps.column.field === 'description'">
+          {{ rowProps.row.description || '—' }}
+        </span>
         <span v-else-if="rowProps.column.field === 'created_at'">
           {{ formatDate(rowProps.row.created_at) }}
         </span>
@@ -134,6 +137,7 @@ import { useAuthStore, can } from '@/stores/auth';
 interface RoleRow {
   id: number;
   name: string;
+  description?: string | null;
   level: number;
   created_at?: string;
   updated_at?: string;
@@ -175,6 +179,7 @@ const selectOptions = {
 const columns = [
   { label: 'ID', field: 'id' },
   { label: 'Name', field: 'name' },
+  { label: 'Description', field: 'description' },
   { label: 'Level', field: 'level', type: 'number', sortable: true },
   { label: 'Tenant', field: 'tenant' },
   { label: 'Created', field: 'created_at' },

--- a/frontend/src/stores/roles.ts
+++ b/frontend/src/stores/roles.ts
@@ -11,6 +11,7 @@ type RolePayload = Role & {
   abilities?: string[];
   tenant_id?: string | null;
   level?: number;
+  description?: string | null;
 };
 
 export const useRolesStore = defineStore('roles', {

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -59,6 +59,7 @@ import { useI18n } from 'vue-i18n';
 interface RoleRow {
   id: number;
   name: string;
+  description?: string | null;
   level: number;
   created_at?: string;
   updated_at?: string;
@@ -102,6 +103,7 @@ async function load() {
   all.value = rolesStore.roles.map((r: any) => ({
     id: r.id,
     name: r.name,
+    description: r.description,
     level: r.level,
     tenant: r.tenant || tenantMap[r.tenant_id] || null,
     tenant_id: r.tenant_id,

--- a/frontend/tests/e2e/roles.spec.ts
+++ b/frontend/tests/e2e/roles.spec.ts
@@ -5,8 +5,12 @@ test.skip('creates a role and assigns it to a user', async ({ page }) => {
   await page.goto('/roles');
   await page.getByRole('button', { name: 'Create' }).click();
   await page.getByPlaceholder('Role name').fill('Tester');
+  await page.getByPlaceholder('Role description').fill('A test role');
   await page.getByRole('button', { name: 'Save' }).click();
-  await page.getByRole('row', { name: /Tester/ }).getByRole('button', { name: 'Assign' }).click();
+  await page
+    .getByRole('row', { name: /Tester/ })
+    .getByRole('button', { name: 'Assign' })
+    .click();
   await page.getByPlaceholder('Search user').fill('John');
   await page.getByRole('option', { name: /John Doe/ }).click();
   await page.getByRole('button', { name: 'Assign' }).click();

--- a/frontend/tests/unit/stores/roles.spec.ts
+++ b/frontend/tests/unit/stores/roles.spec.ts
@@ -19,7 +19,7 @@ describe('roles store', () => {
   });
 
   it('fetches roles with params', async () => {
-    (api.get as any).mockResolvedValue({ data: { data: [{ id: 1 }] } });
+    (api.get as any).mockResolvedValue({ data: { data: [{ id: 1, description: 'desc' }] } });
     const store = useRolesStore();
     await store.fetch({ scope: 'tenant', tenant_id: '1' });
     expect(api.get).toHaveBeenCalledWith('/roles', {
@@ -33,7 +33,7 @@ describe('roles store', () => {
         dir: 'asc',
       },
     });
-    expect(store.roles).toEqual([{ id: 1 }]);
+    expect(store.roles).toEqual([{ id: 1, description: 'desc' }]);
   });
 
   it('omits tenant_id when scope is all', async () => {
@@ -59,6 +59,16 @@ describe('roles store', () => {
     expect(api.post).toHaveBeenCalledWith('/roles/2/assign', {
       user_id: 3,
       tenant_id: '4',
+    });
+  });
+
+  it('creates role with description', async () => {
+    (api.post as any).mockResolvedValue({ data: { id: 1 } });
+    const store = useRolesStore();
+    await store.create({ name: 'Tester', description: 'desc' } as any);
+    expect(api.post).toHaveBeenCalledWith('/roles', {
+      name: 'Tester',
+      description: 'desc',
     });
   });
 });


### PR DESCRIPTION
## Summary
- add description column to roles table with model and resource updates
- expose role descriptions in API resources and frontend roles tables
- cover role description in tests

## Testing
- `php artisan test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `npm test` *(fails: 11 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c57dd527708323b59044076d73658c