### PR TITLE
fix: use router-view slot with transition

### DIFF
--- a/frontend/src/Layout/AppLayout.vue
+++ b/frontend/src/Layout/AppLayout.vue
@@ -6,9 +6,11 @@
         <main class="flex-1 p-4">
           <Breadcrumbs />
           <div class="relative">
-            <Transition name="fade" mode="out-in">
-              <router-view />
-            </Transition>
+            <router-view v-slot="{ Component }">
+              <Transition name="fade" mode="out-in">
+                <component :is="Component" />
+              </Transition>
+            </router-view>
           </div>
         </main>
         <Footer />


### PR DESCRIPTION
## Summary
- wrap AppLayout router-view with slot-based transition usage to avoid Vue Router deprecation warning

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before ":class"; Form label must have an associated control; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c6eff31c83239b741b565c83d49a