### PR TITLE
Skip tenant watcher reset on initial employee load

### DIFF
--- a/frontend/src/views/employees/EmployeeForm.vue
+++ b/frontend/src/views/employees/EmployeeForm.vue
@@ -182,6 +182,7 @@ async function submit() {
 
 watch(tenantId, async (newTenant, oldTenant) => {
   if (!auth.isSuperAdmin || newTenant === oldTenant) return;
+  if (isEdit.value && !oldTenant) return;
   const prev = tenantStore.tenantId;
   tenantStore.setTenant(String(newTenant));
   await loadRoles();


### PR DESCRIPTION
## Summary
- avoid clearing role and feature selections when tenant is assigned during initial load

## Testing
- `npm run lint` *(fails: Existing lint errors in unrelated files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6c87289748323a45a530556ad75f5