### PR TITLE
Add migration to seed tenant users and teams

### DIFF
--- a/backend/database/migrations/2025_10_16_000014_seed_tenant_users_and_teams.php
+++ b/backend/database/migrations/2025_10_16_000014_seed_tenant_users_and_teams.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Database\Seeders\TenantBootstrapSeeder;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        (new TenantBootstrapSeeder())->run();
+    }
+
+    public function down(): void
+    {
+        // Remove seeded team employees
+        $tenantId = DB::table('tenants')->where('name', 'Acme Vet')->value('id');
+        if ($tenantId) {
+            $teamId = DB::table('teams')
+                ->where('tenant_id', $tenantId)
+                ->where('name', 'Front Desk')
+                ->value('id');
+            if ($teamId) {
+                DB::table('team_employee')->where('team_id', $teamId)->delete();
+                DB::table('teams')->where('id', $teamId)->delete();
+            }
+
+            // Remove seeded users and role assignments
+            $userIds = DB::table('users')
+                ->whereIn('email', ['manager@acme.test', 'agent@acme.test'])
+                ->pluck('id');
+            if ($userIds->isNotEmpty()) {
+                DB::table('role_user')
+                    ->whereIn('user_id', $userIds)
+                    ->where('tenant_id', $tenantId)
+                    ->delete();
+                DB::table('users')->whereIn('id', $userIds)->delete();
+            }
+
+            // Remove roles created for this tenant
+            DB::table('roles')->where('tenant_id', $tenantId)->delete();
+
+            // Remove tenant
+            DB::table('tenants')->where('id', $tenantId)->delete();
+        }
+
+        // Remove global super admin role inserted by seeder if unused
+        DB::table('roles')->whereNull('tenant_id')->where('slug', 'super_admin')->delete();
+    }
+};


### PR DESCRIPTION
## Summary
- seed initial tenant, roles, users, and team via TenantBootstrapSeeder

## Testing
- `php artisan test` *(fails: Tests\Feature\RoleLevelRestrictionTest: cannot manage role above level, index scopes roles to tenant and level, Tests\Feature\RoleRoutesTest: crud routes work, Tests\Feature\SuperAdminRoleVisibilityTest: super admin can view roles from all tenants without header, and other failures; warnings about missing .env)*

------
https://chatgpt.com/codex/tasks/task_e_68c6826a129c832384b2139e99ac20a7