### PR TITLE
Gate demo tenant seeder behind env flag

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,3 +24,6 @@ FILESYSTEM_DISK=public
 QUEUE_CONNECTION=database
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
+
+# Set to true to seed demo tenant data
+ENABLE_DEMO_SEEDER=false

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@ This demo application is multi-tenant. Requests include the tenant context via t
 
 Teams group employees within a tenant. Users are attached to teams through the `team_employee` pivot table and gain role abilities via `role_user` records. When creating resources that support assignment, include an `assignee` field in the payload with `{ id: number }` (or an `assigned_user_id` field directly). The backend maps this to an `assigned_user_id` column.
 
-Run the database migrations with seeding to populate a super admin account along with a sample tenant that includes roles, a team, employees, and default task types and statuses:
+Run the database migrations with seeding to populate a super admin account. To include the optional demo tenant with sample data, set `ENABLE_DEMO_SEEDER=true` in your `.env` file before running:
 
 ```bash
 php artisan migrate:fresh --seed

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -10,12 +10,14 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             TenantSeeder::class,
-            TenantBootstrapSeeder::class,
             RoleSeeder::class,
             SuperAdminSeeder::class,
             RoleUserSeeder::class,
-            TenantBootstrapSeeder::class,
             BrandingSeeder::class,
         ]);
+
+        if (env('ENABLE_DEMO_SEEDER', false)) {
+            $this->call(TenantBootstrapSeeder::class);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Deduplicate `TenantBootstrapSeeder` and guard it with `ENABLE_DEMO_SEEDER`
- Add `ENABLE_DEMO_SEEDER` flag to `.env.example`
- Document demo seeder flag in backend README

## Testing
- `composer test` *(fails: Tests\Feature\LookupRoutesTest > abilities lookup scopes for tenant features)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c979593c8323a4e8c913bc939b21