### PR TITLE
feat: hide tenant column for non-super-admins

### DIFF
--- a/frontend/src/components/teams/TeamsTable.vue
+++ b/frontend/src/components/teams/TeamsTable.vue
@@ -131,7 +131,10 @@ interface TeamRow {
   tenant_id?: number | null;
 }
 
-const props = defineProps<{ rows: TeamRow[] }>();
+const props = withDefaults(
+  defineProps<{ rows: TeamRow[]; isSuperAdmin?: boolean }>(),
+  { isSuperAdmin: false },
+);
 const emit = defineEmits<{ (e: 'edit', id: number): void; (e: 'delete', id: number): void; (e: 'delete-selected', ids: number[]): void; }>();
 
 const { t } = useI18n();
@@ -154,14 +157,19 @@ const selectOptions = {
   selectAllByGroup: true,
 };
 
-const columns = [
-  { label: 'Name', field: 'name' },
-  { label: 'Description', field: 'description' },
-  { label: 'Members', field: 'members' },
-  { label: 'Tenant', field: 'tenant' },
-  { label: 'Created', field: 'created_at' },
-  { label: 'Actions', field: 'actions' },
-];
+const columns = computed(() => {
+  const cols = [
+    { label: 'Name', field: 'name' },
+    { label: 'Description', field: 'description' },
+    { label: 'Members', field: 'members' },
+  ];
+  if (props.isSuperAdmin) {
+    cols.push({ label: 'Tenant', field: 'tenant' });
+  }
+  cols.push({ label: 'Created', field: 'created_at' });
+  cols.push({ label: 'Actions', field: 'actions' });
+  return cols;
+});
 
 const selectedIds = ref<number[]>([]);
 

--- a/frontend/src/views/teams/TeamsList.vue
+++ b/frontend/src/views/teams/TeamsList.vue
@@ -3,6 +3,7 @@
     <TeamsTable
       v-if="!loading"
       :rows="all"
+      :is-super-admin="auth.isSuperAdmin"
       @edit="edit"
       @delete="remove"
       @delete-selected="removeMany"


### PR DESCRIPTION
## Summary
- show Tenant column in TeamsTable only for super admins
- pass isSuperAdmin flag from TeamsList to TeamsTable

## Testing
- `pnpm run lint` *(fails: v-slot style, attributes order, etc.)*
- `pnpm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c70b065f648323b92ff45252a13fe1