### PR TITLE
Handle varying employee API response shapes

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -130,4 +130,8 @@ export function extractFormErrors(error: any): Record<string, string[]> {
   return (error && (error.errors as Record<string, string[]>)) || {};
 }
 
+export function extractData<T>(data: any): T {
+  return Array.isArray(data) ? data : data?.data;
+}
+
 export default api;

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -41,7 +41,7 @@ import SkeletonTable from '@/components/ui/Skeleton/Table.vue';
 import Button from '@/components/ui/Button';
 import Select from '@/components/ui/Select/index.vue';
 import Swal from 'sweetalert2';
-import api from '@/services/api';
+import api, { extractData } from '@/services/api';
 import { useNotify } from '@/plugins/notify';
 import { useAuthStore, can } from '@/stores/auth';
 import { useTenantStore } from '@/stores/tenant';
@@ -100,11 +100,12 @@ async function load() {
     params.tenant_id = tenantFilter.value;
   }
   const { data } = await api.get('/employees', { params });
+  const employees = extractData(data);
   const tenantMap = tenantStore.tenants.reduce(
     (acc: Record<number, any>, t: any) => ({ ...acc, [t.id]: t }),
     {},
   );
-  all.value = data.data.map((e: any) => ({
+  all.value = employees.map((e: any) => ({
     id: e.id,
     name: e.name,
     email: e.email,

--- a/frontend/src/views/teams/TeamForm.vue
+++ b/frontend/src/views/teams/TeamForm.vue
@@ -46,7 +46,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import api, { extractFormErrors } from '@/services/api';
+import api, { extractFormErrors, extractData } from '@/services/api';
 import Textinput from '@/components/ui/Textinput/index.vue';
 import VueSelect from '@/components/ui/Select/VueSelect.vue';
 import Button from '@/components/ui/Button/index.vue';
@@ -92,7 +92,7 @@ const availableFeatures = computed(() =>
 
 async function loadEmployees() {
   const { data } = await api.get('/employees');
-  employeeOptions.value = data;
+  employeeOptions.value = extractData(data);
 }
 
 async function loadTeam() {


### PR DESCRIPTION
## Summary
- Add `extractData` helper to normalize API responses that may return an array or `{ data, meta }`
- Use `extractData` when loading employees in EmployeesList and TeamForm to avoid runtime errors

## Testing
- `npm run lint` *(fails: Attribute order and accessibility issues in unrelated components)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59970f6c48323a19945b75cc8d7fb