### PR TITLE
Fetch tenant roles with pagination in task-type form

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -606,15 +606,13 @@ async function refreshTenant(id: number | '', oldId?: number | '') {
   if (id) {
     if (canViewRoles.value) {
       try {
-        const params: Record<string, any> = auth.isSuperAdmin
-          ? { scope: 'all' }
-          : { tenant_id: Number(id) };
+        const params: Record<string, any> = {
+          tenant_id: Number(id),
+          per_page: 100,
+          ...(auth.isSuperAdmin ? { scope: 'all' } : {}),
+        };
         const { data } = await api.get('/roles', { params });
-        let roles = data.data ?? data;
-        if (auth.isSuperAdmin) {
-          const tid = Number(id);
-          roles = roles.filter((r: any) => r.tenant_id === null || r.tenant_id === tid);
-        }
+        const roles = data.data ?? data;
         tenantRoles.value = roles as { id: number; slug: string }[];
         tenantRoles.value.forEach((r) => {
           if (!permissions.value[r.slug]) {


### PR DESCRIPTION
## Summary
- ensure role toggles load by requesting tenant roles with tenant_id and per_page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c717a505648323a3292b0c672e950a