### PR TITLE
Add department field to employees and search table

### DIFF
--- a/backend/app/Http/Controllers/Api/EmployeeController.php
+++ b/backend/app/Http/Controllers/Api/EmployeeController.php
@@ -36,7 +36,7 @@ class EmployeeController extends Controller
 
         $base = User::where('tenant_id', $tenantId)
             ->with('roles');
-        $result = $this->listQuery($base, $request, ['name', 'email'], ['name', 'email']);
+        $result = $this->listQuery($base, $request, ['name', 'email', 'department'], ['name', 'email', 'department']);
 
         return EmployeeResource::collection($result['data'])->additional([
             'meta' => $result['meta'],

--- a/backend/app/Http/Resources/EmployeeResource.php
+++ b/backend/app/Http/Resources/EmployeeResource.php
@@ -14,6 +14,7 @@ class EmployeeResource extends JsonResource
         $data = parent::toArray($request);
         $data['status'] = $this->status;
         $data['last_login_at'] = $this->last_login_at;
+        $data['department'] = $this->department;
 
         return $this->formatDates($data);
     }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable
         'tenant_id',
         'phone',
         'address',
+        'department',
         'status',
         'last_login_at',
     ];

--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -544,7 +544,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\",\n  \"phone\": \"123-456-7890\",\n  \"address\": \"123 Main St\",\n  \"roles\": [\"ClientAdmin\"]\n}"
+              "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"john@example.com\",\n  \"phone\": \"123-456-7890\",\n  \"address\": \"123 Main St\",\n  \"department\": \"Sales\",\n  \"roles\": [\"ClientAdmin\"]\n}"
             },
             "url": {
               "raw": "{{base_url}}/api/employees",
@@ -595,7 +595,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Updated Employee\",\n  \"phone\": \"987-654-3210\",\n  \"address\": \"456 Elm St\",\n  \"roles\": [\"ClientAdmin\"]\n}"
+              "raw": "{\n  \"name\": \"Updated Employee\",\n  \"phone\": \"987-654-3210\",\n  \"address\": \"456 Elm St\",\n  \"department\": \"Sales\",\n  \"roles\": [\"ClientAdmin\"]\n}"
             },
             "url": {
               "raw": "{{base_url}}/api/employees/{employee}",

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -32,6 +32,7 @@ class UserFactory extends Factory
             'tenant_id' => 1,
             'phone' => fake()->phoneNumber(),
             'address' => fake()->address(),
+            'department' => fake()->word(),
         ];
     }
 

--- a/backend/database/migrations/2025_01_01_101300_add_department_to_users_table.php
+++ b/backend/database/migrations/2025_01_01_101300_add_department_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('department')->nullable()->after('address');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('department');
+        });
+    }
+};

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1306,6 +1306,8 @@ components:
           type: integer
         name:
           type: string
+        department:
+          type: string
     Notification:
       type: object
       required:

--- a/frontend/src/components/employees/EmployeesTable.vue
+++ b/frontend/src/components/employees/EmployeesTable.vue
@@ -130,6 +130,7 @@ interface EmployeeRow {
   name: string;
   email: string;
   roles: string;
+  department?: string | null;
   phone?: string | null;
   status?: string | null;
   last_login_at?: string | null;
@@ -163,6 +164,7 @@ const selectOptions = {
 
 const columns = [
   { label: 'Name', field: 'name' },
+  { label: 'Department', field: 'department' },
   { label: 'Roles', field: 'roles' },
   { label: 'Phone', field: 'phone' },
   { label: 'Status', field: 'status' },
@@ -181,6 +183,7 @@ const filteredRows = computed(() => {
       String(r.name).toLowerCase().includes(term) ||
       String(r.email).toLowerCase().includes(term) ||
       String(r.roles).toLowerCase().includes(term) ||
+      String(r.department || '').toLowerCase().includes(term) ||
       String(r.phone || '').toLowerCase().includes(term) ||
       String(r.status || '').toLowerCase().includes(term) ||
       String(r.tenant?.name || '').toLowerCase().includes(term)

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1878,6 +1878,7 @@ export interface components {
         Employee: {
             id?: number;
             name?: string;
+            department?: string;
         };
         Notification: {
             id: number;

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -52,6 +52,7 @@ interface EmployeeRow {
   name: string;
   email: string;
   roles: string;
+  department?: string | null;
   phone?: string | null;
   status?: string | null;
   last_login_at?: string | null;
@@ -108,6 +109,7 @@ async function load() {
     name: e.name,
     email: e.email,
     roles: formatRoles(e.roles || []),
+    department: e.department,
     phone: e.phone,
     status: e.status,
     last_login_at: e.last_login_at,


### PR DESCRIPTION
## Summary
- expose `department` on employees API and database
- display Department column and search support in employees table

## Testing
- `npm run lint` *(fails: Attribute order and default prop warnings)*
- `npx vitest run tests/unit tests/*.test.ts` *(fails: numerous Vue warnings and unresolved components)*
- `composer test` *(fails: multiple warnings and failing feature tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5951e4ad48323b72b2625cdbb17a4