### PR TITLE
feat: allow employees to specify department

### DIFF
--- a/backend/app/Http/Controllers/Api/EmployeeController.php
+++ b/backend/app/Http/Controllers/Api/EmployeeController.php
@@ -50,6 +50,7 @@ class EmployeeController extends Controller
             'email' => 'required|email',
             'phone' => 'nullable|string',
             'address' => 'nullable|string',
+            'department' => 'nullable|string',
             'roles' => 'array|nullable',
             'roles.*' => 'string',
         ]);
@@ -68,6 +69,7 @@ class EmployeeController extends Controller
             'password' => Hash::make(Str::random(config('security.password.min_length'))),
             'phone' => $data['phone'] ?? null,
             'address' => $data['address'] ?? null,
+            'department' => $data['department'] ?? null,
         ]);
 
         if (! empty($data['roles'])) {
@@ -109,6 +111,7 @@ class EmployeeController extends Controller
             'name' => 'sometimes|string',
             'phone' => 'sometimes|string',
             'address' => 'sometimes|string',
+            'department' => 'sometimes|string',
             'roles' => 'sometimes|array',
             'roles.*' => 'string',
         ]);
@@ -121,6 +124,9 @@ class EmployeeController extends Controller
         }
         if (isset($data['address'])) {
             $employee->address = $data['address'];
+        }
+        if (isset($data['department'])) {
+            $employee->department = $data['department'];
         }
         $employee->save();
 

--- a/backend/tests/EmployeeTest.php
+++ b/backend/tests/EmployeeTest.php
@@ -21,4 +21,25 @@ class EmployeeTest extends TestCase
         ));
         $this->assertStringContainsString('SuperAdmin', $code);
     }
+
+    public function test_employee_controller_handles_department(): void
+    {
+        $reflection = new ReflectionClass(EmployeeController::class);
+
+        $store = $reflection->getMethod('store');
+        $storeCode = implode("", array_slice(
+            file($store->getFileName()),
+            $store->getStartLine() - 1,
+            $store->getEndLine() - $store->getStartLine() + 1
+        ));
+        $this->assertStringContainsString('department', $storeCode);
+
+        $update = $reflection->getMethod('update');
+        $updateCode = implode("", array_slice(
+            file($update->getFileName()),
+            $update->getStartLine() - 1,
+            $update->getEndLine() - $update->getStartLine() + 1
+        ));
+        $this->assertStringContainsString('department', $updateCode);
+    }
 }


### PR DESCRIPTION
## Summary
- persist optional department field on employee creation and updates
- cover department handling in EmployeeController with tests

## Testing
- `composer test` *(fails: imagewebp ... No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c59a9d3a9c832395f12536194dd757