### PR TITLE
Relax Task Types view ability requirements

### DIFF
--- a/frontend/src/constant/data.js
+++ b/frontend/src/constant/data.js
@@ -33,13 +33,7 @@ export const menuItems = [
     title: "Task Types",
     icon: "heroicons-outline:tag",
     link: "taskTypes.list",
-    requiredAbilities: [
-      "task_types.view",
-      "task_types.manage",
-      "task_sla_policies.manage",
-      "task_automations.manage",
-      "task_field_snippets.manage",
-    ],
+    requiredAbilities: ["task_types.view"],
     requiredFeatures: ["task_types"],
   },
   {
@@ -164,13 +158,7 @@ export const topMenu = [
     title: "Task Types",
     icon: "heroicons-outline:tag",
     link: "taskTypes.list",
-    requiredAbilities: [
-      "task_types.view",
-      "task_types.manage",
-      "task_sla_policies.manage",
-      "task_automations.manage",
-      "task_field_snippets.manage",
-    ],
+    requiredAbilities: ["task_types.view"],
     requiredFeatures: ["task_types"],
   },
   {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -100,13 +100,7 @@ export const routes = [
     component: () => import('@/views/types/TypesList.vue'),
     meta: {
       requiresAuth: true,
-      requiredAbilities: [
-        'task_types.view',
-        'task_types.manage',
-        'task_sla_policies.manage',
-        'task_automations.manage',
-        'task_field_snippets.manage',
-      ],
+      requiredAbilities: ['task_types.view'],
       breadcrumb: 'routes.taskTypes',
       title: 'Task Types',
       layout: 'app',

--- a/frontend/src/views/types/TypesList.vue
+++ b/frontend/src/views/types/TypesList.vue
@@ -126,6 +126,7 @@ function edit(id: number) {
 }
 
 async function remove(id: number) {
+  if (!can('task_types.manage')) return;
   const res = await Swal.fire({
     title: 'Delete type?',
     icon: 'warning',
@@ -138,6 +139,7 @@ async function remove(id: number) {
   }
 
 async function copy(id: number) {
+  if (!can('task_types.manage')) return;
   let tenantId: string | number | undefined;
   if (auth.isSuperAdmin) {
     await tenantStore.loadTenants();
@@ -159,6 +161,7 @@ async function copy(id: number) {
 }
 
 async function removeMany(ids: number[]) {
+  if (!can('task_types.manage')) return;
   const res = await Swal.fire({
     title: 'Delete selected types?',
     icon: 'warning',
@@ -171,6 +174,7 @@ async function removeMany(ids: number[]) {
 }
 
 async function copyMany(ids: number[]) {
+  if (!can('task_types.manage')) return;
   let tenantId: string | number | undefined;
   if (auth.isSuperAdmin) {
     await tenantStore.loadTenants();


### PR DESCRIPTION
## Summary
- allow the Task Types navigation items and route to require only the view ability
- gate Task Types table bulk/actions behind the manage ability and guard destructive handlers

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c83ddd1ae883238fab1a43e5ae0c49