### PR TITLE
Fix team employees pivot relation

### DIFF
--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -22,6 +22,6 @@ class Team extends Model
 
     public function employees(): BelongsToMany
     {
-        return $this->belongsToMany(Employee::class, 'team_employee');
+        return $this->belongsToMany(Employee::class, 'team_employee', 'team_id', 'employee_id');
     }
 }


### PR DESCRIPTION
## Summary
- specify pivot keys for `Team::employees()` to match `team_employee` columns

## Testing
- `php artisan test tests/Feature/TeamsTest.php`
- `php artisan tinker --execute="echo App\Models\Team::first()->employees()->count();"`
- `composer test` *(fails: Tests: 29 failed, 6 incomplete, 113 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cd4bfd648323b6db78e1fee9fa23