### PR TITLE
feat: add unimpersonate support

### DIFF
--- a/frontend/src/components/admin/TenantSwitcher.vue
+++ b/frontend/src/components/admin/TenantSwitcher.vue
@@ -43,6 +43,10 @@ watch(selected, async (val) => {
   // impersonation request. Instead reset the tenant context.
   if (String(val) === 'super_admin') {
     tenantStore.setTenant('');
+    if (props.impersonate && authStore.isImpersonating) {
+      await authStore.unimpersonate();
+      window.location.reload();
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- add unimpersonate action to restore original session or logout
- clear impersonation data when leaving tenant context
- invoke unimpersonate from TenantSwitcher when selecting Super Admin

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute "v-if" should go before)*


------
https://chatgpt.com/codex/tasks/task_e_68c6d7d46b3c8323b13e2d4225190366