### PR TITLE
feat: show role ability tooltip

### DIFF
--- a/frontend/src/components/roles/RolesTable.vue
+++ b/frontend/src/components/roles/RolesTable.vue
@@ -32,7 +32,21 @@
           {{ rowProps.row.description || '—' }}
         </span>
         <span v-else-if="rowProps.column.field === 'abilities'">
-          {{ summarizeAbilities(rowProps.row.abilities) }}
+          <Tooltip v-if="rowProps.row.abilities.length > 3" theme="light">
+            <template #button>
+              <span class="cursor-help">
+                {{ summarizeAbilities(rowProps.row.abilities) }}
+              </span>
+            </template>
+            <ul class="text-left list-disc pl-4">
+              <li v-for="ability in rowProps.row.abilities" :key="ability">
+                {{ ability }}
+              </li>
+            </ul>
+          </Tooltip>
+          <span v-else>
+            {{ summarizeAbilities(rowProps.row.abilities) }}
+          </span>
         </span>
         <span v-else-if="rowProps.column.field === 'created_at'">
           {{ formatDate(rowProps.row.created_at) }}
@@ -133,6 +147,7 @@ import InputGroup from '@/components/ui/InputGroup';
 import Dropdown from '@/components/ui/Dropdown';
 import Icon from '@/components/ui/Icon';
 import Pagination from '@/components/ui/Pagination';
+import Tooltip from '@/components/ui/Tooltip/index.vue';
 import Breadcrumbs from '@/Layout/Breadcrumbs.vue';
 import { useI18n } from 'vue-i18n';
 import { useAuthStore, can } from '@/stores/auth';

--- a/frontend/tests/e2e/roles.spec.ts
+++ b/frontend/tests/e2e/roles.spec.ts
@@ -37,3 +37,12 @@ test.skip('role form shows only allowed abilities', async ({ page }) => {
   await expect(page.getByRole('option', { name: 'types.manage' })).not.toBeVisible();
 });
 
+test.skip('shows full abilities in a tooltip on hover', async ({ page }) => {
+  await page.goto('/roles');
+  const cell = page
+    .getByRole('row', { name: /ClientAdmin/ })
+    .getByRole('cell', { name: /\+\d+/ });
+  await cell.hover();
+  await expect(page.getByRole('tooltip')).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- display all role abilities in a tooltip when hovering the abilities column
- note expected tooltip behavior in roles e2e test

## Testing
- `pnpm test` *(fails: addMenu.spec.ts, field-palette.spec.ts, sla-policies.spec.ts, status-flow-editor.spec.ts, status-select.spec.ts, task-filters.spec.ts, task-sla-fields.spec.ts, task-type-create-ui.spec.ts, tasks-list.spec.ts and others)*
- `pnpm lint` *(fails: vue/attributes-order, vuejs-accessibility/label-has-for, require-default-prop warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c57d001bbc8323addd5b314058b351