### PR TITLE
Add migration to seed tenant users and teams

### DIFF
--- a/backend/database/migrations/2025_10_16_000014_seed_tenant_users_and_teams.php
+++ b/backend/database/migrations/2025_10_16_000014_seed_tenant_users_and_teams.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Database\Seeders\TenantBootstrapSeeder;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        (new TenantBootstrapSeeder())->run();
+    }
+
+    public function down(): void
+    {
+        // Remove seeded team employees
+        $tenantId = DB::table('tenants')->where('name', 'Acme Vet')->value('id');
+        if ($tenantId) {
+            $teamId = DB::table('teams')
+                ->where('tenant_id', $tenantId)
+                ->where('name', 'Front Desk')
+                ->value('id');
+            if ($teamId) {
+                DB::table('team_employee')->where('team_id', $teamId)->delete();
+                DB::table('teams')->where('id', $teamId)->delete();
+            }
+
+            // Remove seeded users and role assignments
+            $userIds = DB::table('users')
+                ->whereIn('email', ['manager@acme.test', 'agent@acme.test'])
+                ->pluck('id');
+            if ($userIds->isNotEmpty()) {
+                DB::table('role_user')
+                    ->whereIn('user_id', $userIds)
+                    ->where('tenant_id', $tenantId)
+                    ->delete();
+                DB::table('users')->whereIn('id', $userIds)->delete();
+            }
+
+            // Remove roles created for this tenant
+            DB::table('roles')->where('tenant_id', $tenantId)->delete();
+
+            // Remove tenant
+            DB::table('tenants')->where('id', $tenantId)->delete();
+        }
+
+        // Remove global super admin role inserted by seeder if unused
+        DB::table('roles')->whereNull('tenant_id')->where('slug', 'super_admin')->delete();
+    }
+};

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -56,39 +56,6 @@ class TenantBootstrapSeeder extends Seeder
 
         DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant, $tenant->selectedFeatureAbilities());
 
-        $managerAbilities = array_intersect(
-            ['tasks.manage', 'teams.manage', 'task_statuses.manage', 'task_types.manage'],
-            $tenantAbilities
-        );
-        $agentAbilities = array_intersect(
-            ['tasks.view', 'tasks.update', 'tasks.status.update'],
-            $tenantAbilities
-        );
-
-        DB::table('roles')->updateOrInsert(
-            ['tenant_id' => $tenantId, 'slug' => 'manager'],
-            [
-                'name' => 'Manager',
-                'level' => 1,
-                'abilities' => json_encode($managerAbilities),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]
-        );
-        $managerRoleId = DB::table('roles')->where('tenant_id', $tenantId)->where('slug', 'manager')->value('id');
-
-        DB::table('roles')->updateOrInsert(
-            ['tenant_id' => $tenantId, 'slug' => 'agent'],
-            [
-                'name' => 'Agent',
-                'level' => 2,
-                'abilities' => json_encode($agentAbilities),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]
-        );
-        $agentRoleId = DB::table('roles')->where('tenant_id', $tenantId)->where('slug', 'agent')->value('id');
-
         // Team
         DB::table('teams')->updateOrInsert(
             ['tenant_id' => $tenantId, 'name' => 'Front Desk'],
@@ -129,15 +96,33 @@ class TenantBootstrapSeeder extends Seeder
         );
         $agentId = DB::table('users')->where('email', 'agent@acme.test')->value('id');
 
-        // Assign roles to employees
-        DB::table('role_user')->updateOrInsert(
-            ['role_id' => $managerRoleId, 'user_id' => $managerId, 'tenant_id' => $tenantId],
-            ['created_at' => now(), 'updated_at' => now()]
-        );
-        DB::table('role_user')->updateOrInsert(
-            ['role_id' => $agentRoleId, 'user_id' => $agentId, 'tenant_id' => $tenantId],
-            ['created_at' => now(), 'updated_at' => now()]
-        );
+        // Assign existing feature roles to employees
+        $managerRoleIds = DB::table('roles')
+            ->where('tenant_id', $tenantId)
+            ->where(function ($q) {
+                $q->where('slug', 'tenant')
+                    ->orWhere('slug', 'like', '%_manager');
+            })
+            ->pluck('id');
+
+        foreach ($managerRoleIds as $roleId) {
+            DB::table('role_user')->updateOrInsert(
+                ['role_id' => $roleId, 'user_id' => $managerId, 'tenant_id' => $tenantId],
+                ['created_at' => now(), 'updated_at' => now()]
+            );
+        }
+
+        $agentRoleIds = DB::table('roles')
+            ->where('tenant_id', $tenantId)
+            ->where('slug', 'like', '%_editor')
+            ->pluck('id');
+
+        foreach ($agentRoleIds as $roleId) {
+            DB::table('role_user')->updateOrInsert(
+                ['role_id' => $roleId, 'user_id' => $agentId, 'tenant_id' => $tenantId],
+                ['created_at' => now(), 'updated_at' => now()]
+            );
+        }
 
         // Assign employees to team
         foreach ([$managerId, $agentId] as $employeeId) {


### PR DESCRIPTION
## Summary
- seed initial tenant, roles, users, and team via TenantBootstrapSeeder
- assign seeded users to default feature roles rather than custom roles

## Testing
- `php artisan test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.; 27 failed, 103 warnings, 6 incomplete, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6826a129c832384b2139e99ac20a7