### PR TITLE
Fix navigation for nested employee and tenant routes

### DIFF
--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -20,7 +20,7 @@
         />
         <Button
           v-if="can('employees.create') || can('employees.manage')"
-          link="/employees/create"
+          :to="{ name: 'employees.create' }"
           btnClass="btn-primary btn-sm min-w-[100px] !h-8 !py-0"
           icon="heroicons-outline:plus"
           iconClass="w-4 h-4"

--- a/frontend/src/views/tenants/TenantDetails.vue
+++ b/frontend/src/views/tenants/TenantDetails.vue
@@ -11,9 +11,9 @@
         v-if="can('tenants.update') || can('tenants.manage')"
         btnClass="btn-primary btn-sm"
         text="Edit"
-        :link="`/tenants/${tenant.id}/edit`"
+        :to="{ name: 'tenants.edit', params: { id: tenant.id } }"
       />
-      <Button btnClass="btn-secondary btn-sm" text="Back" link="/tenants" />
+      <Button btnClass="btn-secondary btn-sm" text="Back" :to="{ name: 'tenants.list' }" />
     </div>
   </div>
 </template>

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -5,7 +5,7 @@
           v-if="can('tenants.create') || can('tenants.manage')"
           btnClass="btn-primary"
           text="Add Tenant"
-          link="/tenants/create"
+          :to="{ name: 'tenants.create' }"
         />
       </div>
       <DashcodeServerTable
@@ -23,7 +23,7 @@
           />
           <Button
             v-if="can('tenants.update') || can('tenants.manage')"
-            :link="`/tenants/${row.id}/edit`"
+            :to="{ name: 'tenants.edit', params: { id: row.id } }"
             btnClass="btn-outline-primary btn-sm"
             text="Edit"
           />
@@ -112,7 +112,7 @@ async function impersonate(t: any) {
 }
 
 function view(id: number) {
-  router.push(`/tenants/${id}`);
+  router.push({ name: 'tenants.view', params: { id } });
 }
 
 async function remove(id: number) {

--- a/frontend/tests/e2e/roles-abilities.spec.ts
+++ b/frontend/tests/e2e/roles-abilities.spec.ts
@@ -17,7 +17,7 @@ test.skip('deselecting a feature hides its abilities immediately', async ({ page
   await page.getByRole('option').first().click();
   await page.getByLabel('Abilities').click();
   await expect(page.getByRole('option', { name: 'tasks.view' })).toBeVisible();
-  await page.goto('/tenants/1/edit');
+  await page.goto('/users/tenants/1/edit');
   await page.getByLabel('Features').click();
   await page.getByRole('option', { name: /Tasks/ }).click();
   await page.goto('/roles');

--- a/frontend/tests/e2e/routes.guard.spec.ts
+++ b/frontend/tests/e2e/routes.guard.spec.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@playwright/test';
 // Environment does not provide a running server; this test documents
 // the expected redirect when navigating to a guarded route.
 test.skip('redirects unauthorized routes to home', async ({ page }) => {
-  await page.goto('/employees');
+  await page.goto('/users/employees');
   await expect(page).toHaveURL('/');
 });

--- a/frontend/tests/e2e/tenants.spec.ts
+++ b/frontend/tests/e2e/tenants.spec.ts
@@ -2,7 +2,7 @@ import { test } from '@playwright/test';
 
 // No running server in the environment; this test documents the expected flow.
 test.skip('tenant deletion requires confirmation', async ({ page }) => {
-  await page.goto('/tenants');
+  await page.goto('/users/tenants');
   await page.getByRole('button', { name: 'Delete' }).first().click();
   await page.getByRole('button', { name: 'Yes, delete' }).click();
 });
@@ -10,7 +10,7 @@ test.skip('tenant deletion requires confirmation', async ({ page }) => {
 
 // Additional documentation of CRUD flows
 test.skip('super admin can create a tenant', async ({ page }) => {
-  await page.goto('/tenants/create');
+  await page.goto('/users/tenants/create');
   await page.getByLabel('Name').fill('New Tenant');
   await page.getByLabel('Storage Quota (MB)').fill('100');
   await page.getByLabel('Phone').fill('123456');
@@ -19,7 +19,7 @@ test.skip('super admin can create a tenant', async ({ page }) => {
 });
 
 test.skip('super admin can edit a tenant', async ({ page }) => {
-  await page.goto('/tenants/1/edit');
+  await page.goto('/users/tenants/1/edit');
   await page.getByLabel('Name').fill('Updated Tenant');
   await page.getByRole('button', { name: 'Save' }).click();
 });


### PR DESCRIPTION
## Summary
- use route names for employee create button
- update tenant list/detail navigation to new nested routes
- sync e2e tests with `/users` tenant and employee paths

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5bc732a7c8323986c6853cc165fe3