### PR TITLE
fix: ignore super admin tenant when filtering roles

### DIFF
--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -92,7 +92,10 @@ const tenantOptions = computed(() => [
 ]);
 
 async function load() {
-  const isFilteringByTenant = auth.isSuperAdmin && tenantFilter.value !== '';
+  const isFilteringByTenant =
+    auth.isSuperAdmin &&
+    tenantFilter.value !== '' &&
+    tenantFilter.value !== 'super_admin';
   const scope: 'tenant' | 'global' | 'all' = auth.isSuperAdmin
     ? isFilteringByTenant
       ? 'tenant'


### PR DESCRIPTION
## Summary
- avoid treating the `super_admin` sentinel as a tenant filter so the Super Admin option loads all roles

## Testing
- `npm run lint` *(fails: Attribute order and a11y errors in unrelated components)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7048cceb08323ad262b1fcd08128f