### PR TITLE
Enable All tenants view for employees

### DIFF
--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -88,16 +88,6 @@ function formatRoles(roles: any[]) {
 
 async function load() {
   await tenantStore.loadTenants({ per_page: 100 });
-  if (auth.isSuperAdmin) {
-    if (!tenantFilter.value) {
-      tenantFilter.value = tenantStore.currentTenantId || tenantStore.tenants[0]?.id || '';
-    }
-    if (!tenantFilter.value) {
-      loading.value = false;
-      all.value = [];
-      return;
-    }
-  }
   const params: any = {};
   if (auth.isSuperAdmin && tenantFilter.value) {
     params.tenant_id = tenantFilter.value;


### PR DESCRIPTION
## Summary
- Allow super admins to query employees across all tenants
- Default employee list to "All tenants" without forcing a selection

## Testing
- `composer test` *(fails: Tests: 27 failed, 103 warnings, 6 incomplete, 12 passed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6cc5f448c83238e2b92adbd2ac36b