### PR TITLE
Align role permissions with granular role abilities

### DIFF
--- a/backend/app/Policies/RolePolicy.php
+++ b/backend/app/Policies/RolePolicy.php
@@ -11,7 +11,7 @@ class RolePolicy extends TenantOwnedPolicy
 {
     public function create(User $user): bool
     {
-        return Gate::allows('roles.manage');
+        return Gate::allows('roles.create');
     }
 
     public function view(User $user, Model $role): bool
@@ -24,14 +24,14 @@ class RolePolicy extends TenantOwnedPolicy
     public function update(User $user, Model $role): bool
     {
         return $role instanceof Role
-            && Gate::allows('roles.manage')
+            && Gate::allows('roles.update')
             && parent::update($user, $role);
     }
 
     public function delete(User $user, Model $role): bool
     {
         return $role instanceof Role
-            && Gate::allows('roles.manage')
+            && Gate::allows('roles.delete')
             && parent::delete($user, $role);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -205,13 +205,13 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         ->name('task-types.import');
 
     Route::post('roles', [RoleController::class, 'store'])
-        ->middleware(Ability::class . ':roles.manage')
+        ->middleware(Ability::class . ':roles.create')
         ->name('roles.store');
     Route::match(['put', 'patch'], 'roles/{role}', [RoleController::class, 'update'])
-        ->middleware(Ability::class . ':roles.manage')
+        ->middleware(Ability::class . ':roles.update')
         ->name('roles.update');
     Route::delete('roles/{role}', [RoleController::class, 'destroy'])
-        ->middleware(Ability::class . ':roles.manage')
+        ->middleware(Ability::class . ':roles.delete')
         ->name('roles.destroy');
     Route::post('roles/{role}/assign', [RoleController::class, 'assign'])
         ->middleware(Ability::class . ':roles.manage')

--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -32,10 +32,10 @@ const routeAccessConfig: Record<string, RouteAccessConfig> = {
   'taskStatuses.create': { feature: 'task_statuses', abilities: ['manage'] },
   'taskStatuses.edit': { feature: 'task_statuses', abilities: ['manage'] },
   'roles.list': { feature: 'roles', abilities: ['view'] },
-  'roles.create': { feature: 'roles', abilities: ['manage'] },
+  'roles.create': { feature: 'roles', abilities: ['create'] },
   'roles.edit': {
     feature: 'roles',
-    abilities: ['view', 'manage'],
+    abilities: ['update'],
     requireAllAbilities: true,
   },
   'manuals.list': { feature: 'manuals', abilities: ['view'] },


### PR DESCRIPTION
## Summary
- update the role policy to authorize create, update, and delete actions with the new role-specific abilities
- adjust API role routes to require the granular `roles.create`, `roles.update`, and `roles.delete` abilities
- align the frontend route access map to expect `create` and `update` abilities for role pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c95828f1f88323a79ab9c9e6c6f380