### PR TITLE
Prevent tenant impersonation on role tenant selection

### DIFF
--- a/frontend/src/views/roles/RoleForm.vue
+++ b/frontend/src/views/roles/RoleForm.vue
@@ -1,6 +1,10 @@
 <template>
   <div v-if="canAccess">
-    <TenantSwitcher v-if="auth.isSuperAdmin" class="mb-4" />
+    <TenantSwitcher
+      v-if="auth.isSuperAdmin"
+      class="mb-4"
+      :impersonate="false"
+    />
     <form class="max-w-md grid gap-4" @submit.prevent="onSubmit">
       <div>
         <span class="block font-medium mb-1">Name<span class="text-red-600">*</span></span>

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <TenantSwitcher v-if="auth.isSuperAdmin" class="mb-4" />
+    <TenantSwitcher
+      v-if="auth.isSuperAdmin"
+      class="mb-4"
+      :impersonate="false"
+    />
     <RolesTable
       v-if="!loading"
       :rows="all"


### PR DESCRIPTION
## Summary
- prevent TenantSwitcher from impersonating when selecting tenants on role form and list pages

## Testing
- `npm test`
- `npm run lint` *(fails: Attribute order and accessibility issues in existing UI components)*

------
https://chatgpt.com/codex/tasks/task_e_68c701acebe0832380cf4cbfefaa3588