### PR TITLE
Restrict lookup routes with ability middleware

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -313,9 +313,13 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         });
 
     // Lookup endpoints
-    Route::get('lookups/assignees', [LookupController::class, 'assignees']);
-    Route::get('lookups/abilities', [LookupController::class, 'abilities']); // ?forTenant=1
-    Route::get('lookups/feature-map', [LookupController::class, 'featureMap']);
-    Route::get('lookups/features', [LookupController::class, 'features']);
+    Route::get('lookups/assignees', [LookupController::class, 'assignees'])
+        ->middleware(Ability::class . ':tasks.view|employees.view|teams.view');
+    Route::get('lookups/abilities', [LookupController::class, 'abilities']) // ?forTenant=1
+        ->middleware(Ability::class . ':roles.view');
+    Route::get('lookups/feature-map', [LookupController::class, 'featureMap'])
+        ->middleware(Ability::class . ':roles.view|employees.view|teams.view|task_types.view|tenants.view');
+    Route::get('lookups/features', [LookupController::class, 'features'])
+        ->middleware(Ability::class . ':roles.view|tenants.view');
     Route::get('calendar/events', [CalendarController::class, 'events']);
 });


### PR DESCRIPTION
## Summary
- guard the lookups/assignees endpoint behind the tasks, employees, or teams view ability
- require appropriate role or tenant view abilities for other lookup endpoints that expose permission metadata

## Testing
- `php artisan test --filter=LookupRoutesTest` *(fails: existing test expectation omits role create/update/delete abilities returned by the endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f91655a0832391ab11be40194b2d