### PR TITLE
Fix tenant status fetch for super admins

### DIFF
--- a/frontend/src/stores/taskStatuses.ts
+++ b/frontend/src/stores/taskStatuses.ts
@@ -5,12 +5,24 @@ import { withListParams, type ListParams } from './list';
 export const useTaskStatusesStore = defineStore('taskStatuses', {
   actions: {
     async fetch(
-      scope: 'tenant' | 'global' | 'all',
+      scopeOrParams:
+        | 'tenant'
+        | 'global'
+        | 'all'
+        | (ListParams & {
+            scope: 'tenant' | 'global' | 'all';
+            tenant_id?: string | number;
+          }),
       tenantId?: string | number,
       params: ListParams = {},
     ) {
-      const query: any = withListParams({ scope, ...params });
-      if (tenantId) query.tenant_id = tenantId;
+      let query: any;
+      if (typeof scopeOrParams === 'string') {
+        query = withListParams({ scope: scopeOrParams, ...params });
+        if (tenantId) query.tenant_id = tenantId;
+      } else {
+        query = withListParams(scopeOrParams);
+      }
       const { data } = await api.get('/task-statuses', { params: query });
       return data;
     },

--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -85,14 +85,15 @@ async function load() {
   let scopeParam: 'tenant' | 'global' | 'all' = scope.value;
   let tenantId: string | number | undefined;
 
-  if (auth.isSuperAdmin) {
-    scopeParam = tenantFilter.value ? 'all' : 'all';
-    tenantId = tenantFilter.value || undefined;
-  } else if (scope.value !== 'all') {
-    tenantId = tenantStore.currentTenantId;
+  if (auth.isSuperAdmin && tenantFilter.value) {
+    scopeParam = 'all'; // tenant-only
+    tenantId = tenantFilter.value;
   }
 
-  const { data } = await statusesStore.fetch(scopeParam, tenantId);
+  const { data } = await statusesStore.fetch({
+    scope: scopeParam,
+    tenant_id: tenantId,
+  });
   await tenantStore.loadTenants({ per_page: 100 });
   const tenantMap = tenantStore.tenants.reduce(
     (acc: Record<number, any>, t: any) => ({ ...acc, [t.id]: t }),


### PR DESCRIPTION
## Summary
- ensure super admins pass `tenant_id` when filtering task statuses
- allow task status store to accept object-style fetch parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c58d1314a88323ad2d0af3fa4c6aef