### PR TITLE
Add user status and last login columns

### DIFF
--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -33,6 +33,8 @@ class UserFactory extends Factory
             'phone' => fake()->phoneNumber(),
             'address' => fake()->address(),
             'department' => fake()->word(),
+            'status' => 'active',
+            'last_login_at' => null,
         ];
     }
 

--- a/backend/database/migrations/2025_10_16_000012_add_status_and_last_login_at_to_users_table.php
+++ b/backend/database/migrations/2025_10_16_000012_add_status_and_last_login_at_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'status')) {
+                $table->string('status')->default('active')->after('department');
+            }
+            if (! Schema::hasColumn('users', 'last_login_at')) {
+                $table->timestamp('last_login_at')->nullable()->after('status');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'last_login_at')) {
+                $table->dropColumn('last_login_at');
+            }
+            if (Schema::hasColumn('users', 'status')) {
+                $table->dropColumn('status');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add migration to add `status` and `last_login_at` to users table
- seed user factory with default values

## Testing
- `php artisan test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf. Tests: 24 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c59ace4b94832389574ef787a5fdf0