### PR TITLE
Add tenant ID filter to tenant index API

### DIFF
--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -29,7 +29,14 @@ class TenantController extends Controller
     public function index(Request $request)
     {
         $this->ensureSuperAdmin($request);
-        $result = $this->listQuery(Tenant::query(), $request, ['name'], ['name']);
+        $query = Tenant::query();
+
+        if ($request->filled('tenant_id')) {
+            $tenantId = $request->query('tenant_id');
+            $query->where('id', $tenantId);
+        }
+
+        $result = $this->listQuery($query, $request, ['name'], ['name']);
 
         $result['data'] = array_map(function ($tenant) {
             return $tenant->makeVisible('feature_abilities');

--- a/backend/tests/Feature/TenantListFilterTest.php
+++ b/backend/tests/Feature/TenantListFilterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TenantListFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_filter_tenants_by_id(): void
+    {
+        $tenantA = Tenant::create(['name' => 'Alpha']);
+        $tenantB = Tenant::create(['name' => 'Beta']);
+
+        $superRole = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'tenant_id' => $tenantA->id,
+        ]);
+
+        $user = User::create([
+            'name' => 'Root',
+            'email' => 'root@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenantA->id,
+            'phone' => '123456',
+            'address' => 'Street 1',
+        ]);
+
+        $user->roles()->attach($superRole->id, ['tenant_id' => $tenantA->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/tenants?tenant_id=' . $tenantB->id)
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonFragment([
+                'id' => $tenantB->id,
+                'name' => 'Beta',
+            ])
+            ->assertJsonMissing(['id' => $tenantA->id])
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('meta.page', 1)
+            ->assertJsonPath('meta.per_page', 15);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional tenant_id filter before running the tenant index list query
- cover the filtering behavior with a super admin feature test

## Testing
- php artisan test --filter=TenantListFilterTest

------
https://chatgpt.com/codex/tasks/task_e_68c9961782e48323a7ccd906adef3edb