### PR TITLE
Allow status-only permission to change task status

### DIFF
--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -138,7 +138,9 @@
           >
             <Icon icon="heroicons-outline:trash" class="w-5 h-5" />
           </button>
-          <template v-if="hasAny(['tasks.update', 'tasks.manage'])">
+          <template
+            v-if="hasAny(['tasks.update', 'tasks.manage', 'tasks.status.update'])"
+          >
             <button
               v-for="s in getChangeActions(row)"
               :key="s"
@@ -322,7 +324,8 @@ async function applyBulkStatus() {
   for (const id of selected.value) {
     const row = all.value.find((r) => r.id === id);
     if (!row) continue;
-    if (!hasAny(['tasks.update', 'tasks.manage'])) continue;
+    if (!hasAny(['tasks.update', 'tasks.manage', 'tasks.status.update']))
+      continue;
     if (!getChangeActions(row).includes(bulkStatus.value)) continue;
     await api.post(`/tasks/${id}/status`, { status: bulkStatus.value });
     row.status = bulkStatus.value;


### PR DESCRIPTION
## Summary
- allow users with the tasks.status.update ability to see row-level status-change actions in the task list
- permit bulk status updates when a user only holds tasks.status.update

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c963e740c48323a2745f855f956e4b