### PR TITLE
Document super admin helper and tenant bypass tests

### DIFF
--- a/backend/app/Http/Middleware/EnsureTenantScope.php
+++ b/backend/app/Http/Middleware/EnsureTenantScope.php
@@ -10,6 +10,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EnsureTenantScope
 {
+    /**
+     * Enforce tenant scoping while allowing SuperAdmins to bypass checks.
+     */
     public function handle(Request $request, Closure $next): Response
     {
         $user = $request->user();

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -48,6 +48,12 @@ class User extends Authenticatable
         return $this->roles()->wherePivot('tenant_id', $tenantId)->get();
     }
 
+    /**
+     * Determine if the user holds the SuperAdmin role.
+     *
+     * This helper can be reused across policies and middleware to
+     * allow privileged users to bypass tenant restrictions.
+     */
     public function isSuperAdmin(): bool
     {
         return $this->roles()

--- a/backend/app/Policies/TenantOwnedPolicy.php
+++ b/backend/app/Policies/TenantOwnedPolicy.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class TenantOwnedPolicy
 {
+    /**
+     * Grant all abilities to SuperAdmins prior to policy checks.
+     */
     public function before(User $user, string $ability)
     {
         if ($user->isSuperAdmin()) {

--- a/backend/tests/Feature/SuperAdminTenantAccessTest.php
+++ b/backend/tests/Feature/SuperAdminTenantAccessTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SuperAdminTenantAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_view_roles_for_any_tenant(): void
+    {
+        $tenantA = Tenant::create(['name' => 'A']);
+        $tenantB = Tenant::create(['name' => 'B']);
+
+        $superRole = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'tenant_id' => $tenantA->id,
+        ]);
+
+        $user = User::create([
+            'name' => 'SA',
+            'email' => 'sa@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenantA->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($superRole->id, ['tenant_id' => $tenantA->id]);
+
+        $roleB = Role::create(['name' => 'Viewer', 'slug' => 'viewer', 'tenant_id' => $tenantB->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->withHeader('X-Tenant-ID', $tenantB->id)
+            ->getJson('/api/roles?tenant_id=' . $tenantB->id)
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $roleB->id, 'tenant_id' => $tenantB->id]);
+    }
+
+    public function test_super_admin_can_update_role_for_any_tenant(): void
+    {
+        $tenantA = Tenant::create(['name' => 'A']);
+        $tenantB = Tenant::create(['name' => 'B']);
+
+        $superRole = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'tenant_id' => $tenantA->id,
+        ]);
+
+        $user = User::create([
+            'name' => 'SA',
+            'email' => 'sa@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenantA->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+        $user->roles()->attach($superRole->id, ['tenant_id' => $tenantA->id]);
+
+        $roleB = Role::create(['name' => 'Viewer', 'slug' => 'viewer', 'tenant_id' => $tenantB->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->withHeader('X-Tenant-ID', $tenantB->id)
+            ->putJson("/api/roles/{$roleB->id}", [
+                'name' => 'Updated',
+                'slug' => 'updated',
+            ])
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $roleB->id, 'name' => 'Updated', 'slug' => 'updated']);
+
+        $this->assertDatabaseHas('roles', [
+            'id' => $roleB->id,
+            'tenant_id' => $tenantB->id,
+            'name' => 'Updated',
+            'slug' => 'updated',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- document and expose `isSuperAdmin()` helper on `User`
- clarify super-admin bypass in tenant policy and scope middleware
- add feature tests verifying super admin access across tenant IDs

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `./vendor/bin/phpunit tests/Feature/SuperAdminTenantAccessTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6faef70c08323876f184f70d9032a