### PR TITLE
Update GDPR menu access requirements

### DIFF
--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -100,8 +100,7 @@ const routeAccessMap: Record<string, RouteAccess> = {
     requiredFeatures: ['branding'],
   },
   'gdpr.index': {
-    requiredAbilities: ['gdpr.view', 'gdpr.manage'],
-    requireAllAbilities: true,
+    requiredAbilities: ['gdpr.view'],
     requiredFeatures: ['gdpr'],
   },
   reports: {


### PR DESCRIPTION
## Summary
- relax the GDPR menu entry so only the `gdpr.view` ability is required

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8f85865088323ad0d7e31099fc932