### PR TITLE
Add billing feature mapping and seed defaults

### DIFF
--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -79,6 +79,10 @@ return [
     'gdpr.export',
     'gdpr.delete',
 
+    // Billing
+    'billing.view',
+    'billing.manage',
+
     // Reports
     'reports.view',
     'reports.manage',

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -37,6 +37,13 @@ return [
             'reports.manage',
         ],
     ],
+    'billing' => [
+        'label' => 'Billing',
+        'abilities' => [
+            'billing.view',
+            'billing.manage',
+        ],
+    ],
     'roles' => [
         'label' => 'Roles & Permissions',
         'abilities' => [

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -25,12 +25,23 @@ class TenantBootstrapSeeder extends Seeder
         );
 
         // Tenant
+        $defaultFeatures = [
+            'tasks',
+            'notifications',
+            'task_types',
+            'task_statuses',
+            'teams',
+            'themes',
+            'billing',
+        ];
+        $defaultFeatures = array_values(array_intersect($defaultFeatures, config('features', [])));
+
         DB::table('tenants')->updateOrInsert(
             ['id' => 1],
             [
                 'name' => 'Acme Vet',
                 'quota_storage_mb' => 0,
-                'features' => json_encode(['tasks', 'notifications', 'task_types', 'task_statuses', 'teams', 'themes']),
+                'features' => json_encode($defaultFeatures),
                 'phone' => '555-123-4567',
                 'address' => '1 Pet Street',
                 'created_at' => now(),

--- a/backend/database/seeders/TenantRolesBackfillSeeder.php
+++ b/backend/database/seeders/TenantRolesBackfillSeeder.php
@@ -9,7 +9,17 @@ class TenantRolesBackfillSeeder extends Seeder
 {
     public function run(): void
     {
-        $defaultFeatures = ['tasks','notifications','roles','types','teams','statuses','themes'];
+        $defaultFeatures = [
+            'tasks',
+            'notifications',
+            'roles',
+            'task_types',
+            'task_statuses',
+            'teams',
+            'themes',
+            'billing',
+        ];
+        $defaultFeatures = array_values(array_intersect($defaultFeatures, config('features', [])));
 
         Tenant::query()->lazy()->each(function (Tenant $tenant) use ($defaultFeatures) {
             if (empty($tenant->features)) {


### PR DESCRIPTION
## Summary
- define the billing abilities and expose them through the feature map
- ensure the demo tenant feature lists include billing and stay in sync with configured feature slugs

## Testing
- composer test *(fails: existing suite requires seeded .env and fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68c86a093a9883239dd1c37a9a25644e