### PR TITLE
Align employee creation ability with employees.create

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -266,13 +266,12 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     Route::put('notification-preferences', [NotificationController::class, 'updatePreferences'])
         ->middleware(Ability::class . ':notifications.manage');
 
-    Route::apiResource('employees', EmployeeController::class)->middleware([
-        'index' => Ability::class . ':employees.view',
-        'show' => Ability::class . ':employees.view',
-        'store' => Ability::class . ':employees.manage',
-        'update' => Ability::class . ':employees.manage',
-        'destroy' => Ability::class . ':employees.manage',
-    ]);
+    Route::apiResource('employees', EmployeeController::class)
+        ->middlewareFor('index', Ability::class . ':employees.view')
+        ->middlewareFor('show', Ability::class . ':employees.view')
+        ->middlewareFor('store', Ability::class . ':employees.create')
+        ->middlewareFor('update', Ability::class . ':employees.manage')
+        ->middlewareFor('destroy', Ability::class . ':employees.manage');
     Route::post('employees/{employee}', [EmployeeController::class, 'update'])
         ->middleware(Ability::class . ':employees.manage');
     Route::patch('employees/{employee}/toggle-status', [EmployeeController::class, 'toggleStatus'])

--- a/backend/tests/Feature/EmployeeCreateAbilityTest.php
+++ b/backend/tests/Feature/EmployeeCreateAbilityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use App\Services\AbilityService;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class EmployeeCreateAbilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_without_employees_create_cannot_create_employee(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['employees']]);
+
+        $role = Role::create([
+            'name' => 'Viewer',
+            'slug' => 'viewer',
+            'tenant_id' => $tenant->id,
+            'abilities' => ['employees.view'],
+            'level' => 3,
+        ]);
+
+        $user = User::create([
+            'name' => 'Viewer User',
+            'email' => 'viewer@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '1234567890',
+            'address' => '1 Street',
+        ]);
+
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        $user->refresh();
+        Sanctum::actingAs($user);
+
+        Password::shouldReceive('sendResetLink')->never();
+
+        $payload = [
+            'name' => 'New Employee',
+            'email' => 'employee@example.com',
+        ];
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/employees', $payload)
+            ->assertStatus(403);
+    }
+
+    public function test_user_with_employees_create_can_create_employee(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['employees']]);
+
+        $role = Role::create([
+            'name' => 'Editor',
+            'slug' => 'editor',
+            'tenant_id' => $tenant->id,
+            'abilities' => ['employees.create'],
+            'level' => 2,
+        ]);
+
+        $user = User::create([
+            'name' => 'Editor User',
+            'email' => 'editor@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '0987654321',
+            'address' => '2 Street',
+        ]);
+
+        $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+        $user->refresh();
+        Sanctum::actingAs($user);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->assertTrue(
+            app(AbilityService::class)->userHasAbility($user->fresh(), 'employees.create', $tenant->id)
+        );
+
+        $payload = [
+            'name' => 'Created Employee',
+            'email' => 'created@example.com',
+        ];
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson('/api/employees', $payload)
+            ->assertStatus(201);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'created@example.com',
+            'tenant_id' => $tenant->id,
+            'type' => 'employee',
+        ]);
+    }
+}
+

--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -49,7 +49,7 @@ const routeAccessConfig: Record<string, RouteAccessConfig> = {
   reports: { feature: 'reports', abilities: ['view'] },
   'reports.kpis': { feature: 'reports', abilities: ['view'] },
   'employees.list': { feature: 'employees', abilities: ['view'] },
-  'employees.create': { feature: 'employees', abilities: ['create'] },
+  'employees.create': { feature: 'employees', abilities: ['employees.create'] },
   'employees.edit': {
     feature: 'employees',
     abilities: ['view', 'manage'],


### PR DESCRIPTION
## Summary
- ensure the employee store route uses per-action middleware and requires the employees.create ability
- update the frontend menu entry to check the employees.create ability
- add a feature test that verifies only roles with the employees.create ability can create employees

## Testing
- ./vendor/bin/phpunit --filter EmployeeCreateAbilityTest

------
https://chatgpt.com/codex/tasks/task_e_68c931d7ff608323a914d1057fed6073