### PR TITLE
Skip task automations with non-string status conditions

### DIFF
--- a/backend/app/Models/TaskAutomation.php
+++ b/backend/app/Models/TaskAutomation.php
@@ -38,12 +38,20 @@ class TaskAutomation extends Model
 
         foreach ($rules as $rule) {
             $conditions = $rule->conditions_json ?? [];
-            if (
-                isset($conditions['status'])
-                && TaskStatus::stripPrefix($task->status_slug) !== TaskStatus::stripPrefix($conditions['status'])
-            ) {
-                continue;
+
+            if (isset($conditions['status'])) {
+                if (!is_string($conditions['status'])) {
+                    continue;
+                }
+
+                if (
+                    TaskStatus::stripPrefix($task->status_slug)
+                    !== TaskStatus::stripPrefix($conditions['status'])
+                ) {
+                    continue;
+                }
             }
+
             foreach ($rule->actions_json as $action) {
                 if (($action['type'] ?? null) === 'notify_team' && isset($action['team_id'])) {
                     AutomationNotifyTeamJob::dispatch($task->id, $action['team_id']);

--- a/backend/tests/Unit/TaskAutomationRunTest.php
+++ b/backend/tests/Unit/TaskAutomationRunTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Task;
+use App\Models\TaskAutomation;
+use App\Models\TaskStatus;
+use App\Models\TaskType;
+use App\Models\Team;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class TaskAutomationRunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_run_skips_rule_with_non_string_status(): void
+    {
+        Queue::fake();
+
+        $tenant = Tenant::create(['name' => 'T', 'features' => ['tasks']]);
+
+        $user = User::create([
+            'name' => 'U',
+            'email' => 'u@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+
+        TaskStatus::create(['slug' => 'draft', 'name' => 'Draft', 'tenant_id' => $tenant->id]);
+        TaskStatus::create(['slug' => 'completed', 'name' => 'Completed', 'tenant_id' => $tenant->id]);
+
+        $type = TaskType::create([
+            'name' => 'Type',
+            'tenant_id' => $tenant->id,
+            'schema_json' => ['sections' => []],
+            'statuses' => ['draft' => [], 'completed' => []],
+            'status_flow_json' => [['draft', 'completed']],
+        ]);
+
+        $team = Team::create(['tenant_id' => $tenant->id, 'name' => 'Team X']);
+
+        TaskAutomation::create([
+            'task_type_id' => $type->id,
+            'event' => 'status_changed',
+            'conditions_json' => ['status' => 123],
+            'actions_json' => [['type' => 'notify_team', 'team_id' => $team->id]],
+            'enabled' => true,
+        ]);
+
+        $task = Task::create([
+            'tenant_id' => $tenant->id,
+            'user_id' => $user->id,
+            'task_type_id' => $type->id,
+            'status_slug' => TaskStatus::prefixSlug('draft', $tenant->id),
+            'board_position' => 1,
+        ]);
+
+        TaskAutomation::run($task, 'status_changed');
+
+        Queue::assertNothingPushed();
+    }
+}


### PR DESCRIPTION
## Summary
- guard task automation rules against non-string status conditions
- add unit test ensuring malformed status conditions are ignored

## Testing
- `composer test` *(fails: Expected response code 201 but received 403)*
- `./vendor/bin/phpunit --filter TaskAutomationRunTest`


------
https://chatgpt.com/codex/tasks/task_e_68c58a1f325c8323992a48db3d1d7477