### PR TITLE
Handle super admin tenant filter

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskStatusController.php
+++ b/backend/app/Http/Controllers/Api/TaskStatusController.php
@@ -21,7 +21,7 @@ class TaskStatusController extends Controller
         }
     }
 
-        public function index(Request $request)
+    public function index(Request $request)
     {
         $scope = $request->query('scope', $request->user()->hasRole('SuperAdmin') ? 'all' : 'tenant');
         $query = TaskStatus::query()->withCount('tasks');
@@ -35,7 +35,13 @@ class TaskStatusController extends Controller
             $query->whereNull('tenant_id');
         } else {
             if ($request->has('tenant_id')) {
-                $query->where('tenant_id', $request->query('tenant_id'));
+                $tenantId = $request->query('tenant_id');
+
+                if ($tenantId === 'super_admin') {
+                    $query->whereNull('tenant_id');
+                } else {
+                    $query->where('tenant_id', $tenantId);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Treat `tenant_id=super_admin` as global when listing task statuses

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d54f2a5c8323987025bed7425458