### PR TITLE
Seed tenant employees by default

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,10 +6,10 @@ This demo application is multi-tenant. Requests include the tenant context via t
 
 Teams group employees within a tenant. Users are attached to teams through the `team_employee` pivot table and gain role abilities via `role_user` records. When creating resources that support assignment, include an `assignee` field in the payload with `{ id: number }` (or an `assigned_user_id` field directly). The backend maps this to an `assigned_user_id` column.
 
-Run the tenant bootstrap seeder to populate a sample tenant with roles, a team, users, and default task types and statuses:
+Run the database migrations with seeding to populate a sample tenant with roles, a team, users, and default task types and statuses:
 
 ```bash
-php artisan migrate:fresh --seed --seeder=TenantBootstrapSeeder
+php artisan migrate:fresh --seed
 ```
 
 ## Role Levels

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -10,6 +10,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             TenantSeeder::class,
+            TenantBootstrapSeeder::class,
             RoleSeeder::class,
             SuperAdminSeeder::class,
             RoleUserSeeder::class,


### PR DESCRIPTION
## Summary
- Run TenantBootstrapSeeder from DatabaseSeeder so migrations seed demo tenant employees
- Document updated seeding instructions

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf. Tests: 37 failed, 93 warnings, 6 incomplete, 12 passed (305 assertions))*

------
https://chatgpt.com/codex/tasks/task_e_68c6918729708323a1e95685e5c86c67