### PR TITLE
Reload team form data when tenant selection changes

### DIFF
--- a/frontend/src/views/teams/TeamForm.vue
+++ b/frontend/src/views/teams/TeamForm.vue
@@ -113,7 +113,7 @@ watch(tenantId, async (newTenant, oldTenant) => {
   hiddenRoles.value = {};
   featureGrants.value = {} as Record<string, string[]>;
   if (isEdit.value) {
-    await loadTeam();
+    await loadTeam(true);
   }
   availableFeatures.value.forEach((f) => {
     if (!featureGrants.value[f]) featureGrants.value[f] = [];
@@ -126,12 +126,14 @@ async function loadEmployees() {
   employeeOptions.value = extractData(data);
 }
 
-async function loadTeam() {
+async function loadTeam(preserveTenant = false) {
   if (!isEdit.value) return;
   const { data } = await api.get(`/teams/${route.params.id}`);
   form.value.name = data.name || '';
   form.value.description = data.description || '';
-  tenantId.value = data.tenant_id ? String(data.tenant_id) : '';
+  if (!preserveTenant) {
+    tenantId.value = data.tenant_id ? String(data.tenant_id) : '';
+  }
   selectedEmployees.value = (data.employees || []).map((e: any) => e.id);
   hiddenRoles.value = {};
   featureGrants.value = {} as Record<string, string[]>;


### PR DESCRIPTION
## Summary
- watch tenant selection and reload employees and feature grant state
- prevent tenant picker from reverting on edit by preserving selection during reload

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before ":class" and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d9e6b34883238a38975e73223ab6