### PR TITLE
Add dashboard ability and guard endpoints

### DIFF
--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -4,6 +4,9 @@
 // The SuperAdmin role is granted the "*" wildcard so new entries
 // automatically apply to those users without additional changes.
 return [
+    // Dashboard
+    'dashboard.view',
+
     // Tenants
     'tenants.view',
     'tenants.create',

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -1,6 +1,12 @@
 <?php
 
 return [
+    'dashboard' => [
+        'label' => 'Dashboard',
+        'abilities' => [
+            'dashboard.view',
+        ],
+    ],
     'tasks' => [
         'label' => 'Tasks',
         'abilities' => [

--- a/backend/config/features.php
+++ b/backend/config/features.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'dashboard',
     'tasks',
     'manuals',
     'notifications',

--- a/backend/database/migrations/2025_09_03_000000_backfill_tenant_roles.php
+++ b/backend/database/migrations/2025_09_03_000000_backfill_tenant_roles.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        $defaultFeatures = ['tasks','notifications','roles','task_types','teams','task_statuses','themes'];
+        $defaultFeatures = ['dashboard','tasks','notifications','roles','task_types','teams','task_statuses','themes'];
 
         Tenant::query()->lazy()->each(function (Tenant $tenant) use ($defaultFeatures) {
             if (empty($tenant->features)) {

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -26,6 +26,7 @@ class TenantBootstrapSeeder extends Seeder
 
         // Tenant
         $defaultFeatures = [
+            'dashboard',
             'tasks',
             'notifications',
             'task_types',

--- a/backend/database/seeders/TenantRolesBackfillSeeder.php
+++ b/backend/database/seeders/TenantRolesBackfillSeeder.php
@@ -10,6 +10,7 @@ class TenantRolesBackfillSeeder extends Seeder
     public function run(): void
     {
         $defaultFeatures = [
+            'dashboard',
             'tasks',
             'notifications',
             'roles',

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -301,10 +301,12 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
             ->middleware(Ability::class . ':gdpr.delete');
     });
 
+    Route::get('reports/overview', [ReportController::class, 'overview'])
+        ->middleware(Ability::class . ':dashboard.view');
+
     Route::prefix('reports')
         ->middleware(Ability::class . ':reports.view')
         ->group(function () {
-            Route::get('overview', [ReportController::class, 'overview']);
             Route::get('kpis', [ReportController::class, 'kpis']);
             Route::get('materials', [ReportController::class, 'materials']);
             Route::get('tasks/overview', [ReportController::class, 'tasksOverview']);

--- a/backend/tests/Feature/FeatureAbilitiesTest.php
+++ b/backend/tests/Feature/FeatureAbilitiesTest.php
@@ -65,6 +65,7 @@ class FeatureAbilitiesTest extends TestCase
     public static function featureAbilityProvider(): array
     {
         return [
+            'dashboard' => ['dashboard', '/api/reports/overview', 'dashboard.view'],
             'gdpr' => ['gdpr', '/api/gdpr/consents', 'gdpr.view'],
             'notifications' => ['notifications', '/api/notifications', 'notifications.view'],
             'roles' => ['roles', '/api/roles', 'roles.view'],

--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -6,8 +6,8 @@ export interface RouteAccess {
 
 const routeAccessMap: Record<string, RouteAccess> = {
   dashboard: {
-    requiredAbilities: ['reports.view'],
-    requiredFeatures: ['reports'],
+    requiredAbilities: ['dashboard.view'],
+    requiredFeatures: ['dashboard'],
   },
   'tasks.list': {
     requiredAbilities: ['tasks.view'],

--- a/frontend/src/views/home/Dashboard.vue
+++ b/frontend/src/views/home/Dashboard.vue
@@ -81,7 +81,7 @@ const loading = ref(false);
 const error = ref(false);
 
 async function fetchData() {
-  if (!can('reports.view')) {
+  if (!can('dashboard.view')) {
     return;
   }
   loading.value = true;


### PR DESCRIPTION
## Summary
- register a `dashboard.view` ability and map it to the new dashboard feature across configs and seeders
- require the dashboard ability for the reports overview endpoint while keeping the query compatible across database drivers
- update frontend access rules and dashboard fetch logic to use the new ability and feature

## Testing
- php artisan test --filter=FeatureAbilitiesTest

------
https://chatgpt.com/codex/tasks/task_e_68c90019b600832389ad56474838dc7d