### PR TITLE
Align tenant ability gating in UI and tests

### DIFF
--- a/frontend/src/components/tenants/TenantsTable.vue
+++ b/frontend/src/components/tenants/TenantsTable.vue
@@ -47,7 +47,7 @@
           <Dropdown classMenuItems=" w-[160px]">
             <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
             <template #menus>
-              <MenuItem v-if="can('tenants.view') || can('tenants.manage')">
+              <MenuItem v-if="can('tenants.view')">
                 <button
                   type="button"
                   class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
@@ -57,7 +57,7 @@
                   <span>{{ t('actions.view') }}</span>
                 </button>
               </MenuItem>
-              <MenuItem v-if="can('tenants.update') || can('tenants.manage')">
+              <MenuItem v-if="can('tenants.update')">
                 <button
                   type="button"
                   class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
@@ -77,7 +77,7 @@
                   <span>{{ t('actions.impersonate') }}</span>
                 </button>
               </MenuItem>
-              <MenuItem v-if="can('tenants.delete') || can('tenants.manage')">
+              <MenuItem v-if="can('tenants.delete')">
                 <button
                   type="button"
                   class="bg-danger-500 text-danger-500 bg-opacity-30 hover:bg-opacity-100 hover:text-white w-full px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
@@ -93,7 +93,7 @@
       </template>
       <template #selected-row-actions>
         <button
-          v-if="can('tenants.delete') || can('tenants.manage')"
+          v-if="can('tenants.delete')"
           type="button"
           class="ml-2 text-danger-500 hover:underline cursor-pointer"
           @click="emit('delete-selected', selectedIds)"

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -18,7 +18,7 @@
           :aria-label="t('tenants.label')"
         />
         <Button
-          v-if="can('tenants.create') || can('tenants.manage')"
+          v-if="can('tenants.create')"
           :link="{ name: 'tenants.create' }"
           btnClass="btn-primary btn-sm min-w-[100px] !h-8 !py-0"
           icon="heroicons-outline:plus"
@@ -45,7 +45,6 @@ import Select from '@/components/ui/Select/index.vue';
 import api, { extractData } from '@/services/api';
 import { useNotify } from '@/plugins/notify';
 import { useAuthStore, can } from '@/stores/auth';
-import hasAbility from '@/utils/ability';
 import { useTenantStore } from '@/stores/tenant';
 import { useI18n } from 'vue-i18n';
 
@@ -85,7 +84,7 @@ async function refreshTenantOptions() {
 }
 
 async function loadTenants() {
-  if (!hasAbility('tenants.view') && !hasAbility('tenants.manage')) {
+  if (!can('tenants.view')) {
     all.value = [];
     loading.value = false;
     return;
@@ -140,17 +139,17 @@ watch(tenantFilter, () => {
 });
 
 function view(id: number | string) {
-  if (!can('tenants.view') && !can('tenants.manage')) return;
+  if (!can('tenants.view')) return;
   router.push({ name: 'tenants.view', params: { id } });
 }
 
 function edit(id: number | string) {
-  if (!can('tenants.update') && !can('tenants.manage')) return;
+  if (!can('tenants.update')) return;
   router.push({ name: 'tenants.edit', params: { id } });
 }
 
 async function impersonate(id: number | string) {
-  if (!hasAbility('tenants.manage')) return;
+  if (!can('tenants.manage')) return;
   const tenantId = String(id);
   const tenant =
     all.value.find((t) => String(t.id) === tenantId) ||
@@ -164,7 +163,7 @@ async function impersonate(id: number | string) {
 }
 
 async function remove(id: number | string) {
-  if (!hasAbility('tenants.delete') && !hasAbility('tenants.manage')) return;
+  if (!can('tenants.delete')) return;
   const result = await Swal.fire({
     title: 'Delete tenant?',
     icon: 'warning',
@@ -182,7 +181,7 @@ async function remove(id: number | string) {
 
 async function removeMany(ids: Array<number | string>) {
   if (!ids.length) return;
-  if (!hasAbility('tenants.delete') && !hasAbility('tenants.manage')) return;
+  if (!can('tenants.delete')) return;
   const res = await Swal.fire({
     title: 'Delete selected tenants?',
     icon: 'warning',

--- a/frontend/tests/e2e/tenants.spec.ts
+++ b/frontend/tests/e2e/tenants.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 // No running server in the environment; this test documents the expected flow.
 test.skip('tenant deletion requires confirmation', async ({ page }) => {
@@ -22,4 +22,32 @@ test.skip('super admin can edit a tenant', async ({ page }) => {
   await page.goto('/users/tenants/1/edit');
   await page.getByLabel('Name').fill('Updated Tenant');
   await page.getByRole('button', { name: 'Save' }).click();
+});
+
+test.skip('tenant create button hidden without tenants.create', async ({ page }) => {
+  // Precondition: log in as a user missing the `tenants.create` ability.
+  await page.goto('/users/tenants');
+  await expect(page.getByRole('button', { name: 'Add Tenant' })).toBeHidden();
+});
+
+test.skip('tenant row actions respect granular abilities', async ({ page }) => {
+  // Precondition: log in as a user that can view tenants but lacks update/delete.
+  await page.goto('/users/tenants');
+  const actionsToggle = page.locator('button[aria-haspopup="menu"]').first();
+  await actionsToggle.click();
+  await expect(page.getByRole('menuitem', { name: 'View' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Edit' })).toHaveCount(0);
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toHaveCount(0);
+});
+
+test.skip('impersonation is forbidden without tenants.manage', async ({ page }) => {
+  // Precondition: log in as a user missing the `tenants.manage` ability.
+  await page.goto('/users/tenants');
+  const actionsToggle = page.locator('button[aria-haspopup="menu"]').first();
+  await actionsToggle.click();
+  await expect(page.getByRole('menuitem', { name: 'Impersonate' })).toHaveCount(0);
+
+  // Even if the API is called manually, the backend should respond with 403.
+  const response = await page.request.post('/api/tenants/1/impersonate');
+  expect(response.status()).toBe(403);
 });


### PR DESCRIPTION
## Summary
- confirm tenant routes enforce Ability middleware for tenant listing, mutations, and impersonation
- gate TenantsTable and TenantsList actions behind matching `can('tenants.*')` checks
- document permission expectations in the tenants E2E specification

## Testing
- pnpm lint *(fails: existing lint violations in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68c997a8510083239432cc8bf93bc170