### PR TITLE
Ensure super admin task status filter defaults to all tenants

### DIFF
--- a/frontend/src/views/statuses/StatusesList.vue
+++ b/frontend/src/views/statuses/StatusesList.vue
@@ -82,8 +82,11 @@ const tenantOptions = computed(() => [
 ]);
 
 async function load() {
-  const scopeParam: 'tenant' | 'global' | 'all' = scope.value;
-  const tenantId: string | number | '' | undefined = auth.isSuperAdmin
+  const isFilteringByTenant = auth.isSuperAdmin && tenantFilter.value !== '';
+  const scopeParam: 'tenant' | 'global' | 'all' = isFilteringByTenant
+    ? 'tenant'
+    : scope.value;
+  const tenantId: string | number | undefined = isFilteringByTenant
     ? tenantFilter.value
     : undefined;
 


### PR DESCRIPTION
## Summary
- Show all task statuses by default for super admins
- Filter task statuses by tenant only when a tenant is selected

## Testing
- `npm run lint` (fails: Attribute order and accessibility issues)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e08b625c832391f1f4ff910eeca1