### PR TITLE
Fix tenant filter for roles and employees pages

### DIFF
--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -89,7 +89,8 @@ function formatRoles(roles: any[]) {
 async function load() {
   await tenantStore.loadTenants({ per_page: 100 });
   const params: any = {};
-  if (auth.isSuperAdmin) {
+  const isFilteringByTenant = auth.isSuperAdmin && tenantFilter.value !== '';
+  if (isFilteringByTenant) {
     params.tenant_id = tenantFilter.value;
   }
   const { data } = await api.get('/employees', { params });
@@ -122,9 +123,7 @@ function reload() {
   load();
 }
 
-watch(tenantFilter, () => {
-  if (auth.isSuperAdmin) reload();
-});
+watch(tenantFilter, reload);
 
 watch(
   () => tenantStore.currentTenantId,

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -86,15 +86,17 @@ const tenantOptions = computed(() => [
 ]);
 
 async function load() {
-  let scope: 'tenant' | 'global' | 'all' = 'tenant';
-  let tenantId: string | number | undefined;
-
-  if (auth.isSuperAdmin) {
-    scope = 'all';
-    tenantId = tenantFilter.value || undefined;
-  } else {
-    tenantId = tenantStore.currentTenantId || undefined;
-  }
+  const isFilteringByTenant = auth.isSuperAdmin && tenantFilter.value !== '';
+  const scope: 'tenant' | 'global' | 'all' = auth.isSuperAdmin
+    ? isFilteringByTenant
+      ? 'tenant'
+      : 'all'
+    : 'tenant';
+  const tenantId: string | number | undefined = auth.isSuperAdmin
+    ? isFilteringByTenant
+      ? tenantFilter.value
+      : undefined
+    : tenantStore.currentTenantId || undefined;
 
   await rolesStore.fetch({ scope, tenant_id: tenantId });
   await tenantStore.loadTenants({ per_page: 100 });


### PR DESCRIPTION
## Summary
- Ensure tenant filter for roles list uses tenant-specific scope when a tenant is selected
- Apply the same tenant-filter loading logic to employees list

## Testing
- `pnpm lint` *(fails: Attribute order and default prop warnings)*
- `pnpm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f3de62e48323ae6db0f556b7ec4a