### PR TITLE
Restrict task creation policy to tasks.create ability

### DIFF
--- a/backend/app/Policies/TaskPolicy.php
+++ b/backend/app/Policies/TaskPolicy.php
@@ -11,7 +11,7 @@ class TaskPolicy extends TenantOwnedPolicy
 {
     public function create(User $user): bool
     {
-        return true;
+        return Gate::allows('tasks.create');
     }
 
     public function assign(User $user, Task $task): bool

--- a/backend/tests/Feature/TaskAbilityRestrictionTest.php
+++ b/backend/tests/Feature/TaskAbilityRestrictionTest.php
@@ -6,6 +6,7 @@ use App\Models\Role;
 use App\Models\Task;
 use App\Models\Tenant;
 use App\Models\User;
+use App\Policies\TaskPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Sanctum\Sanctum;
@@ -37,6 +38,8 @@ class TaskAbilityRestrictionTest extends TestCase
         ]);
         $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($user);
+
+        $this->assertFalse(app(TaskPolicy::class)->create($user));
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
             ->postJson('/api/tasks', [])


### PR DESCRIPTION
## Summary
- require the tasks.create gate when checking TaskPolicy::create
- extend the task ability restriction test to confirm the policy denies users without the create ability

## Testing
- php artisan test --filter=TaskAbilityRestrictionTest


------
https://chatgpt.com/codex/tasks/task_e_68c858d56db88323a3b580a8eeae5151