### PR TITLE
feat(ui): improve button link prop and update create buttons

### DIFF
--- a/frontend/src/components/ui/Button/index.vue
+++ b/frontend/src/components/ui/Button/index.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    v-if="!link && !div"
+    v-if="!linkValue && !div"
     :disabled="isDisabled"
     class="btn inline-flex justify-center"
     :class="`
@@ -56,8 +56,8 @@
   </button>
 
   <router-link
-    v-if="link && !div"
-    :to="link"
+    v-if="linkValue && !div"
+    :to="linkValue"
     class="btn inline-flex justify-center"
     :class="`
     ${isLoading ? ' pointer-events-none' : ''}
@@ -111,7 +111,7 @@
     </div>
   </router-link>
   <div
-    v-if="div && !link"
+    v-if="div && !linkValue"
     class="btn inline-flex justify-center"
     :class="`
     ${isLoading ? ' pointer-events-none' : ''}
@@ -207,12 +207,21 @@ export default {
       default: "",
     },
     link: {
-      type: String,
+      type: [String, Object],
+      default: "",
+    },
+    to: {
+      type: [String, Object],
       default: "",
     },
     div: {
       type: Boolean,
       default: false,
+    },
+  },
+  computed: {
+    linkValue() {
+      return this.link || this.to || "";
     },
   },
 };

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -20,7 +20,7 @@
         />
         <Button
           v-if="can('employees.create') || can('employees.manage')"
-          :to="{ name: 'employees.create' }"
+          :link="{ name: 'employees.create' }"
           btnClass="btn-primary btn-sm min-w-[100px] !h-8 !py-0"
           icon="heroicons-outline:plus"
           iconClass="w-4 h-4"

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -5,7 +5,7 @@
           v-if="can('tenants.create') || can('tenants.manage')"
           btnClass="btn-primary"
           text="Add Tenant"
-          :to="{ name: 'tenants.create' }"
+          :link="{ name: 'tenants.create' }"
         />
       </div>
       <DashcodeServerTable


### PR DESCRIPTION
## Summary
- use `link` prop for tenant and employee creation buttons
- allow `Button` `link` prop to take strings or objects and add `to` alias

## Testing
- `pnpm lint` *(fails: Attribute "v-if" should go before ...)*
- `pnpm test` *(fails: ELIFECYCLE Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ce26dad08323aab180e25912e5ef