### PR TITLE
fix: use v-slot for router view

### DIFF
--- a/frontend/src/Layout/DashcodeLayout.vue
+++ b/frontend/src/Layout/DashcodeLayout.vue
@@ -46,7 +46,7 @@
           }`"
         >
 
-          <router-view #default="{ Component }">
+          <router-view v-slot="{ Component }">
             <Transition name="fade" mode="out-in">
               <component :is="Component" />
             </Transition>


### PR DESCRIPTION
## Summary
- replace deprecated router-view shorthand with `v-slot` in Dashcode layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7bd2ea48323be6d64d7ae4e2ea6