### PR TITLE
Enforce policies for task type and status controllers

### DIFF
--- a/backend/app/Policies/TaskStatusPolicy.php
+++ b/backend/app/Policies/TaskStatusPolicy.php
@@ -4,22 +4,49 @@ namespace App\Policies;
 
 use App\Models\TaskStatus;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Gate;
 
 class TaskStatusPolicy extends TenantOwnedPolicy
 {
+    public function viewAny(User $user): bool
+    {
+        return Gate::allows('task_statuses.view') || Gate::allows('task_statuses.manage');
+    }
+
+    public function view(User $user, Model $status): bool
+    {
+        if (! $status instanceof TaskStatus) {
+            return false;
+        }
+
+        if ($status->tenant_id === null) {
+            return $this->viewAny($user);
+        }
+
+        return $this->viewAny($user) && parent::view($user, $status);
+    }
+
     public function create(User $user): bool
     {
         return Gate::allows('task_statuses.manage');
     }
 
-    public function update(User $user, TaskStatus $status): bool
+    public function update(User $user, Model $status): bool
     {
+        if (! $status instanceof TaskStatus) {
+            return false;
+        }
+
         return Gate::allows('task_statuses.manage') && parent::update($user, $status);
     }
 
-    public function delete(User $user, TaskStatus $status): bool
+    public function delete(User $user, Model $status): bool
     {
+        if (! $status instanceof TaskStatus) {
+            return false;
+        }
+
         return Gate::allows('task_statuses.manage') && parent::delete($user, $status);
     }
 }

--- a/backend/app/Policies/TaskTypePolicy.php
+++ b/backend/app/Policies/TaskTypePolicy.php
@@ -9,6 +9,20 @@ use Illuminate\Support\Facades\Gate;
 
 class TaskTypePolicy extends TenantOwnedPolicy
 {
+    public function viewAny(User $user): bool
+    {
+        return Gate::allows('task_types.view') || Gate::allows('task_types.manage');
+    }
+
+    public function view(User $user, Model $type): bool
+    {
+        if (! $type instanceof TaskType) {
+            return false;
+        }
+
+        return $this->viewAny($user) && parent::view($user, $type);
+    }
+
     public function create(User $user): bool
     {
         return Gate::allows('task_types.create') || Gate::allows('task_types.manage');


### PR DESCRIPTION
## Summary
- add policy authorization checks across task type endpoints including bulk utilities, validation, copy, and export flows
- add corresponding policy checks for task status endpoints including transitions and tenant copy helpers
- extend task type and status policies with view/viewAny logic and model guards to enforce abilities and tenant ownership

## Testing
- php artisan test --filter=AssigneesExcludeTenantTest *(fails: expected 200 but received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c96647dec48323a6dd42f949062e58