### PR TITLE
Add manuals view ability and enforce access controls

### DIFF
--- a/backend/app/Http/Controllers/Api/ManualController.php
+++ b/backend/app/Http/Controllers/Api/ManualController.php
@@ -16,6 +16,8 @@ class ManualController extends Controller
 
     public function index(Request $request)
     {
+        $this->authorize('viewAny', Manual::class);
+
         $tenantId = $request->user()->tenant_id;
         $search = $request->query('search', '');
         $perPage = $request->query('per_page', 15);

--- a/backend/app/Policies/ManualPolicy.php
+++ b/backend/app/Policies/ManualPolicy.php
@@ -8,6 +8,16 @@ use Illuminate\Support\Facades\Gate;
 
 class ManualPolicy extends TenantOwnedPolicy
 {
+    public function viewAny(User $user): bool
+    {
+        return Gate::allows('manuals.view');
+    }
+
+    public function view(User $user, Manual $manual): bool
+    {
+        return Gate::allows('manuals.view') && parent::view($user, $manual);
+    }
+
     public function create(User $user): bool
     {
         return Gate::allows('manuals.manage');

--- a/backend/config/abilities.php
+++ b/backend/config/abilities.php
@@ -27,6 +27,7 @@ return [
     'tasks.manage',
 
     // Manuals
+    'manuals.view',
     'manuals.manage',
 
     // Notifications

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -25,6 +25,7 @@ return [
     'manuals' => [
         'label' => 'Manuals',
         'abilities' => [
+            'manuals.view',
             'manuals.manage',
         ],
     ],

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -252,11 +252,17 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
             'destroy' => Ability::class . ':tasks.delete',
         ]);
     Route::get('manuals/{manual}/download', [ManualController::class, 'download'])
-        ->middleware(Ability::class . ':manuals.manage');
+        ->middleware(Ability::class . ':manuals.view');
     Route::post('manuals/{manual}/replace', [ManualController::class, 'replace'])
         ->middleware(Ability::class . ':manuals.manage');
     Route::apiResource('manuals', ManualController::class)
-        ->middleware(Ability::class . ':manuals.manage');
+        ->middleware([
+            'index' => Ability::class . ':manuals.view',
+            'show' => Ability::class . ':manuals.view',
+            'store' => Ability::class . ':manuals.manage',
+            'update' => Ability::class . ':manuals.manage',
+            'destroy' => Ability::class . ':manuals.manage',
+        ]);
     Route::get('notifications', [NotificationController::class, 'index'])
         ->middleware(Ability::class . ':notifications.view');
     Route::post('notifications/{notification}/read', [NotificationController::class, 'markAsRead'])

--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -38,7 +38,7 @@ const routeAccessConfig: Record<string, RouteAccessConfig> = {
     abilities: ['view', 'manage'],
     requireAllAbilities: true,
   },
-  'manuals.list': { feature: 'manuals', abilities: ['manage'] },
+  'manuals.list': { feature: 'manuals', abilities: ['view'] },
   'manuals.create': { feature: 'manuals', abilities: ['manage'] },
   'manuals.edit': { feature: 'manuals', abilities: ['manage'] },
   'notifications.inbox': { feature: 'notifications', abilities: ['view'] },


### PR DESCRIPTION
## Summary
- register a new `manuals.view` ability and expose it through the manuals feature mapping
- require the view ability for manual listing, show, and download endpoints while keeping manage for writes
- ensure policies, controller checks, and frontend route guards honor the new read ability

## Testing
- `composer test` *(fails: missing backend/vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c9378431a883239f87b8086b94af3a