### PR TITLE
Fix ability watcher waiting for features load

### DIFF
--- a/frontend/src/components/types/TypeAbilitiesEditor.vue
+++ b/frontend/src/components/types/TypeAbilitiesEditor.vue
@@ -83,6 +83,10 @@ watch(
 watch(
   abilityLabels,
   (labels) => {
+    if (!featuresStore.hasFeatureData) {
+      return;
+    }
+
     const keys = Object.keys(labels) as (keyof Abilities)[];
     Object.keys(localAbilities).forEach((k) => {
       if (!keys.includes(k as keyof Abilities)) {
@@ -90,9 +94,7 @@ watch(
       }
     });
     keys.forEach((k) => {
-      if (!(k in localAbilities)) {
-        (localAbilities as any)[k] = false;
-      }
+      (localAbilities as any)[k] = props.modelValue[k];
     });
   },
   { immediate: true },


### PR DESCRIPTION
## Summary
- guard the type ability watcher so it only runs after the feature map has loaded
- repopulate local ability values from the current model when the allowed abilities become available so stored permissions persist

## Testing
- `pnpm lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9839885548323b2831388be1b78d5