### PR TITLE
Handle super admin tenant context and verify tenant switching headers

### DIFF
--- a/backend/app/Http/Middleware/EnsureTenantScope.php
+++ b/backend/app/Http/Middleware/EnsureTenantScope.php
@@ -21,7 +21,13 @@ class EnsureTenantScope
         if ($user->isSuperAdmin()) {
             if ($tenantId) {
                 $this->bindTenant($request, (int) $tenantId);
+            } else {
+                Tenant::setCurrent(null);
+                app()->forgetInstance('tenant_id');
+                config(['tenant' => []]);
+                config(['tenant.branding' => null]);
             }
+
             return $next($request);
         }
 

--- a/frontend/tests/tenant-switch.test.ts
+++ b/frontend/tests/tenant-switch.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+import { setActivePinia, createPinia } from 'pinia';
+
+let api: any;
+let TENANT_HEADER: any;
+let useTenantStore: any;
+
+describe('tenant switching', () => {
+  let mock: MockAdapter;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const store: Record<string, string> = {};
+    // @ts-ignore
+    globalThis.localStorage = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => (store[k] = v),
+      removeItem: (k: string) => delete store[k],
+    };
+
+    ({ default: api } = await import('../src/services/api'));
+    ({ TENANT_HEADER } = await import('../src/config/app'));
+    ({ useTenantStore } = await import('../src/stores/tenant'));
+
+    setActivePinia(createPinia());
+    mock = new MockAdapter(api);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('attaches tenant header and exposes abilities on switch', async () => {
+    mock.onGet('/tenants').reply(200, {
+      data: [
+        { id: 1, feature_abilities: { tasks: ['create'] } },
+        { id: 2, feature_abilities: { tasks: ['edit'] } },
+      ],
+      meta: {},
+    });
+
+    const store = useTenantStore();
+    await store.loadTenants();
+
+    // switch to tenant 1
+    store.setTenant('1');
+    mock.onGet('/check').reply((config) => {
+      expect(config.headers[TENANT_HEADER]).toBe('1');
+      return [200, { ok: true }];
+    });
+    await api.get('/check');
+    expect(store.tenantAllowedAbilities('1')).toEqual({ tasks: ['create'] });
+
+    // switch to tenant 2
+    store.setTenant('2');
+    mock.onGet('/check').reply((config) => {
+      expect(config.headers[TENANT_HEADER]).toBe('2');
+      return [200, { ok: true }];
+    });
+    await api.get('/check');
+    expect(store.tenantAllowedAbilities('2')).toEqual({ tasks: ['edit'] });
+  });
+});


### PR DESCRIPTION
## Summary
- reset tenant context for super admins without `X-Tenant-ID`
- add integration test confirming tenant switching updates headers and abilities

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf; Tests: 24 failed, 108 warnings, 6 incomplete, 12 passed)*
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist; 20 failed)*
- `pnpm exec playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68c6fd6471d4832389ee5c1547cd5779