### PR TITLE
fix: clear team form state on tenant switch

### DIFF
--- a/frontend/src/views/teams/TeamForm.vue
+++ b/frontend/src/views/teams/TeamForm.vue
@@ -132,18 +132,18 @@ async function loadTeam(preserveTenant = false) {
   form.value.description = data.description || '';
   if (!preserveTenant) {
     tenantId.value = data.tenant_id ? String(data.tenant_id) : '';
+    selectedEmployees.value = (data.employees || []).map((e: any) => e.id);
+    hiddenRoles.value = {};
+    featureGrants.value = {} as Record<string, string[]>;
+    (data.roles || []).forEach((r: any) => {
+      if (r.slug?.startsWith('__fg__')) {
+        const parts = r.slug.split('__').filter(Boolean);
+        const feature = parts[2];
+        hiddenRoles.value[feature] = r;
+        featureGrants.value[feature] = r.abilities || [];
+      }
+    });
   }
-  selectedEmployees.value = (data.employees || []).map((e: any) => e.id);
-  hiddenRoles.value = {};
-  featureGrants.value = {} as Record<string, string[]>;
-  (data.roles || []).forEach((r: any) => {
-    if (r.slug?.startsWith('__fg__')) {
-      const parts = r.slug.split('__').filter(Boolean);
-      const feature = parts[2];
-      hiddenRoles.value[feature] = r;
-      featureGrants.value[feature] = r.abilities || [];
-    }
-  });
 }
 
 const { handleSubmit, setErrors, errors } = useForm();


### PR DESCRIPTION
## Summary
- Avoid repopulating team employees and grants when tenant changes

## Testing
- `pnpm lint` *(fails: Attribute "v-if" should go before ":class", missing default prop)*
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist; run `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dbd22d048323a847f05b63c41fa7