### PR TITLE
Remove deprecated task board/list abilities

### DIFF
--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -20,8 +20,6 @@ return [
     'tasks.status.update',
     'tasks.comment.create',
     'tasks.attach.upload',
-    'tasks.board.view',
-    'tasks.list.view',
     'tasks.watch',
     'tasks.manage',
 

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -12,8 +12,6 @@ return [
             'tasks.status.update',
             'tasks.comment.create',
             'tasks.attach.upload',
-            'tasks.board.view',
-            'tasks.list.view',
             'tasks.watch',
             'tasks.manage',
         ],


### PR DESCRIPTION
## Summary
- remove the obsolete `tasks.board.view` and `tasks.list.view` entries from the ability registry
- keep required abilities such as `manuals.manage` and `task_statuses.view` present in both configuration lists

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68c84589f42083239e324f9ebef29428