### PR TITLE
fix: retain original impersonator

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -118,10 +118,18 @@ export const useAuthStore = defineStore('auth', {
       await api.post('/auth/password/reset', payload);
     },
     async impersonate(tenantId: string, tenantName: string) {
-      localStorage.setItem('impersonator', JSON.stringify(this.user));
-      localStorage.setItem('impersonatorAccessToken', this.accessToken || '');
-      localStorage.setItem('impersonatorRefreshToken', this.refreshToken || '');
-      this.impersonator = this.user;
+      if (!this.isImpersonating) {
+        localStorage.setItem('impersonator', JSON.stringify(this.user));
+        localStorage.setItem(
+          'impersonatorAccessToken',
+          this.accessToken || '',
+        );
+        localStorage.setItem(
+          'impersonatorRefreshToken',
+          this.refreshToken || '',
+        );
+        this.impersonator = this.user;
+      }
       const { data } = await api.post(`/tenants/${tenantId}/impersonate`);
       this.accessToken = data.access_token;
       this.refreshToken = data.refresh_token;


### PR DESCRIPTION
## Summary
- preserve original session when chaining impersonations

## Testing
- `npm test` *(fails: 16 failed, 25 skipped, 4 did not run)*
- `npm run lint` *(fails: Attribute "v-if" should go before)*

------
https://chatgpt.com/codex/tasks/task_e_68c6df2eb1948323a776fb7cb360fd38