### PR TITLE
Add account management endpoints for employees and owners

### DIFF
--- a/backend/app/Http/Controllers/Api/Concerns/ManagesTenantUsers.php
+++ b/backend/app/Http/Controllers/Api/Concerns/ManagesTenantUsers.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api\Concerns;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Password;
+
+trait ManagesTenantUsers
+{
+    protected function ensureUserIsNotSuperAdmin(User $user): void
+    {
+        if ($user->hasRole('SuperAdmin')) {
+            abort(403, 'Cannot modify a SuperAdmin');
+        }
+    }
+
+    protected function dispatchPasswordReset(User $user): void
+    {
+        Password::sendResetLink(['email' => $user->email]);
+    }
+
+    protected function dispatchInvite(User $user): void
+    {
+        $this->dispatchPasswordReset($user);
+    }
+
+    protected function resetUserEmail(User $user, string $email): void
+    {
+        $user->forceFill([
+            'email' => $email,
+            'email_verified_at' => null,
+        ])->save();
+
+        $this->dispatchPasswordReset($user);
+    }
+}

--- a/backend/app/Http/Controllers/Api/TenantController.php
+++ b/backend/app/Http/Controllers/Api/TenantController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Api\Concerns\ManagesTenantUsers;
 use App\Http\Requests\TenantUpsertRequest;
 use App\Models\Tenant;
 use App\Models\User;
@@ -14,10 +15,12 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use App\Support\ListQuery;
+use App\Http\Resources\TenantOwnerResource;
 
 class TenantController extends Controller
 {
     use ListQuery;
+    use ManagesTenantUsers;
 
     protected function ensureSuperAdmin(Request $request): void
     {
@@ -121,5 +124,93 @@ class TenantController extends Controller
             'user' => $user->load('roles'),
             'impersonator_id' => $request->user()->id,
         ]);
+    }
+
+    protected function ensureTenantRouteScope(Request $request, Tenant $tenant): void
+    {
+        $user = $request->user();
+
+        if ($user->isSuperAdmin()) {
+            return;
+        }
+
+        $tenantId = $request->attributes->get('tenant_id') ?? $request->header('X-Tenant-ID');
+
+        if ((int) $tenant->id !== (int) $tenantId) {
+            abort(404);
+        }
+    }
+
+    protected function resolveTenantOwner(Tenant $tenant): User
+    {
+        $tenantRoleId = $tenant->roles()->where('slug', 'tenant')->value('id');
+
+        if ($tenantRoleId) {
+            $owner = User::whereHas('roles', function ($query) use ($tenantRoleId, $tenant) {
+                $query->where('roles.id', $tenantRoleId)
+                    ->where('role_user.tenant_id', $tenant->id);
+            })->first();
+
+            if ($owner) {
+                return $owner;
+            }
+        }
+
+        return User::where('tenant_id', $tenant->id)
+            ->where(function ($query) {
+                $query->whereNull('type')
+                    ->orWhere('type', 'tenant');
+            })
+            ->orderBy('id')
+            ->firstOrFail();
+    }
+
+    public function owner(Request $request, Tenant $tenant)
+    {
+        $this->ensureTenantRouteScope($request, $tenant);
+
+        $owner = $this->resolveTenantOwner($tenant)->load('roles');
+
+        return new TenantOwnerResource($owner);
+    }
+
+    public function ownerPasswordReset(Request $request, Tenant $tenant)
+    {
+        $this->ensureTenantRouteScope($request, $tenant);
+
+        $owner = $this->resolveTenantOwner($tenant);
+        $this->ensureUserIsNotSuperAdmin($owner);
+
+        $this->dispatchPasswordReset($owner);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function ownerResendInvite(Request $request, Tenant $tenant)
+    {
+        $this->ensureTenantRouteScope($request, $tenant);
+
+        $owner = $this->resolveTenantOwner($tenant);
+        $this->ensureUserIsNotSuperAdmin($owner);
+
+        $this->dispatchInvite($owner);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    public function ownerResetEmail(Request $request, Tenant $tenant)
+    {
+        $this->ensureTenantRouteScope($request, $tenant);
+
+        $owner = $this->resolveTenantOwner($tenant);
+        $this->ensureUserIsNotSuperAdmin($owner);
+
+        $data = $request->validate([
+            'email' => 'required|email|unique:users,email,' . $owner->id,
+        ]);
+
+        $this->resetUserEmail($owner, $data['email']);
+
+        return new TenantOwnerResource($owner->fresh()->load('roles'));
     }
 }

--- a/backend/app/Http/Resources/TenantOwnerResource.php
+++ b/backend/app/Http/Resources/TenantOwnerResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Concerns\FormatsDateTimes;
+
+class TenantOwnerResource extends JsonResource
+{
+    use FormatsDateTimes;
+
+    public function toArray($request): array
+    {
+        $data = [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'phone' => $this->phone,
+            'address' => $this->address,
+            'last_login_at' => $this->last_login_at,
+            'roles' => $this->whenLoaded('roles', function () {
+                return $this->roles->map(fn ($role) => [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                    'slug' => $role->slug,
+                ]);
+            }),
+        ];
+
+        return $this->formatDates($data);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -286,8 +286,24 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
         ->middleware(Ability::class . ':employees.manage');
     Route::post('employees/{employee}/impersonate', [EmployeeController::class, 'impersonate'])
         ->middleware(Ability::class . ':employees.manage');
+    Route::post('employees/{employee}/password-reset', [EmployeeController::class, 'sendPasswordReset'])
+        ->middleware(Ability::class . ':employees.manage');
+    Route::post('employees/{employee}/invite-resend', [EmployeeController::class, 'resendInvite'])
+        ->middleware(Ability::class . ':employees.manage');
+    Route::post('employees/{employee}/email-reset', [EmployeeController::class, 'resetEmail'])
+        ->middleware(Ability::class . ':employees.manage');
     Route::post('employees/{employee}/resend-invite', [EmployeeController::class, 'resendInvite'])
         ->middleware(Ability::class . ':employees.manage');
+    Route::prefix('tenants/{tenant}/owner')->group(function () {
+        Route::get('/', [TenantController::class, 'owner'])
+            ->middleware(Ability::class . ':tenants.view|tenants.manage');
+        Route::post('password-reset', [TenantController::class, 'ownerPasswordReset'])
+            ->middleware(Ability::class . ':tenants.manage');
+        Route::post('invite-resend', [TenantController::class, 'ownerResendInvite'])
+            ->middleware(Ability::class . ':tenants.manage');
+        Route::post('email-reset', [TenantController::class, 'ownerResetEmail'])
+            ->middleware(Ability::class . ':tenants.manage');
+    });
 
     Route::put('branding', [BrandingController::class, 'update'])
         ->middleware(Ability::class . ':branding.manage');

--- a/backend/tests/EmployeeTest.php
+++ b/backend/tests/EmployeeTest.php
@@ -43,17 +43,21 @@ class EmployeeTest extends TestCase
         $this->assertStringContainsString('department', $updateCode);
     }
 
-    public function test_employee_controller_has_impersonation_and_invite_methods(): void
+    public function test_employee_controller_has_impersonation_and_account_methods(): void
     {
         $this->assertTrue(method_exists(EmployeeController::class, 'impersonate'));
         $this->assertTrue(method_exists(EmployeeController::class, 'resendInvite'));
+        $this->assertTrue(method_exists(EmployeeController::class, 'sendPasswordReset'));
+        $this->assertTrue(method_exists(EmployeeController::class, 'resetEmail'));
     }
 
     public function test_employee_routes_include_impersonation_and_invite_resend(): void
     {
         $routes = file_get_contents(dirname(__DIR__) . '/routes/api.php');
         $this->assertStringContainsString("employees/{employee}/impersonate", $routes);
-        $this->assertStringContainsString("employees/{employee}/resend-invite", $routes);
+        $this->assertStringContainsString("employees/{employee}/password-reset", $routes);
+        $this->assertStringContainsString("employees/{employee}/invite-resend", $routes);
+        $this->assertStringContainsString("employees/{employee}/email-reset", $routes);
         $this->assertStringContainsString('employees.manage', $routes);
     }
 }

--- a/backend/tests/Feature/EmployeeAccountActionsTest.php
+++ b/backend/tests/Feature/EmployeeAccountActionsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class EmployeeAccountActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_password_reset_requires_manage_ability(): void
+    {
+        [$tenant, $admin] = $this->createTenantAdmin(['employees.view']);
+        $employee = $this->createEmployee($tenant, 'Agent', 'agent@example.com');
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')->never();
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/employees/{$employee->id}/password-reset")
+            ->assertStatus(403);
+    }
+
+    public function test_password_reset_dispatches_notification(): void
+    {
+        [$tenant, $admin] = $this->createTenantAdmin(['employees.manage']);
+        $employee = $this->createEmployee($tenant, 'Agent', 'agent@example.com');
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->with(['email' => $employee->email])
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/employees/{$employee->id}/password-reset")
+            ->assertStatus(200)
+            ->assertJson(['status' => 'ok']);
+    }
+
+    public function test_invite_resend_dispatches_notification(): void
+    {
+        [$tenant, $admin] = $this->createTenantAdmin(['employees.manage']);
+        $employee = $this->createEmployee($tenant, 'Agent', 'agent@example.com');
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->with(['email' => $employee->email])
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/employees/{$employee->id}/invite-resend")
+            ->assertStatus(200)
+            ->assertJson(['status' => 'ok']);
+    }
+
+    public function test_email_reset_updates_address_and_sends_notification(): void
+    {
+        [$tenant, $admin] = $this->createTenantAdmin(['employees.manage']);
+        $employee = $this->createEmployee($tenant, 'Agent', 'agent@example.com');
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->with(['email' => 'updated@example.com'])
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/employees/{$employee->id}/email-reset", [
+                'email' => 'updated@example.com',
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('data.email', 'updated@example.com');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $employee->id,
+            'email' => 'updated@example.com',
+        ]);
+    }
+
+    /**
+     * @return array{0: Tenant, 1: User}
+     */
+    protected function createTenantAdmin(array $abilities): array
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['employees']]);
+
+        $role = Role::create([
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'tenant_id' => $tenant->id,
+            'abilities' => $abilities,
+        ]);
+
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '1234567890',
+            'address' => '1 Admin Street',
+            'type' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $role->users()->attach($admin->id, ['tenant_id' => $tenant->id]);
+
+        return [$tenant, $admin];
+    }
+
+    protected function createEmployee(Tenant $tenant, string $name, string $email): User
+    {
+        return User::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '5550000000',
+            'address' => '1 Employee Street',
+            'type' => 'employee',
+            'status' => 'active',
+        ]);
+    }
+}

--- a/backend/tests/Feature/TenantOwnerAccountActionsTest.php
+++ b/backend/tests/Feature/TenantOwnerAccountActionsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TenantOwnerAccountActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_endpoint_returns_owner_metadata(): void
+    {
+        [$tenant, $owner, $admin] = $this->createTenantWithOwner(['tenants.view']);
+
+        Sanctum::actingAs($admin);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->getJson("/api/tenants/{$tenant->id}/owner")
+            ->assertStatus(200)
+            ->assertJsonPath('data.email', $owner->email)
+            ->assertJsonPath('data.id', $owner->id);
+    }
+
+    public function test_owner_password_reset_requires_manage_ability(): void
+    {
+        [$tenant, $owner, $admin] = $this->createTenantWithOwner(['tenants.view']);
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')->never();
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/tenants/{$tenant->id}/owner/password-reset")
+            ->assertStatus(403);
+    }
+
+    public function test_owner_password_reset_dispatches_notification(): void
+    {
+        [$tenant, $owner, $admin] = $this->createTenantWithOwner(['tenants.manage']);
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->with(['email' => $owner->email])
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/tenants/{$tenant->id}/owner/password-reset")
+            ->assertStatus(200)
+            ->assertJson(['status' => 'ok']);
+    }
+
+    public function test_owner_invite_resend_dispatches_notification(): void
+    {
+        [$tenant, $owner, $admin] = $this->createTenantWithOwner(['tenants.manage']);
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->with(['email' => $owner->email])
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/tenants/{$tenant->id}/owner/invite-resend")
+            ->assertStatus(200)
+            ->assertJson(['status' => 'ok']);
+    }
+
+    public function test_owner_email_reset_updates_address_and_sends_notification(): void
+    {
+        [$tenant, $owner, $admin] = $this->createTenantWithOwner(['tenants.manage']);
+
+        Sanctum::actingAs($admin);
+
+        Password::shouldReceive('sendResetLink')
+            ->once()
+            ->with(['email' => 'new-owner@example.com'])
+            ->andReturn(Password::RESET_LINK_SENT);
+
+        $this->withHeader('X-Tenant-ID', $tenant->id)
+            ->postJson("/api/tenants/{$tenant->id}/owner/email-reset", [
+                'email' => 'new-owner@example.com',
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('data.email', 'new-owner@example.com');
+
+        $this->assertDatabaseHas('users', [
+            'id' => $owner->id,
+            'email' => 'new-owner@example.com',
+        ]);
+    }
+
+    /**
+     * @return array{0: Tenant, 1: User, 2: User}
+     */
+    protected function createTenantWithOwner(array $adminAbilities): array
+    {
+        $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['employees']]);
+
+        $ownerRole = $tenant->roles()->where('slug', 'tenant')->first();
+
+        if ($ownerRole) {
+            $ownerRole->update(['abilities' => ['tenants.manage']]);
+        } else {
+            $ownerRole = Role::create([
+                'name' => 'Tenant Owner',
+                'slug' => 'tenant',
+                'tenant_id' => $tenant->id,
+                'abilities' => ['tenants.manage'],
+            ]);
+        }
+
+        $owner = User::create([
+            'name' => 'Owner',
+            'email' => 'owner@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '5550001000',
+            'address' => '1 Owner Street',
+            'type' => 'tenant',
+            'status' => 'active',
+        ]);
+
+        $ownerRole->users()->attach($owner->id, ['tenant_id' => $tenant->id]);
+
+        $adminRole = Role::create([
+            'name' => 'Tenant Admin',
+            'slug' => 'tenant_admin',
+            'tenant_id' => $tenant->id,
+            'abilities' => $adminAbilities,
+        ]);
+
+        $admin = User::create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '5550002000',
+            'address' => '2 Admin Street',
+            'type' => 'employee',
+            'status' => 'active',
+        ]);
+
+        $adminRole->users()->attach($admin->id, ['tenant_id' => $tenant->id]);
+
+        return [$tenant, $owner, $admin];
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable trait to centralize tenant user account updates and notifications
- extend employee and tenant controllers with password reset, invite resend, and email reset flows plus tenant-owner exposure
- register new API routes and resources and cover them with feature and regression tests

## Testing
- php artisan test --filter=EmployeeAccountActionsTest
- php artisan test --filter=TenantOwnerAccountActionsTest

------
https://chatgpt.com/codex/tasks/task_e_68c9a29246a0832399fb76ce1af42f24