### PR TITLE
Use extractData when loading team form

### DIFF
--- a/frontend/src/views/teams/TeamForm.vue
+++ b/frontend/src/views/teams/TeamForm.vue
@@ -128,15 +128,16 @@ async function loadEmployees() {
 async function loadTeam(preserveTenant = false) {
   if (!isEdit.value) return;
   const { data } = await api.get(`/teams/${route.params.id}`);
-  form.value.name = data.name || '';
-  form.value.description = data.description || '';
+  const team = extractData(data);
+  form.value.name = team.name || '';
+  form.value.description = team.description || '';
   if (!preserveTenant) {
-    tenantId.value = data.tenant_id ? String(data.tenant_id) : '';
+    tenantId.value = team.tenant_id ? String(team.tenant_id) : '';
   }
-  selectedEmployees.value = (data.employees || []).map((e: any) => e.id);
+  selectedEmployees.value = (team.employees || []).map((e: any) => e.id);
   hiddenRoles.value = {};
   featureGrants.value = {} as Record<string, string[]>;
-  (data.roles || []).forEach((r: any) => {
+  (team.roles || []).forEach((r: any) => {
     if (r.slug?.startsWith('__fg__')) {
       const parts = r.slug.split('__').filter(Boolean);
       const feature = parts[2];


### PR DESCRIPTION
## Summary
- Parse team API responses with `extractData` before mapping fields in the team form
- Ensure API helper `extractData` is imported

## Testing
- `npm run lint` *(fails: 10 errors, 4 warnings)*
- `npm test` *(unit tests pass; e2e tests fail: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c70580c4188323b436158daea7cf6a