### PR TITLE
Update dashboard ability mapping

### DIFF
--- a/backend/config/ability_aliases.php
+++ b/backend/config/ability_aliases.php
@@ -2,5 +2,5 @@
 
 return [
     // Legacy ability => canonical replacement mapping.
-    'dashboard.view' => 'reports.view',
+    'reports.view' => 'dashboard.view',
 ];

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -4,7 +4,7 @@ return [
     'dashboard' => [
         'label' => 'Dashboard',
         'abilities' => [
-            'reports.view',
+            'dashboard.view',
         ],
     ],
     'tasks' => [

--- a/backend/tests/Unit/AbilityServiceTest.php
+++ b/backend/tests/Unit/AbilityServiceTest.php
@@ -99,7 +99,7 @@ class AbilityServiceTest extends TestCase
         $this->assertFalse($this->service->userHasAbility($user, 'tasks.view', $tenantTwo->id));
     }
 
-    public function test_dashboard_view_alias_grants_reports_view(): void
+    public function test_reports_view_alias_grants_dashboard_view(): void
     {
         $tenant = Tenant::create(['name' => 'Gamma Corp', 'features' => ['dashboard']]);
 
@@ -115,13 +115,13 @@ class AbilityServiceTest extends TestCase
             'name' => 'Viewer',
             'slug' => 'viewer',
             'level' => 3,
-            'abilities' => ['dashboard.view'],
+            'abilities' => ['reports.view'],
         ]);
 
         $role->users()->attach($user->id, ['tenant_id' => $tenant->id]);
 
-        $this->assertTrue($this->service->userHasAbility($user, 'reports.view'));
         $this->assertTrue($this->service->userHasAbility($user, 'dashboard.view'));
-        $this->assertContains('reports.view', $this->service->resolveAbilities($user));
+        $this->assertTrue($this->service->userHasAbility($user, 'reports.view'));
+        $this->assertContains('dashboard.view', $this->service->resolveAbilities($user));
     }
 }

--- a/frontend/src/views/home/Dashboard.vue
+++ b/frontend/src/views/home/Dashboard.vue
@@ -81,7 +81,7 @@ const loading = ref(false);
 const error = ref(false);
 
 async function fetchData() {
-  if (!can('reports.view')) {
+  if (!can('dashboard.view')) {
     return;
   }
   loading.value = true;


### PR DESCRIPTION
## Summary
- point the dashboard feature to the new `dashboard.view` ability and remap the legacy `reports.view` code
- align the ability service unit test and frontend dashboard guard with the new canonical ability

## Testing
- php artisan config:cache

------
https://chatgpt.com/codex/tasks/task_e_68c95351004883238e6fae6da3a30e80