### PR TITLE
Emit selected team IDs array to fix bulk delete

### DIFF
--- a/frontend/src/components/teams/TeamsTable.vue
+++ b/frontend/src/components/teams/TeamsTable.vue
@@ -79,7 +79,7 @@
           v-if="can('teams.delete') || can('teams.manage')"
           type="button"
           class="ml-2 text-danger-500 hover:underline cursor-pointer"
-          @click="emit('delete-selected', selectedIds)"
+          @click="emit('delete-selected', selectedIds.value)"
         >
           {{ t('actions.delete') }}
         </button>


### PR DESCRIPTION
## Summary
- emit `selectedIds.value` so bulk team deletion receives an array of IDs

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before ":class" and related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba69395c8323bb3c5a54abf4bb34