### PR TITLE
feat: add team lead

### DIFF
--- a/backend/app/Http/Requests/TeamUpsertRequest.php
+++ b/backend/app/Http/Requests/TeamUpsertRequest.php
@@ -28,6 +28,7 @@ class TeamUpsertRequest extends FormRequest
             ],
             'description' => ['nullable', 'string'],
             'tenant_id' => ['nullable', 'exists:tenants,id'],
+            'lead_id' => ['nullable', 'integer', 'exists:users,id'],
         ];
     }
 
@@ -37,6 +38,7 @@ class TeamUpsertRequest extends FormRequest
             'name' => 'name',
             'description' => 'description',
             'tenant_id' => 'tenant',
+            'lead_id' => 'team lead',
         ];
     }
 

--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -13,6 +13,7 @@ class Team extends Model
         'tenant_id',
         'name',
         'description',
+        'lead_id',
     ];
 
     public function tenant(): BelongsTo
@@ -23,5 +24,10 @@ class Team extends Model
     public function employees(): BelongsToMany
     {
         return $this->belongsToMany(Employee::class, 'team_employee', 'team_id', 'employee_id');
+    }
+
+    public function lead(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'lead_id');
     }
 }

--- a/backend/database/migrations/2025_08_28_000003_add_lead_id_to_teams_table.php
+++ b/backend/database/migrations/2025_08_28_000003_add_lead_id_to_teams_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->foreignId('lead_id')->nullable()->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('lead_id');
+        });
+    }
+};

--- a/frontend/src/components/teams/TeamsTable.vue
+++ b/frontend/src/components/teams/TeamsTable.vue
@@ -40,6 +40,23 @@
           </Tooltip>
           <span v-else>—</span>
         </span>
+        <span v-else-if="rowProps.column.field === 'lead'">
+          <div v-if="rowProps.row.lead" class="flex items-center gap-2">
+            <div
+              class="w-8 h-8 rounded-full bg-slate-200 text-xs font-medium text-slate-600 flex items-center justify-center overflow-hidden"
+            >
+              <img
+                v-if="rowProps.row.lead.avatar"
+                :src="rowProps.row.lead.avatar"
+                alt="avatar"
+                class="w-full h-full object-cover"
+              />
+              <span v-else>{{ getInitials(rowProps.row.lead.name) }}</span>
+            </div>
+            <span>{{ rowProps.row.lead.name }}</span>
+          </div>
+          <span v-else>—</span>
+        </span>
         <span v-else-if="rowProps.column.field === 'members'">
           <AvatarGroup :members="rowProps.row.members" :max="3" />
         </span>
@@ -125,6 +142,7 @@ interface TeamRow {
   name: string;
   description: string | null;
   members: { name: string; avatar?: string | null }[];
+  lead?: { id: number; name: string; avatar?: string | null } | null;
   created_at: string;
   updated_at: string;
   tenant?: { id: number; name: string } | null;
@@ -161,6 +179,7 @@ const columns = computed(() => {
   const cols = [
     { label: 'Name', field: 'name' },
     { label: 'Description', field: 'description' },
+    { label: 'Team Lead', field: 'lead' },
     { label: 'Members', field: 'members' },
   ];
   if (props.isSuperAdmin) {
@@ -193,5 +212,15 @@ function truncateDescription(desc: string) {
 
 function formatDate(d: string) {
   return new Date(d).toLocaleDateString();
+}
+
+function getInitials(name: string) {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
 }
 </script>

--- a/frontend/src/views/teams/TeamsList.vue
+++ b/frontend/src/views/teams/TeamsList.vue
@@ -52,6 +52,7 @@ interface TeamRow {
   name: string;
   description: string | null;
   members: { name: string; avatar?: string | null }[];
+  lead?: { id: number; name: string; avatar?: string | null } | null;
   created_at: string;
   updated_at: string;
   tenant?: { id: number; name: string } | null;
@@ -89,6 +90,7 @@ async function load() {
     name: t.name,
     description: t.description,
     members: (t.employees || []).map((e: any) => ({ name: e.name, avatar: e.avatar })),
+    lead: t.lead ? { id: t.lead.id, name: t.lead.name, avatar: t.lead.avatar } : null,
     created_at: t.created_at,
     updated_at: t.updated_at,
     tenant: t.tenant || tenantMap[t.tenant_id] || null,


### PR DESCRIPTION
## Summary
- add `lead_id` field and relation for teams
- expose team lead via API and table column

## Testing
- `composer test` *(fails: Tests\Feature\TaskTypeBuilderTest > store task type with abilities; Tests: 24 failed, 108 warnings, 6 incomplete, 12 passed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c70e2c73248323b8c7f80208621b25