### PR TITLE
Show super admin in tenant selectors

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -27,6 +27,7 @@ export const useAuthStore = defineStore('auth', {
     accessToken: initialAccess as string | null,
     refreshToken: initialRefresh as string | null,
     impersonatedTenant: localStorage.getItem('impersonatingTenant') || '',
+    impersonator: JSON.parse(localStorage.getItem('impersonator') || 'null') as any,
     abilities: [] as string[],
     features: [] as string[],
   }),
@@ -72,7 +73,10 @@ export const useAuthStore = defineStore('auth', {
       this.abilities = data.abilities || [];
       this.features = data.features || [];
       const tenantStore = useTenantStore();
-      tenantStore.setTenant(data.user?.tenant_id || '');
+      const tenantId = this.isSuperAdmin
+        ? 'super_admin'
+        : data.user?.tenant_id || '';
+      tenantStore.setTenant(tenantId);
       if (this.isSuperAdmin || this.isImpersonating) {
         await tenantStore.loadTenants();
       }
@@ -91,6 +95,8 @@ export const useAuthStore = defineStore('auth', {
       delete api.defaults.headers.common['Authorization'];
       this.impersonatedTenant = '';
       localStorage.removeItem('impersonatingTenant');
+      this.impersonator = null;
+      localStorage.removeItem('impersonator');
       localStorage.removeItem(TENANTS_KEY);
       const tenantStore = useTenantStore();
       tenantStore.setTenant('');
@@ -114,6 +120,8 @@ export const useAuthStore = defineStore('auth', {
       await api.post('/auth/password/reset', payload);
     },
     async impersonate(tenantId: string, tenantName: string) {
+      localStorage.setItem('impersonator', JSON.stringify(this.user));
+      this.impersonator = this.user;
       const { data } = await api.post(`/tenants/${tenantId}/impersonate`);
       this.accessToken = data.access_token;
       this.refreshToken = data.refresh_token;

--- a/frontend/src/stores/tenant.ts
+++ b/frontend/src/stores/tenant.ts
@@ -29,16 +29,17 @@ export const useTenantStore = defineStore('tenant', {
         try {
           const { useAuthStore } = await import('@/stores/auth');
           const auth = useAuthStore();
+          const superAdmin = auth.isImpersonating ? auth.impersonator : auth.user;
           if (
-            auth.user &&
-            auth.isSuperAdmin &&
-            !this.tenants.some((t: any) => String(t.id) === String(auth.user?.tenant_id))
+            (auth.isSuperAdmin || auth.isImpersonating) &&
+            superAdmin &&
+            !this.tenants.some((t: any) => String(t.id) === 'super_admin')
           ) {
             this.tenants.unshift({
-              id: auth.user.tenant_id,
-              name: auth.user.name,
-              phone: auth.user.phone ?? '',
-              address: auth.user.address ?? '',
+              id: 'super_admin',
+              name: superAdmin?.name || 'Super Admin',
+              phone: superAdmin?.phone ?? '',
+              address: superAdmin?.address ?? '',
             });
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- assign a placeholder tenant ID for super admins so the switcher can select it
- prepend a Super Admin entry when loading tenants

## Testing
- `npm test`
- `npm run lint` *(fails: attribute order and accessibility issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a7f019648323a1e2f1377764b2b7