### PR TITLE
Support impersonation refresh tokens

### DIFF
--- a/backend/tests/Feature/RefreshTokenTest.php
+++ b/backend/tests/Feature/RefreshTokenTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class RefreshTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_refresh_token_can_be_renewed(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['tasks']]);
+
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $refresh = $user->createToken('refresh-token', ['refresh'], now()->addDays(30));
+
+        $response = $this->postJson('/api/auth/refresh', [
+            'refresh_token' => $refresh->plainTextToken,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['access_token', 'refresh_token']);
+
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $refresh->accessToken->id]);
+        $this->assertDatabaseHas('personal_access_tokens', ['name' => 'access-token', 'tokenable_id' => $user->id]);
+        $this->assertDatabaseHas('personal_access_tokens', ['name' => 'refresh-token', 'tokenable_id' => $user->id]);
+    }
+
+    public function test_impersonation_refresh_token_can_be_renewed(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['tasks']]);
+
+        $user = User::create([
+            'name' => 'User',
+            'email' => 'user2@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $refresh = $user->createToken('impersonation-refresh', ['refresh'], now()->addDays(30));
+
+        $response = $this->postJson('/api/auth/refresh', [
+            'refresh_token' => $refresh->plainTextToken,
+        ]);
+
+        $response->assertStatus(200)->assertJsonStructure(['access_token', 'refresh_token']);
+
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $refresh->accessToken->id]);
+        $this->assertDatabaseHas('personal_access_tokens', ['name' => 'impersonation', 'tokenable_id' => $user->id]);
+        $this->assertDatabaseHas('personal_access_tokens', ['name' => 'impersonation-refresh', 'tokenable_id' => $user->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow `AuthController::refresh` to accept impersonation refresh tokens
- create `RefreshTokenTest` covering standard and impersonation token renewal

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `php artisan test tests/Feature/RefreshTokenTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb07e1f48323be752b006f49449b