### PR TITLE
Seed tenant employees without replacing super admin

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,10 +6,10 @@ This demo application is multi-tenant. Requests include the tenant context via t
 
 Teams group employees within a tenant. Users are attached to teams through the `team_employee` pivot table and gain role abilities via `role_user` records. When creating resources that support assignment, include an `assignee` field in the payload with `{ id: number }` (or an `assigned_user_id` field directly). The backend maps this to an `assigned_user_id` column.
 
-Run the tenant bootstrap seeder to populate a sample tenant with roles, a team, users, and default task types and statuses:
+Run the database migrations with seeding to populate a super admin account along with a sample tenant that includes roles, a team, employees, and default task types and statuses:
 
 ```bash
-php artisan migrate:fresh --seed --seeder=TenantBootstrapSeeder
+php artisan migrate:fresh --seed
 ```
 
 ## Role Levels

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,7 @@ class DatabaseSeeder extends Seeder
             RoleSeeder::class,
             SuperAdminSeeder::class,
             RoleUserSeeder::class,
+            TenantBootstrapSeeder::class,
             BrandingSeeder::class,
         ]);
     }


### PR DESCRIPTION
## Summary
- Seed a demo tenant with employees while preserving the existing super admin tenant
- Reorder default seeding so the super admin user is created before tenant demo data
- Document that seeding creates both a super admin account and a demo tenant with sample employees

## Testing
- `php artisan migrate:fresh --seed --force`
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf. Tests: 37 failed, 93 warnings, 6 incomplete, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6918729708323a1e95685e5c86c67