### PR TITLE
Adjust TypeForm access logic

### DIFF
--- a/frontend/src/views/types/TypeForm.vue
+++ b/frontend/src/views/types/TypeForm.vue
@@ -541,14 +541,21 @@ const isEdit = computed(
 const isCreate = computed(
   () => route.name === 'taskTypes.create' && auth.isSuperAdmin,
 );
-const canAccess = computed(
-  () =>
-    auth.isSuperAdmin ||
-    (hasAbility('task_types.manage') &&
-      (isEdit.value
-        ? hasAbility('task_types.view')
-        : hasAbility('task_types.create'))),
-);
+const canAccess = computed(() => {
+  if (auth.isSuperAdmin) {
+    return true;
+  }
+
+  if (hasAbility('task_types.manage')) {
+    return true;
+  }
+
+  if (isEdit.value) {
+    return hasAbility('task_types.update');
+  }
+
+  return hasAbility('task_types.create');
+});
 
 const skipTenantWatch = ref(isEdit.value);
 


### PR DESCRIPTION
## Summary
- update the TypeForm access guard to honor create, update, or manage task type abilities while preserving the super admin bypass

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c964b797608323a6e8d515b2fe63a9