### PR TITLE
Fix permissions loader not marking state loaded after failed fetches

### DIFF
--- a/frontend/src/services/permissions.ts
+++ b/frontend/src/services/permissions.ts
@@ -85,21 +85,27 @@ export function loadPermissions(force = false): Promise<void> {
       api.get<string[]>('/lookups/abilities'),
     ])
       .then(([featureResult, abilityResult]) => {
-        if (featureResult.status === 'fulfilled') {
+        const featureLoaded = featureResult.status === 'fulfilled';
+        const abilityLoaded = abilityResult.status === 'fulfilled';
+
+        if (featureLoaded) {
           state.featureMap = featureResult.value.data ?? {};
         } else if (force) {
           state.featureMap = {};
         }
 
-        if (abilityResult.status === 'fulfilled') {
+        if (abilityLoaded) {
           state.abilityList = abilityResult.value.data ?? [];
         } else if (force) {
           state.abilityList = [];
         }
 
         buildAbilityLookup();
-        state.loaded = true;
-        notifyListeners();
+
+        state.loaded = featureLoaded && abilityLoaded;
+        if (state.loaded) {
+          notifyListeners();
+        }
       })
       .finally(() => {
         loadPromise = null;


### PR DESCRIPTION
## Summary
- ensure the permissions loader only marks the service as loaded when both feature and ability lookups succeed
- prevent notifying load listeners on failed requests so that later retries can repopulate permission mappings

## Testing
- pnpm --dir frontend lint *(fails: existing lint violations in unrelated Vue components)*

------
https://chatgpt.com/codex/tasks/task_e_68c986a241b483239f1d4ae48e47cbc3