### PR TITLE
feat(frontend): handle roles without abilities

### DIFF
--- a/frontend/src/components/roles/RolesTable.vue
+++ b/frontend/src/components/roles/RolesTable.vue
@@ -32,20 +32,26 @@
           {{ rowProps.row.description || '—' }}
         </span>
         <span v-else-if="rowProps.column.field === 'abilities'">
-          <Tooltip v-if="rowProps.row.abilities.length > 3" theme="light">
+          <Tooltip
+            v-if="(rowProps.row.abilities ?? []).length > 3"
+            theme="light"
+          >
             <template #button>
               <span class="cursor-help">
-                {{ summarizeAbilities(rowProps.row.abilities) }}
+                {{ summarizeAbilities(rowProps.row.abilities ?? []) }}
               </span>
             </template>
             <ul class="text-left list-disc pl-4">
-              <li v-for="ability in rowProps.row.abilities" :key="ability">
+              <li
+                v-for="ability in rowProps.row.abilities ?? []"
+                :key="ability"
+              >
                 {{ ability }}
               </li>
             </ul>
           </Tooltip>
           <span v-else>
-            {{ summarizeAbilities(rowProps.row.abilities) }}
+            {{ summarizeAbilities(rowProps.row.abilities ?? []) }}
           </span>
         </span>
         <span v-else-if="rowProps.column.field === 'created_at'">
@@ -157,7 +163,7 @@ interface RoleRow {
   name: string;
   description?: string | null;
   level: number;
-  abilities: string[];
+  abilities?: string[];
   created_at?: string;
   updated_at?: string;
   tenant?: { id: number; name: string } | null;


### PR DESCRIPTION
## Summary
- guard RolesTable tooltips against missing abilities
- pass default empty array when summarizing abilities
- mark RoleRow abilities optional

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute order and accessibility errors in dashcode components)*


------
https://chatgpt.com/codex/tasks/task_e_68c58d25b2388323af51ca6a639a7a97