### PR TITLE
feat: support tenant teams

### DIFF
--- a/frontend/src/components/teams/TeamsTable.vue
+++ b/frontend/src/components/teams/TeamsTable.vue
@@ -43,6 +43,9 @@
         <span v-else-if="rowProps.column.field === 'memberCount'">
           {{ rowProps.row.memberCount }}
         </span>
+        <span v-else-if="rowProps.column.field === 'tenant'">
+          {{ rowProps.row.tenant?.name || '—' }}
+        </span>
         <span v-else-if="rowProps.column.field === 'created_at'">
           {{ formatDate(rowProps.row.created_at) }}
         </span>
@@ -79,7 +82,7 @@
           v-if="can('teams.delete') || can('teams.manage')"
           type="button"
           class="ml-2 text-danger-500 hover:underline cursor-pointer"
-          @click="emit('delete-selected', selectedIds.value)"
+          @click="emit('delete-selected', selectedIds)"
         >
           {{ t('actions.delete') }}
         </button>
@@ -123,6 +126,8 @@ interface TeamRow {
   memberCount: number;
   created_at: string;
   updated_at: string;
+  tenant?: { id: number; name: string } | null;
+  tenant_id?: number | null;
 }
 
 const props = defineProps<{ rows: TeamRow[] }>();
@@ -152,6 +157,7 @@ const columns = [
   { label: 'Name', field: 'name' },
   { label: 'Description', field: 'description' },
   { label: 'Members', field: 'memberCount' },
+  { label: 'Tenant', field: 'tenant' },
   { label: 'Created', field: 'created_at' },
   { label: 'Actions', field: 'actions' },
 ];

--- a/frontend/src/stores/teams.ts
+++ b/frontend/src/stores/teams.ts
@@ -3,15 +3,25 @@ import api from '@/services/api';
 import type { components } from '@/types/api';
 import { withListParams, type ListParams } from './list';
 
-type Team = components['schemas']['Team'];
-type TeamPayload = Omit<Team, 'id' | 'employees'>;
+type Team = components['schemas']['Team'] & {
+  tenant_id?: number | null;
+  tenant?: { id: number; name: string } | null;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type TeamPayload = {
+  name: string;
+  description?: string | null;
+  tenant_id?: number | null;
+};
 
 export const useTeamsStore = defineStore('teams', {
   state: () => ({
     teams: [] as Team[],
   }),
   actions: {
-    async fetch(params: ListParams = {}) {
+    async fetch(params: ListParams & { tenant_id?: string | number } = {}) {
       const { data } = await api.get('/teams', { params: withListParams(params) });
       this.teams = data.data as Team[];
       return data.meta;


### PR DESCRIPTION
## Summary
- allow filtering teams by tenant and assign tenant when creating
- expose tenant info in teams table and backend API
- fix bulk delete action in teams table

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute order and accessibility warnings)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cd0a439883238e13bee327dda07b