### PR TITLE
Handle undefined abilities when building access requirements

### DIFF
--- a/frontend/src/constants/menu.ts
+++ b/frontend/src/constants/menu.ts
@@ -100,14 +100,14 @@ function resolveAbilityList(
           return spec;
         }
         const ability = rest.join('.');
-        return abilityFor(abilityFeature, ability) ?? `${abilityFeature}.${ability}`;
+        return abilityFor(abilityFeature, ability);
       }
 
       if (!feature) {
         return undefined;
       }
 
-      return abilityFor(feature, spec) ?? `${feature}.${spec}`;
+      return abilityFor(feature, spec);
     })
     .filter((ability): ability is string => Boolean(ability));
 

--- a/frontend/src/services/permissions.ts
+++ b/frontend/src/services/permissions.ts
@@ -132,7 +132,7 @@ export function abilityFor(feature: string, ability: string): string | undefined
     return fallback;
   }
 
-  return fallback;
+  return undefined;
 }
 
 export function featureLabel(feature: string, fallback?: string): string {


### PR DESCRIPTION
## Summary
- make `abilityFor` return `undefined` when a fallback ability name is not present in the loaded ability list
- stop adding fallback ability names while building menu access requirements so undefined abilities are ignored

## Testing
- pnpm lint *(fails: existing lint violations in unrelated Vue components)*

------
https://chatgpt.com/codex/tasks/task_e_68c959107cd88323b2aed7635239c853