### PR TITLE
Extract ability service and add tests

### DIFF
--- a/backend/app/Http/Middleware/Ability.php
+++ b/backend/app/Http/Middleware/Ability.php
@@ -2,45 +2,26 @@
 
 namespace App\Http\Middleware;
 
+use App\Services\AbilityService;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class Ability
 {
+    public function __construct(protected AbilityService $abilityService)
+    {
+    }
+
     public function handle(Request $request, Closure $next, string $code): Response
     {
         $user = $request->user();
 
-        if ($user->isSuperAdmin()) {
-            return $next($request);
-        }
+        $tenantId = $request->attributes->get('tenant_id');
+        $codes = array_filter(explode('|', $code));
 
-        $tenantId = $request->attributes->get('tenant_id', $user->tenant_id);
-
-        $roles = $user->rolesForTenant($tenantId)
-            ->merge($user->roles()->wherePivotNull('tenant_id')->get());
-
-        $abilities = $roles->pluck('abilities')->flatten()->filter()->unique()->all();
-
-        if (! in_array('*', $abilities)) {
-            $codes = explode('|', $code);
-            $allowed = false;
-            foreach ($codes as $abilityCode) {
-                if (in_array($abilityCode, $abilities)) {
-                    $allowed = true;
-                    break;
-                }
-                $prefix = explode('.', $abilityCode)[0] . '.manage';
-                if (in_array($prefix, $abilities)) {
-                    $allowed = true;
-                    break;
-                }
-            }
-
-            if (! $allowed) {
-                return response()->json(['message' => 'forbidden'], 403);
-            }
+        if (! $this->abilityService->userHasAnyAbility($user, $codes ?: [$code], $tenantId)) {
+            return response()->json(['message' => 'forbidden'], 403);
         }
 
         return $next($request);

--- a/backend/app/Services/AbilityService.php
+++ b/backend/app/Services/AbilityService.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class AbilityService
+{
+    public function userHasAbility(User $user, string $code, ?int $tenantId = null): bool
+    {
+        return $this->userHasAnyAbility($user, [$code], $tenantId);
+    }
+
+    public function userHasAnyAbility(User $user, array $codes, ?int $tenantId = null): bool
+    {
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        $abilities = $this->resolveAbilities($user, $tenantId);
+
+        if (in_array('*', $abilities, true)) {
+            return true;
+        }
+
+        foreach ($codes as $code) {
+            if ($this->abilityMatches($code, $abilities)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function resolveAbilities(User $user, ?int $tenantId = null): array
+    {
+        $tenantId = $this->resolveTenantId($user, $tenantId);
+
+        $roles = $user->rolesForTenant($tenantId)
+            ->merge($user->roles()->wherePivotNull('tenant_id')->get());
+
+        return $roles->pluck('abilities')->flatten()->filter()->unique()->values()->all();
+    }
+
+    protected function resolveTenantId(User $user, ?int $tenantId = null): int
+    {
+        if ($tenantId !== null) {
+            return $tenantId;
+        }
+
+        if (app()->bound('tenant_id')) {
+            return (int) app('tenant_id');
+        }
+
+        return (int) $user->tenant_id;
+    }
+
+    protected function abilityMatches(string $code, array $abilities): bool
+    {
+        if (in_array($code, $abilities, true)) {
+            return true;
+        }
+
+        $prefix = explode('.', $code)[0] . '.manage';
+
+        return in_array($prefix, $abilities, true);
+    }
+}

--- a/backend/tests/Unit/AbilityServiceTest.php
+++ b/backend/tests/Unit/AbilityServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\AbilityService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AbilityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected AbilityService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = $this->app->make(AbilityService::class);
+    }
+
+    public function test_user_with_wildcard_has_any_ability(): void
+    {
+        $tenant = Tenant::create(['name' => 'Acme Inc.', 'features' => []]);
+
+        $user = User::create([
+            'name' => 'Owner',
+            'email' => 'owner@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $role = Role::create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Owner',
+            'slug' => 'owner',
+            'level' => 1,
+            'abilities' => ['*'],
+        ]);
+
+        $role->users()->attach($user->id, ['tenant_id' => $tenant->id]);
+
+        $this->assertTrue($this->service->userHasAbility($user, 'tasks.update'));
+        $this->assertTrue($this->service->userHasAnyAbility($user, ['foo.bar', 'baz.qux']));
+    }
+
+    public function test_manage_prefix_grants_related_permissions(): void
+    {
+        $tenant = Tenant::create(['name' => 'Beta LLC', 'features' => []]);
+
+        $user = User::create([
+            'name' => 'Manager',
+            'email' => 'manager@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $role = Role::create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Manager',
+            'slug' => 'manager',
+            'level' => 2,
+            'abilities' => ['tasks.manage'],
+        ]);
+
+        $role->users()->attach($user->id, ['tenant_id' => $tenant->id]);
+
+        $this->assertTrue($this->service->userHasAbility($user, 'tasks.update'));
+        $this->assertFalse($this->service->userHasAbility($user, 'reports.view'));
+    }
+
+    public function test_tenant_specific_abilities_are_isolated(): void
+    {
+        $tenantOne = Tenant::create(['name' => 'Tenant One', 'features' => []]);
+        $tenantTwo = Tenant::create(['name' => 'Tenant Two', 'features' => []]);
+
+        $user = User::create([
+            'name' => 'Employee',
+            'email' => 'employee@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenantOne->id,
+        ]);
+
+        $role = Role::create([
+            'tenant_id' => $tenantOne->id,
+            'name' => 'Analyst',
+            'slug' => 'analyst',
+            'level' => 3,
+            'abilities' => ['tasks.view'],
+        ]);
+
+        $role->users()->attach($user->id, ['tenant_id' => $tenantOne->id]);
+
+        $this->assertTrue($this->service->userHasAbility($user, 'tasks.view', $tenantOne->id));
+        $this->assertFalse($this->service->userHasAbility($user, 'tasks.view', $tenantTwo->id));
+    }
+}


### PR DESCRIPTION
## Summary
- extract the ability resolution logic into a dedicated `AbilityService`
- update the `AuthServiceProvider` gates and the `Ability` middleware to delegate to the shared service
- add unit coverage for wildcard, manage-prefix, and tenant-specific behaviors of the service

## Testing
- ./vendor/bin/phpunit --filter AbilityServiceTest

------
https://chatgpt.com/codex/tasks/task_e_68c85005247c8323b60bd7a2317010b2