### PR TITLE
Ensure settings profile access remains unrestricted

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/Profile.vue
+++ b/frontend/src/components/ui/Header/Navtools/Profile.vue
@@ -51,6 +51,7 @@ import Dropdown from '@/components/Dropdown';
 import Icon from '@/components/Icon';
 import { useAuthStore } from '@/stores/auth';
 import { useRouter } from 'vue-router';
+import { accessForRoute } from '@/constants/menu';
 
 const authStore = useAuthStore();
 const router = useRouter();
@@ -71,6 +72,7 @@ const ProfileMenu = [
   {
     label: 'Profile',
     icon: 'heroicons-outline:user',
+    ...accessForRoute('settings.profile'),
     link: () => {
       router.push({ name: 'settings.profile' });
     },

--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -72,6 +72,16 @@ const routeAccessConfig: Record<string, RouteAccessConfig> = {
   },
 };
 
+// Routes that should be explicitly represented in the access map even when they
+// do not require any abilities or features. Keeping them here allows future
+// adjustments to be made without touching the consuming code.
+const additionalRouteAccess: Record<string, RouteAccess> = {
+  'settings.profile': {
+    requiredAbilities: [],
+    requiredFeatures: [],
+  },
+};
+
 const routeAccessMap = reactive<Record<string, RouteAccess>>({});
 
 function resolveAbilityList(
@@ -126,6 +136,10 @@ function rebuildRouteAccess(): void {
 
   Object.entries(routeAccessConfig).forEach(([route, config]) => {
     routeAccessMap[route] = buildRouteAccess(config);
+  });
+
+  Object.entries(additionalRouteAccess).forEach(([route, access]) => {
+    routeAccessMap[route] = { ...access };
   });
 }
 

--- a/frontend/tests/unit/navmenu.features.test.ts
+++ b/frontend/tests/unit/navmenu.features.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import Navmenu from '@/components/ui/Sidebar/Navmenu.vue';
 import { useAuthStore } from '@/stores/auth';
+import { accessForRoute } from '@/constants/menu';
 
 function runVisible(items: any[]) {
   const { visibleItems } = (Navmenu as any).setup(
@@ -58,5 +59,29 @@ describe('Navmenu feature gating', () => {
     const visible = runVisible(items);
     expect(visible).toHaveLength(1);
     expect(visible[0].child).toHaveLength(1);
+  });
+
+  it('shows the profile menu item without feature or ability requirements', () => {
+    const auth = useAuthStore();
+    auth.abilities = [];
+    auth.features = [];
+
+    const items = [
+      {
+        title: 'Settings',
+        child: [
+          {
+            childtitle: 'Profile',
+            childlink: 'settings.profile',
+            ...accessForRoute('settings.profile'),
+          },
+        ],
+      },
+    ];
+
+    const visible = runVisible(items);
+    expect(visible).toHaveLength(1);
+    expect(visible[0].child).toHaveLength(1);
+    expect(visible[0].child?.[0].childlink).toBe('settings.profile');
   });
 });


### PR DESCRIPTION
## Summary
- add an explicit `settings.profile` entry to the route access map with no required abilities or features
- have the header profile menu consume `accessForRoute('settings.profile')` so future changes live in one place
- add a unit test that ensures menu filtering keeps the profile link visible to authenticated users

## Testing
- pnpm vitest run tests/unit/navmenu.features.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c92c5dfb94832389b68739beade6fc