### PR TITLE
Refactor menu configuration to share data

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/DesktopMenu.vue
+++ b/frontend/src/components/ui/Header/Navtools/DesktopMenu.vue
@@ -101,7 +101,7 @@
   </ul>
 </template>
 <script>
-import { topMenu } from "@/constants/menu";
+import { filterMenuItems, topMenu } from "@/constants/menu";
 import Icon from "../../Icon";
 import { useAuthStore } from "@/stores/auth";
 
@@ -112,17 +112,12 @@ export default {
   computed: {
     newMenulist() {
       const auth = useAuthStore();
-      return topMenu.filter((item) => {
-        if (item.isHeadr) return false;
-        const features = item.requiredFeatures || [];
-        if (!features.every((f) => auth.features.includes(f))) {
-          return false;
-        }
-        const req = item.requiredAbilities || [];
-        return (item.requireAllAbilities
-          ? auth.hasAll(req)
-          : auth.hasAny(req));
+      const accessible = filterMenuItems(topMenu, {
+        hasFeature: (feature) => auth.features.includes(feature),
+        hasAllAbilities: (abilities) => auth.hasAll(abilities),
+        hasAnyAbility: (abilities) => auth.hasAny(abilities),
       });
+      return accessible.filter((item) => !item.isHeadr);
     },
   },
 };

--- a/frontend/src/components/ui/Sidebar/Navmenu.vue
+++ b/frontend/src/components/ui/Sidebar/Navmenu.vue
@@ -112,6 +112,7 @@
 <script>
 import { computed } from "vue";
 import { useRouter } from "vue-router";
+import { filterMenuItems } from "@/constants/menu";
 import { useAuthStore } from "@/stores/auth";
 import Icon from "../Icon";
 export default {
@@ -138,37 +139,12 @@ export default {
 
   setup(props) {
     const auth = useAuthStore();
-    const hasFeatures = (features = []) =>
-      features.every((f) => auth.features.includes(f));
-    const meetsAbility = (abilities = [], requireAll = false) =>
-      requireAll ? auth.hasAll(abilities) : auth.hasAny(abilities);
     const visibleItems = computed(() =>
-      props.items
-        .map((it) => {
-          const child = it.child
-            ? it.child.filter((ci) => {
-                if (!hasFeatures(ci.requiredFeatures || [])) {
-                  return false;
-                }
-                return meetsAbility(
-                  ci.requiredAbilities || [],
-                  ci.requireAllAbilities || false,
-                );
-              })
-            : null;
-          return { ...it, child };
-        })
-        .filter((it) => {
-          if (!hasFeatures(it.requiredFeatures || [])) return false;
-          const allowed = meetsAbility(
-            it.requiredAbilities || [],
-            it.requireAllAbilities || false,
-          );
-          if (it.child) {
-            return allowed && it.child.length > 0;
-          }
-          return allowed;
-        }),
+      filterMenuItems(props.items, {
+        hasFeature: (feature) => auth.features.includes(feature),
+        hasAllAbilities: (abilities) => auth.hasAll(abilities),
+        hasAnyAbility: (abilities) => auth.hasAny(abilities),
+      }),
     );
     return { visibleItems };
   },


### PR DESCRIPTION
## Summary
- centralize the sidebar navigation definitions in a shared menu configuration and derive the top menu from it
- add helper utilities for filtering menu entries by access requirements and enrich settings children with explicit icons and labels
- update the sidebar and desktop navigation components to reuse the shared filtering helper

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c86c24db148323a303ab53eb84ccbf