### PR TITLE
Seed tenant employees without replacing super admin

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,10 +6,10 @@ This demo application is multi-tenant. Requests include the tenant context via t
 
 Teams group employees within a tenant. Users are attached to teams through the `team_employee` pivot table and gain role abilities via `role_user` records. When creating resources that support assignment, include an `assignee` field in the payload with `{ id: number }` (or an `assigned_user_id` field directly). The backend maps this to an `assigned_user_id` column.
 
-Run the tenant bootstrap seeder to populate a sample tenant with roles, a team, users, and default task types and statuses:
+Run the database migrations with seeding to populate a super admin account along with a sample tenant that includes roles, a team, employees, and default task types and statuses:
 
 ```bash
-php artisan migrate:fresh --seed --seeder=TenantBootstrapSeeder
+php artisan migrate:fresh --seed
 ```
 
 ## Role Levels

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,7 @@ class DatabaseSeeder extends Seeder
             RoleSeeder::class,
             SuperAdminSeeder::class,
             RoleUserSeeder::class,
+            TenantBootstrapSeeder::class,
             BrandingSeeder::class,
         ]);
     }

--- a/frontend/src/components/ui/Header/index.vue
+++ b/frontend/src/components/ui/Header/index.vue
@@ -49,7 +49,7 @@
         <div
           class="nav-tools flex items-center lg:space-x-5 space-x-3 rtl:space-x-reverse"
         >
-          <TenantSwitcher v-if="authStore.isSuperAdmin" />
+          <TenantSwitcher v-if="authStore.isSuperAdmin || authStore.isImpersonating" />
           <AddNew />
           <SwitchDark />
           <Message v-if="window.width > 768" />

--- a/frontend/src/config/app.js
+++ b/frontend/src/config/app.js
@@ -2,6 +2,7 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 export const ACCESS_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY || 'access_token';
 export const REFRESH_TOKEN_KEY = import.meta.env.VITE_REFRESH_TOKEN_KEY || 'refresh_token';
 export const TENANT_ID_KEY = import.meta.env.VITE_TENANT_ID_KEY || 'tenant_id';
+export const TENANTS_KEY = import.meta.env.VITE_TENANTS_KEY || 'tenants';
 export const USER_KEY = import.meta.env.VITE_USER_KEY || 'user';
 export const AUTH_HEADER = 'Authorization';
 export const TENANT_HEADER = 'X-Tenant-ID';

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import api, { registerAuthStore } from '@/services/api';
 import { useThemeSettingsStore } from './themeSettings';
 import { useTenantStore } from '@/stores/tenant';
+import { TENANTS_KEY } from '@/config/app';
 import {
   getAccessToken,
   getRefreshToken,
@@ -86,7 +87,10 @@ export const useAuthStore = defineStore('auth', {
       delete api.defaults.headers.common['Authorization'];
       this.impersonatedTenant = '';
       localStorage.removeItem('impersonatingTenant');
-      useTenantStore().setTenant('');
+      localStorage.removeItem(TENANTS_KEY);
+      const tenantStore = useTenantStore();
+      tenantStore.setTenant('');
+      tenantStore.tenants = [];
     },
     async refresh() {
       if (!this.refreshToken) return;

--- a/frontend/src/stores/tenant.ts
+++ b/frontend/src/stores/tenant.ts
@@ -1,15 +1,16 @@
 import { defineStore } from 'pinia';
 import api from '@/services/api';
-import { TENANT_ID_KEY } from '@/config/app';
+import { TENANT_ID_KEY, TENANTS_KEY } from '@/config/app';
 import { withListParams, type ListParams } from './list';
 import { useLookupsStore } from '@/stores/lookups';
 
 const initialTenant = localStorage.getItem(TENANT_ID_KEY) || '';
+const initialTenants = JSON.parse(localStorage.getItem(TENANTS_KEY) || '[]');
 
 export const useTenantStore = defineStore('tenant', {
   state: () => ({
     currentTenantId: initialTenant as string,
-    tenants: [] as any[],
+    tenants: initialTenants as any[],
     allowedAbilities: {} as Record<string, Record<string, string[]>>,
   }),
   getters: {
@@ -24,6 +25,7 @@ export const useTenantStore = defineStore('tenant', {
           params: withListParams(params),
         });
         this.tenants = data.data;
+        localStorage.setItem(TENANTS_KEY, JSON.stringify(this.tenants));
         data.data.forEach((t: any) => {
           this.setAllowedAbilities(t.id, t.feature_abilities || {});
         });


### PR DESCRIPTION
## Summary
- Seed a demo tenant with employees while preserving the existing super admin tenant
- Reorder default seeding so the super admin user is created before tenant demo data
- Document that seeding creates both a super admin account and a demo tenant with sample employees
- Persist tenant list and expose the super admin tenant in the switcher for impersonation

## Testing
- `php artisan migrate:fresh --seed --force`
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf. Tests: 37 failed, 93 warnings, 6 incomplete, 12 passed)*
- `npm test` *(fails: missing Playwright browsers; 5 failed, 17 skipped, 57 did not run, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6918729708323a1e95685e5c86c67