### PR TITLE
Show super admin in tenant selectors

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -27,6 +27,7 @@ export const useAuthStore = defineStore('auth', {
     accessToken: initialAccess as string | null,
     refreshToken: initialRefresh as string | null,
     impersonatedTenant: localStorage.getItem('impersonatingTenant') || '',
+    impersonator: JSON.parse(localStorage.getItem('impersonator') || 'null') as any,
     abilities: [] as string[],
     features: [] as string[],
   }),
@@ -91,6 +92,8 @@ export const useAuthStore = defineStore('auth', {
       delete api.defaults.headers.common['Authorization'];
       this.impersonatedTenant = '';
       localStorage.removeItem('impersonatingTenant');
+      this.impersonator = null;
+      localStorage.removeItem('impersonator');
       localStorage.removeItem(TENANTS_KEY);
       const tenantStore = useTenantStore();
       tenantStore.setTenant('');
@@ -114,6 +117,8 @@ export const useAuthStore = defineStore('auth', {
       await api.post('/auth/password/reset', payload);
     },
     async impersonate(tenantId: string, tenantName: string) {
+      localStorage.setItem('impersonator', JSON.stringify(this.user));
+      this.impersonator = this.user;
       const { data } = await api.post(`/tenants/${tenantId}/impersonate`);
       this.accessToken = data.access_token;
       this.refreshToken = data.refresh_token;

--- a/frontend/src/stores/tenant.ts
+++ b/frontend/src/stores/tenant.ts
@@ -29,16 +29,19 @@ export const useTenantStore = defineStore('tenant', {
         try {
           const { useAuthStore } = await import('@/stores/auth');
           const auth = useAuthStore();
+          const superAdmin = auth.isImpersonating ? auth.impersonator : auth.user;
           if (
-            auth.user &&
-            auth.isSuperAdmin &&
-            !this.tenants.some((t: any) => String(t.id) === String(auth.user?.tenant_id))
+            superAdmin &&
+            (auth.isSuperAdmin || auth.isImpersonating) &&
+            !this.tenants.some(
+              (t: any) => String(t.id) === String(superAdmin.tenant_id),
+            )
           ) {
             this.tenants.unshift({
-              id: auth.user.tenant_id,
-              name: auth.user.name,
-              phone: auth.user.phone ?? '',
-              address: auth.user.address ?? '',
+              id: superAdmin.tenant_id,
+              name: superAdmin.name,
+              phone: superAdmin.phone ?? '',
+              address: superAdmin.address ?? '',
             });
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- preserve the original super admin account when impersonating
- use impersonator info to prepend Super Admin tenant while impersonating

## Testing
- `npm test` *(fails: command terminated with Vue warnings)*
- `npm run lint` *(fails: Attribute order issues and accessibility warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a7f019648323a1e2f1377764b2b7