### PR TITLE
test: cover impersonation and invite resend

### DIFF
--- a/backend/tests/EmployeeTest.php
+++ b/backend/tests/EmployeeTest.php
@@ -42,4 +42,18 @@ class EmployeeTest extends TestCase
         ));
         $this->assertStringContainsString('department', $updateCode);
     }
+
+    public function test_employee_controller_has_impersonation_and_invite_methods(): void
+    {
+        $this->assertTrue(method_exists(EmployeeController::class, 'impersonate'));
+        $this->assertTrue(method_exists(EmployeeController::class, 'resendInvite'));
+    }
+
+    public function test_employee_routes_include_impersonation_and_invite_resend(): void
+    {
+        $routes = file_get_contents(dirname(__DIR__) . '/routes/api.php');
+        $this->assertStringContainsString("employees/{employee}/impersonate", $routes);
+        $this->assertStringContainsString("employees/{employee}/resend-invite", $routes);
+        $this->assertStringContainsString('employees.manage', $routes);
+    }
 }

--- a/frontend/tests/e2e/employees.crud.spec.ts
+++ b/frontend/tests/e2e/employees.crud.spec.ts
@@ -1,18 +1,63 @@
 import { test, expect } from '@playwright/test';
 
-// No running server in the environment; this test documents the
-// expected authorization behaviour for employees CRUD operations.
-test.skip('employees CRUD actions are gated by abilities', async ({ page }) => {
-  await page.goto('/employees');
+// No running server in the environment; these tests document the expected
+// authorization behaviour for employee management under the Users menu.
+test.skip('employees actions are gated by abilities', async ({ page }) => {
+  await page.goto('/users/employees');
   await expect(page.getByRole('button', { name: 'Create' })).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'Impersonate' })).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'Resend Invite' })).not.toBeVisible();
 
   page.route('**/api/employees', route =>
     route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
   );
+  page.route('**/api/employees/1/impersonate', route =>
+    route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
+  );
+  page.route('**/api/employees/1/resend-invite', route =>
+    route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
+  );
+
   await Promise.all([
     page.waitForResponse(resp =>
       resp.url().includes('/api/employees') && resp.status() === 403
     ),
     page.evaluate(() => fetch('/api/employees', { method: 'POST' })),
+  ]);
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/employees/1/impersonate') && resp.status() === 403
+    ),
+    page.evaluate(() => fetch('/api/employees/1/impersonate', { method: 'POST' })),
+  ]);
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/employees/1/resend-invite') && resp.status() === 403
+    ),
+    page.evaluate(() => fetch('/api/employees/1/resend-invite', { method: 'POST' })),
+  ]);
+});
+
+test.skip('employees impersonation and invite-resend actions succeed', async ({ page }) => {
+  await page.goto('/users/employees');
+
+  page.route('**/api/employees/1/impersonate', route =>
+    route.fulfill({ status: 200, body: '{"access_token":"a","refresh_token":"b"}' })
+  );
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/employees/1/impersonate') && resp.status() === 200
+    ),
+    page.getByRole('button', { name: 'Impersonate' }).first().click(),
+  ]);
+
+  page.route('**/api/employees/1/resend-invite', route =>
+    route.fulfill({ status: 200, body: '{"status":"ok"}' })
+  );
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/employees/1/resend-invite') && resp.status() === 200
+    ),
+    page.getByRole('button', { name: 'Resend Invite' }).first().click(),
   ]);
 });

--- a/frontend/tests/e2e/tenants.users.spec.ts
+++ b/frontend/tests/e2e/tenants.users.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+// No running server in the environment; these tests document the expected
+// authorization behaviour for tenant management under the Users menu.
+test.skip('tenants actions are gated by abilities', async ({ page }) => {
+  await page.goto('/users/tenants');
+  await expect(page.getByRole('button', { name: 'Create' })).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'Impersonate' })).not.toBeVisible();
+
+  page.route('**/api/tenants', route =>
+    route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
+  );
+  page.route('**/api/tenants/1/impersonate', route =>
+    route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
+  );
+
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/tenants') && resp.status() === 403
+    ),
+    page.evaluate(() => fetch('/api/tenants', { method: 'POST' })),
+  ]);
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/tenants/1/impersonate') && resp.status() === 403
+    ),
+    page.evaluate(() => fetch('/api/tenants/1/impersonate', { method: 'POST' })),
+  ]);
+});
+
+test.skip('tenants impersonation action succeeds', async ({ page }) => {
+  await page.goto('/users/tenants');
+
+  page.route('**/api/tenants/1/impersonate', route =>
+    route.fulfill({ status: 200, body: '{"access_token":"t"}' })
+  );
+  await Promise.all([
+    page.waitForResponse(resp =>
+      resp.url().includes('/api/tenants/1/impersonate') && resp.status() === 200
+    ),
+    page.getByRole('button', { name: 'Impersonate' }).first().click(),
+  ]);
+});


### PR DESCRIPTION
## Summary
- add coverage for impersonation and invite-resend endpoints
- document employees and tenants flows under new Users menu

## Testing
- `cd backend && ./vendor/bin/phpunit tests/EmployeeTest.php` (fails: No such file or directory)
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a44187948323810c8b3b68aa34f3