### PR TITLE
Translate tenants menu strings

### DIFF
--- a/frontend/src/components/tenants/TenantsTable.vue
+++ b/frontend/src/components/tenants/TenantsTable.vue
@@ -164,22 +164,22 @@ const perPageOptions = [
   { value: '50', label: '50' },
 ];
 
-const selectOptions = {
+const selectOptions = computed(() => ({
   enabled: true,
   selectOnCheckboxOnly: true,
   selectionInfoClass: 'custom-class',
-  selectionText: 'rows selected',
-  clearSelectionText: 'clear',
+  selectionText: t('tenants.table.rowsSelected'),
+  clearSelectionText: t('actions.clear'),
   selectAllByGroup: true,
-};
+}));
 
-const columns = [
-  { label: 'Name', field: 'name' },
-  { label: 'Phone', field: 'phone' },
-  { label: 'Address', field: 'address' },
-  { label: 'Features', field: 'feature_count' },
-  { label: 'Actions', field: 'actions' },
-];
+const columns = computed(() => [
+  { label: t('tenants.table.columns.name'), field: 'name' },
+  { label: t('tenants.table.columns.phone'), field: 'phone' },
+  { label: t('tenants.table.columns.address'), field: 'address' },
+  { label: t('tenants.table.columns.features'), field: 'feature_count' },
+  { label: t('actions.actions'), field: 'actions' },
+]);
 
 const selectedIds = ref<Array<number | string>>([]);
 

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -26,6 +26,7 @@
     "select": "Επιλογή",
     "close": "Κλείσιμο",
     "clear": "Καθαρισμός",
+    "back": "Πίσω",
     "export": "Εξαγωγή",
     "chooseFile": "Επιλογή αρχείου",
     "view": "Προβολή"
@@ -68,7 +69,37 @@
   "tenants": {
     "label": "Μισθωτές",
     "form": {
-      "search": "Αναζήτηση"
+      "search": "Αναζήτηση",
+      "name": "Όνομα",
+      "storageQuota": "Όριο αποθήκευσης (MB)",
+      "phone": "Τηλέφωνο",
+      "address": "Διεύθυνση",
+      "adminName": "Όνομα διαχειριστή",
+      "adminEmail": "Email διαχειριστή",
+      "features": "Δυνατότητες",
+      "abilitiesPerFeature": "Δικαιώματα ανά δυνατότητα",
+      "saveError": "Αποτυχία αποθήκευσης μισθωτή"
+    },
+    "list": {
+      "addTenant": "Προσθήκη μισθωτή",
+      "deleteTenantTitle": "Διαγραφή μισθωτή;",
+      "deleteSelectedTenantsTitle": "Διαγραφή επιλεγμένων μισθωτών;",
+      "confirmDelete": "Ναι, διαγραφή"
+    },
+    "table": {
+      "rowsSelected": "γραμμές επιλεγμένες",
+      "columns": {
+        "name": "Όνομα",
+        "phone": "Τηλέφωνο",
+        "address": "Διεύθυνση",
+        "features": "Δυνατότητες"
+      }
+    },
+    "details": {
+      "id": "ID",
+      "name": "Όνομα",
+      "phone": "Τηλέφωνο",
+      "address": "Διεύθυνση"
     }
   },
   "allTenants": "Όλοι οι μισθωτές",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -26,6 +26,7 @@
     "select": "Select",
     "close": "Close",
     "clear": "Clear",
+    "back": "Back",
     "export": "Export",
     "chooseFile": "Choose File",
     "view": "View"
@@ -68,7 +69,37 @@
   "tenants": {
     "label": "Tenants",
     "form": {
-      "search": "Search"
+      "search": "Search",
+      "name": "Name",
+      "storageQuota": "Storage Quota (MB)",
+      "phone": "Phone",
+      "address": "Address",
+      "adminName": "Admin Name",
+      "adminEmail": "Admin Email",
+      "features": "Features",
+      "abilitiesPerFeature": "Abilities per feature",
+      "saveError": "Failed to save tenant"
+    },
+    "list": {
+      "addTenant": "Add Tenant",
+      "deleteTenantTitle": "Delete tenant?",
+      "deleteSelectedTenantsTitle": "Delete selected tenants?",
+      "confirmDelete": "Yes, delete"
+    },
+    "table": {
+      "rowsSelected": "rows selected",
+      "columns": {
+        "name": "Name",
+        "phone": "Phone",
+        "address": "Address",
+        "features": "Features"
+      }
+    },
+    "details": {
+      "id": "ID",
+      "name": "Name",
+      "phone": "Phone",
+      "address": "Address"
     }
   },
   "allTenants": "All tenants",

--- a/frontend/src/views/tenants/TenantDetails.vue
+++ b/frontend/src/views/tenants/TenantDetails.vue
@@ -1,19 +1,23 @@
 <template>
   <div v-if="tenant" class="max-w-md">
     <div class="grid gap-2">
-      <div><strong>ID:</strong> {{ tenant.id }}</div>
-      <div><strong>Name:</strong> {{ tenant.name }}</div>
-      <div><strong>Phone:</strong> {{ tenant.phone }}</div>
-      <div><strong>Address:</strong> {{ tenant.address }}</div>
+      <div><strong>{{ t('tenants.details.id') }}:</strong> {{ tenant.id }}</div>
+      <div><strong>{{ t('tenants.details.name') }}:</strong> {{ tenant.name }}</div>
+      <div><strong>{{ t('tenants.details.phone') }}:</strong> {{ tenant.phone }}</div>
+      <div><strong>{{ t('tenants.details.address') }}:</strong> {{ tenant.address }}</div>
     </div>
     <div class="mt-4 flex gap-2">
       <Button
         v-if="can('tenants.update') || can('tenants.manage')"
         btnClass="btn-primary btn-sm"
-        text="Edit"
+        :text="t('actions.edit')"
         :to="{ name: 'tenants.edit', params: { id: tenant.id } }"
       />
-      <Button btnClass="btn-secondary btn-sm" text="Back" :to="{ name: 'tenants.list' }" />
+      <Button
+        btnClass="btn-secondary btn-sm"
+        :text="t('actions.back')"
+        :to="{ name: 'tenants.list' }"
+      />
     </div>
   </div>
 </template>
@@ -25,9 +29,11 @@ import api from '@/services/api';
 import Button from '@/components/ui/Button/index.vue';
 import { can } from '@/stores/auth';
 import hasAbility from '@/utils/ability';
+import { useI18n } from 'vue-i18n';
 
 const route = useRoute();
 const tenant = ref<any>(null);
+const { t } = useI18n();
 
 onMounted(async () => {
   if (!hasAbility('tenants.view') && !hasAbility('tenants.manage')) return;

--- a/frontend/src/views/tenants/TenantForm.vue
+++ b/frontend/src/views/tenants/TenantForm.vue
@@ -1,25 +1,25 @@
 <template>
   <div v-if="canAccess">
     <form class="max-w-md grid gap-4" @submit.prevent="onSubmit">
-      <Textinput v-model="form.name" label="Name" />
+      <Textinput v-model="form.name" :label="t('tenants.form.name')" />
       <div v-if="errors.name" class="text-red-600 text-sm">{{ errors.name }}</div>
       <Textinput
         v-model.number="form.quota_storage_mb"
-        label="Storage Quota (MB)"
+        :label="t('tenants.form.storageQuota')"
         type="number"
       />
-      <Textinput v-model="form.phone" label="Phone" />
-      <Textinput v-model="form.address" label="Address" />
-      <Textinput v-if="!isEdit" v-model="form.user_name" label="Admin Name" />
+      <Textinput v-model="form.phone" :label="t('tenants.form.phone')" />
+      <Textinput v-model="form.address" :label="t('tenants.form.address')" />
+      <Textinput v-if="!isEdit" v-model="form.user_name" :label="t('tenants.form.adminName')" />
       <div v-if="!isEdit && errors.user_name" class="text-red-600 text-sm">{{ errors.user_name }}</div>
       <Textinput
         v-if="!isEdit"
         v-model="form.user_email"
-        label="Admin Email"
+        :label="t('tenants.form.adminEmail')"
         type="email"
       />
       <div v-if="!isEdit && errors.user_email" class="text-red-600 text-sm">{{ errors.user_email }}</div>
-      <VueSelect label="Features" :error="errors.features">
+      <VueSelect :label="t('tenants.form.features')" :error="errors.features">
         <template #default="{ inputId }">
           <vSelect
             :id="inputId"
@@ -31,7 +31,7 @@
         </template>
       </VueSelect>
       <div v-if="form.features.length" class="grid gap-4">
-        <h3 class="font-medium">Abilities per feature</h3>
+        <h3 class="font-medium">{{ t('tenants.form.abilitiesPerFeature') }}</h3>
         <VueSelect
           v-for="f in form.features"
           :key="f"
@@ -49,7 +49,7 @@
         </VueSelect>
       </div>
       <div v-if="serverError" class="text-red-600 text-sm">{{ serverError }}</div>
-      <Button type="submit" text="Save" btnClass="btn-dark" />
+      <Button type="submit" :text="t('actions.save')" btnClass="btn-dark" />
     </form>
   </div>
 </template>
@@ -67,6 +67,7 @@ import { useTenantStore } from '@/stores/tenant';
 import hasAbility from '@/utils/ability';
 import { useFeaturesStore } from '@/stores/features';
 import { storeToRefs } from 'pinia';
+import { useI18n } from 'vue-i18n';
 
 const route = useRoute();
 const router = useRouter();
@@ -74,6 +75,7 @@ const isEdit = computed(() => route.name === 'tenants.edit');
 const tenantStore = useTenantStore();
 const featuresStore = useFeaturesStore();
 const { featureMap } = storeToRefs(featuresStore);
+const { t } = useI18n();
 
 const canAccess = computed(
   () =>
@@ -162,7 +164,7 @@ const onSubmit = handleSubmit(async () => {
     if (Object.keys(errs).length) {
       setErrors(errs);
     } else {
-      serverError.value = e.message || 'Failed to save';
+      serverError.value = e.message || t('tenants.form.saveError');
     }
   }
 });

--- a/frontend/src/views/tenants/TenantsList.vue
+++ b/frontend/src/views/tenants/TenantsList.vue
@@ -23,8 +23,8 @@
           btnClass="btn-primary btn-sm min-w-[100px] !h-8 !py-0"
           icon="heroicons-outline:plus"
           iconClass="w-4 h-4"
-          text="Add Tenant"
-          aria-label="Add Tenant"
+          :text="t('tenants.list.addTenant')"
+          :aria-label="t('tenants.list.addTenant')"
         />
       </template>
     </TenantsTable>
@@ -165,10 +165,11 @@ async function impersonate(id: number | string) {
 async function remove(id: number | string) {
   if (!can('tenants.delete')) return;
   const result = await Swal.fire({
-    title: 'Delete tenant?',
+    title: t('tenants.list.deleteTenantTitle'),
     icon: 'warning',
     showCancelButton: true,
-    confirmButtonText: 'Yes, delete',
+    confirmButtonText: t('tenants.list.confirmDelete'),
+    cancelButtonText: t('actions.cancel'),
   });
   if (!result.isConfirmed) return;
   try {
@@ -183,9 +184,11 @@ async function removeMany(ids: Array<number | string>) {
   if (!ids.length) return;
   if (!can('tenants.delete')) return;
   const res = await Swal.fire({
-    title: 'Delete selected tenants?',
+    title: t('tenants.list.deleteSelectedTenantsTitle'),
     icon: 'warning',
     showCancelButton: true,
+    confirmButtonText: t('tenants.list.confirmDelete'),
+    cancelButtonText: t('actions.cancel'),
   });
   if (!res.isConfirmed) return;
 


### PR DESCRIPTION
## Summary
- localize tenant list action buttons and confirmation prompts
- add translation-backed labels for tenant table columns and selection text
- translate tenant form and detail view fields and add corresponding locale entries

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c99b39bdac8323938b6041ed1713e5