### PR TITLE
Include timestamps in role API responses

### DIFF
--- a/backend/app/Http/Resources/RoleResource.php
+++ b/backend/app/Http/Resources/RoleResource.php
@@ -20,6 +20,8 @@ class RoleResource extends JsonResource
             'tenant_id' => $this->tenant_id,
             'level' => $this->level,
             'users_count' => $this->users_count ?? 0,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
         ]);
     }
 }

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1224,6 +1224,12 @@ components:
           nullable: true
         level:
           type: integer
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     RoleAssignment:
       type: object
       required:

--- a/backend/tests/Feature/RolesTest.php
+++ b/backend/tests/Feature/RolesTest.php
@@ -51,6 +51,12 @@ class RolesTest extends TestCase
             ->assertJsonFragment([
                 'id' => $role->id,
                 'users_count' => 1,
+            ])
+            ->assertJsonStructure([
+                'data' => [[
+                    'created_at',
+                    'updated_at',
+                ]],
             ]);
     }
 

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1839,6 +1839,8 @@ export interface components {
             name?: string;
             description?: string | null;
             level?: number;
+            created_at?: string;
+            updated_at?: string;
         };
         RoleAssignment: {
             user_id: number;


### PR DESCRIPTION
## Summary
- include `created_at`/`updated_at` in `RoleResource` so roles list shows dates
- document timestamp fields in OpenAPI spec and frontend API types
- test role listing to ensure timestamps are present

## Testing
- `composer test` *(fails: The chunk field must be a file of type: jpg, jpeg, png, pdf.)*
- `php artisan test tests/Feature/RolesTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c715f8e51883239742f2c9214dff40