### PR TITLE
Expose user counts for roles

### DIFF
--- a/backend/app/Http/Controllers/Api/RoleController.php
+++ b/backend/app/Http/Controllers/Api/RoleController.php
@@ -38,7 +38,8 @@ class RoleController extends Controller
         if (! $request->user()->isSuperAdmin()) {
             $tenantId = $request->user()->tenant_id;
             $userLevel = $request->user()->roleLevel($tenantId);
-            $base = Role::where('tenant_id', $tenantId)
+            $base = Role::withCount('users')
+                ->where('tenant_id', $tenantId)
                 ->where('level', '>=', $userLevel);
             $result = $this->listQuery($base, $request, ['name'], ['name']);
             return RoleResource::collection($result['data'])->additional([
@@ -48,7 +49,7 @@ class RoleController extends Controller
 
         $scope = $scope ?? ($tenantId ? 'tenant' : 'all');
 
-        $query = Role::query();
+        $query = Role::query()->withCount('users');
 
         switch ($scope) {
             case 'global':

--- a/backend/app/Http/Resources/RoleResource.php
+++ b/backend/app/Http/Resources/RoleResource.php
@@ -19,6 +19,7 @@ class RoleResource extends JsonResource
             'abilities' => $this->abilities,
             'tenant_id' => $this->tenant_id,
             'level' => $this->level,
+            'users_count' => $this->users_count ?? 0,
         ]);
     }
 }

--- a/frontend/src/components/roles/RolesTable.vue
+++ b/frontend/src/components/roles/RolesTable.vue
@@ -143,6 +143,7 @@ interface RoleRow {
   updated_at?: string;
   tenant?: { id: number; name: string } | null;
   tenant_id?: number | null;
+  users_count: number;
 }
 
 const props = defineProps<{ rows: RoleRow[] }>();
@@ -181,6 +182,7 @@ const columns = [
   { label: 'Name', field: 'name' },
   { label: 'Description', field: 'description' },
   { label: 'Level', field: 'level', type: 'number', sortable: true },
+  { label: 'Users', field: 'users_count', type: 'number', sortable: true },
   { label: 'Tenant', field: 'tenant' },
   { label: 'Created', field: 'created_at' },
   { label: 'Updated', field: 'updated_at' },

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -65,6 +65,7 @@ interface RoleRow {
   updated_at?: string;
   tenant?: { id: number; name: string } | null;
   tenant_id?: number | null;
+  users_count: number;
 }
 
 const router = useRouter();
@@ -109,6 +110,7 @@ async function load() {
     tenant_id: r.tenant_id,
     created_at: r.created_at,
     updated_at: r.updated_at,
+    users_count: r.users_count,
   }));
   loading.value = false;
 }

--- a/frontend/tests/e2e/roles.spec.ts
+++ b/frontend/tests/e2e/roles.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 // No running server in the environment; this test documents the expected flow.
 test.skip('creates a role and assigns it to a user', async ({ page }) => {
@@ -14,6 +14,14 @@ test.skip('creates a role and assigns it to a user', async ({ page }) => {
   await page.getByPlaceholder('Search user').fill('John');
   await page.getByRole('option', { name: /John Doe/ }).click();
   await page.getByRole('button', { name: 'Assign' }).click();
+});
+
+test.skip('shows user counts for each role', async ({ page }) => {
+  await page.goto('/roles');
+  await expect(page.getByRole('columnheader', { name: 'Users' })).toBeVisible();
+  await expect(
+    page.getByRole('row', { name: /ClientAdmin/ }).getByRole('cell', { name: /\d+/ })
+  ).toBeVisible();
 });
 
 test.skip('role form shows only allowed abilities', async ({ page }) => {


### PR DESCRIPTION
## Summary
- count users in `RoleController@index`
- include `users_count` in `RoleResource`
- show user counts in role list UI and update tests

## Testing
- `composer test` *(fails: file_get_contents(/workspace/asbuild/backend/.env): Failed to open stream: No such file or directory)*
- `pnpm test` *(fails: ELIFECYCLE Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68c583af9b98832385b9a5b382c655f9