### PR TITLE
Add employee and tenant owner account recovery actions

### DIFF
--- a/frontend/src/components/employees/EmployeesTable.vue
+++ b/frontend/src/components/employees/EmployeesTable.vue
@@ -58,7 +58,7 @@
           {{ formatDate(rowProps.row.last_login_at) }}
         </span>
         <span v-else-if="rowProps.column.field === 'actions'">
-          <Dropdown classMenuItems=" w-[140px]">
+          <Dropdown classMenuItems=" w-[180px]">
             <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
             <template #menus>
               <MenuItem v-if="can('employees.manage')">
@@ -79,6 +79,26 @@
                 >
                   <span class="text-base"><Icon icon="heroicons-outline:envelope" /></span>
                   <span>{{ t('actions.resendInvite') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="can('employees.manage')">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('reset-email', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:at-symbol" /></span>
+                  <span>{{ t('actions.resetEmail') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="can('employees.manage')">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('send-password-reset', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:key" /></span>
+                  <span>{{ t('actions.sendPasswordReset') }}</span>
                 </button>
               </MenuItem>
               <MenuItem v-if="can('employees.update') || can('employees.manage')">
@@ -170,6 +190,8 @@ const emit = defineEmits<{
   (e: 'delete-selected', ids: number[]): void;
   (e: 'impersonate', id: number): void;
   (e: 'resend-invite', id: number): void;
+  (e: 'reset-email', id: number): void;
+  (e: 'send-password-reset', id: number): void;
 }>();
 
 const { t } = useI18n();

--- a/frontend/src/components/tenants/TenantsTable.vue
+++ b/frontend/src/components/tenants/TenantsTable.vue
@@ -44,7 +44,7 @@
           {{ formatFeatureCount(rowProps.row) }}
         </span>
         <span v-else-if="rowProps.column.field === 'actions'">
-          <Dropdown classMenuItems=" w-[160px]">
+          <Dropdown classMenuItems=" w-[200px]">
             <span class="text-xl"><Icon icon="heroicons-outline:dots-vertical" /></span>
             <template #menus>
               <MenuItem v-if="can('tenants.view')">
@@ -75,6 +75,36 @@
                 >
                   <span class="text-base"><Icon icon="heroicons-outline:user" /></span>
                   <span>{{ t('actions.impersonate') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="can('tenants.manage') && rowProps.row.owner">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('owner-resend-invite', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:envelope" /></span>
+                  <span>{{ t('actions.resendInvite') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="can('tenants.manage') && rowProps.row.owner">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('owner-reset-email', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:at-symbol" /></span>
+                  <span>{{ t('actions.resetEmail') }}</span>
+                </button>
+              </MenuItem>
+              <MenuItem v-if="can('tenants.manage') && rowProps.row.owner">
+                <button
+                  type="button"
+                  class="hover:bg-slate-900 hover:text-white dark:hover:bg-slate-600 dark:hover:bg-opacity-50 w-full border-b border-b-gray-500 border-opacity-10 px-4 py-2 text-sm flex space-x-2 items-center rtl:space-x-reverse"
+                  @click="$emit('owner-password-reset', rowProps.row.id)"
+                >
+                  <span class="text-base"><Icon icon="heroicons-outline:key" /></span>
+                  <span>{{ t('actions.sendPasswordReset') }}</span>
                 </button>
               </MenuItem>
               <MenuItem v-if="can('tenants.delete')">
@@ -132,6 +162,12 @@ import Breadcrumbs from '@/Layout/Breadcrumbs.vue';
 import { useI18n } from 'vue-i18n';
 import { can } from '@/stores/auth';
 
+interface TenantOwner {
+  id: number | string;
+  name?: string | null;
+  email?: string | null;
+}
+
 interface TenantRow {
   id: number | string;
   name: string;
@@ -142,6 +178,7 @@ interface TenantRow {
   features?: string[] | null;
   feature_count?: number | null;
   features_count?: number | null;
+  owner?: TenantOwner | null;
 }
 
 const props = defineProps<{ rows: TenantRow[] }>();
@@ -151,6 +188,9 @@ const emit = defineEmits<{
   (e: 'delete', id: number | string): void;
   (e: 'delete-selected', ids: Array<number | string>): void;
   (e: 'impersonate', id: number | string): void;
+  (e: 'owner-resend-invite', id: number | string): void;
+  (e: 'owner-reset-email', id: number | string): void;
+  (e: 'owner-password-reset', id: number | string): void;
 }>();
 
 const { t } = useI18n();
@@ -192,6 +232,8 @@ const filteredRows = computed(() => {
     const address = String(r.address || '').toLowerCase();
     const slug = String(r.slug || '').toLowerCase();
     const domain = String(r.domain || '').toLowerCase();
+    const ownerName = String(r.owner?.name || '').toLowerCase();
+    const ownerEmail = String(r.owner?.email || '').toLowerCase();
     const featureCount = featureCountValue(r);
     const featureText = Array.isArray(r.features)
       ? r.features.join(' ').toLowerCase()
@@ -203,6 +245,8 @@ const filteredRows = computed(() => {
       address.includes(term) ||
       slug.includes(term) ||
       domain.includes(term) ||
+      ownerName.includes(term) ||
+      ownerEmail.includes(term) ||
       featureText.includes(term)
     );
   });

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -12,6 +12,8 @@
     "delete": "Διαγραφή",
     "impersonate": "Υποδύσου",
     "resendInvite": "Επαναποστολή πρόσκλησης",
+    "resetEmail": "Επαναφορά email",
+    "sendPasswordReset": "Αποστολή επαναφοράς κωδικού",
     "save": "Αποθήκευση",
     "publish": "Δημοσίευση",
     "unpublish": "Αποδημοσίευση",
@@ -85,6 +87,20 @@
       "deleteTenantTitle": "Διαγραφή μισθωτή;",
       "deleteSelectedTenantsTitle": "Διαγραφή επιλεγμένων μισθωτών;",
       "confirmDelete": "Ναι, διαγραφή"
+    },
+    "owner": {
+      "resetEmail": {
+        "title": "Επαναφορά email ιδιοκτήτη",
+        "label": "Νέο email",
+        "placeholder": "name@example.com",
+        "confirm": "Επαναφορά email",
+        "required": "Απαιτείται email",
+        "success": "Το email του ιδιοκτήτη ενημερώθηκε"
+      },
+      "passwordReset": {
+        "success": "Στάλθηκε email επαναφοράς κωδικού στον ιδιοκτήτη"
+      },
+      "inviteResent": "Η πρόσκληση του ιδιοκτήτη στάλθηκε ξανά"
     },
     "table": {
       "rowsSelected": "γραμμές επιλεγμένες",
@@ -429,6 +445,17 @@
     "addEmployee": "Πρόσκληση υπαλλήλου",
     "form": {
       "search": "Αναζήτηση"
+    },
+    "resetEmail": {
+      "title": "Επαναφορά email υπαλλήλου",
+      "label": "Νέο email",
+      "placeholder": "name@example.com",
+      "confirm": "Επαναφορά email",
+      "required": "Απαιτείται email",
+      "success": "Το email του υπαλλήλου ενημερώθηκε"
+    },
+    "passwordReset": {
+      "success": "Στάλθηκε email επαναφοράς κωδικού"
     }
   },
   "roles": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -12,6 +12,8 @@
     "delete": "Delete",
     "impersonate": "Impersonate",
     "resendInvite": "Resend Invite",
+    "resetEmail": "Reset Email",
+    "sendPasswordReset": "Send Password Reset",
     "save": "Save",
     "publish": "Publish",
     "unpublish": "Unpublish",
@@ -85,6 +87,20 @@
       "deleteTenantTitle": "Delete tenant?",
       "deleteSelectedTenantsTitle": "Delete selected tenants?",
       "confirmDelete": "Yes, delete"
+    },
+    "owner": {
+      "resetEmail": {
+        "title": "Reset tenant owner email",
+        "label": "New email address",
+        "placeholder": "name@example.com",
+        "confirm": "Reset email",
+        "required": "Email is required",
+        "success": "Tenant owner email updated"
+      },
+      "passwordReset": {
+        "success": "Tenant owner password reset email sent"
+      },
+      "inviteResent": "Tenant owner invitation resent"
     },
     "table": {
       "rowsSelected": "rows selected",
@@ -429,6 +445,17 @@
     "addEmployee": "Invite Employee",
     "form": {
       "search": "Search"
+    },
+    "resetEmail": {
+      "title": "Reset employee email",
+      "label": "New email address",
+      "placeholder": "name@example.com",
+      "confirm": "Reset email",
+      "required": "Email is required",
+      "success": "Employee email updated"
+    },
+    "passwordReset": {
+      "success": "Password reset email sent"
     }
   },
   "roles": {

--- a/frontend/tests/unit/employees.actions.test.ts
+++ b/frontend/tests/unit/employees.actions.test.ts
@@ -1,0 +1,101 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const { notifySuccess, notifyError, swalFire, swalShowValidationMessage } = vi.hoisted(() => ({
+  notifySuccess: vi.fn(),
+  notifyError: vi.fn(),
+  swalFire: vi.fn(),
+  swalShowValidationMessage: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/plugins/notify', () => ({
+  useNotify: () => ({ success: notifySuccess, error: notifyError }),
+}));
+
+vi.mock('sweetalert2', () => ({
+  __esModule: true,
+  default: {
+    fire: swalFire,
+    showValidationMessage: swalShowValidationMessage,
+  },
+}));
+
+import EmployeesList from '@/views/employees/EmployeesList.vue';
+import api from '@/services/api';
+import { useAuthStore } from '@/stores/auth';
+import { useTenantStore } from '@/stores/tenant';
+
+function createSetup() {
+  const ctx = { attrs: {}, slots: {}, emit: () => {}, expose: () => {} };
+  return (EmployeesList as any).setup?.(undefined, ctx) as any;
+}
+
+describe('EmployeesList user actions', () => {
+  let getSpy: ReturnType<typeof vi.spyOn>;
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    notifySuccess.mockReset();
+    notifyError.mockReset();
+    swalFire.mockReset();
+    swalShowValidationMessage.mockReset();
+
+    const auth = useAuthStore();
+    auth.abilities = ['employees.manage'];
+    auth.user = { roles: [] } as any;
+
+    const tenantStore = useTenantStore();
+    tenantStore.tenants = [];
+    tenantStore.currentTenantId = '' as any;
+    tenantStore.loadTenants = vi.fn().mockResolvedValue(undefined) as any;
+
+    getSpy = vi.spyOn(api, 'get').mockResolvedValue({ data: { data: [] } } as any);
+    postSpy = vi.spyOn(api, 'post').mockResolvedValue({ data: {} } as any);
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+    postSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('sends reset email request with provided address', async () => {
+    swalFire.mockResolvedValue({ isConfirmed: true, value: 'new@example.com' });
+
+    const setup = createSetup();
+    setup.all.value = [{ id: 7, email: 'old@example.com' }];
+
+    await setup.resetEmail(7);
+
+    expect(swalFire).toHaveBeenCalled();
+    expect(postSpy).toHaveBeenCalledWith(
+      '/employees/7/email-reset',
+      { email: 'new@example.com' },
+      { params: {} },
+    );
+    expect(notifySuccess).toHaveBeenCalledWith('employees.resetEmail.success');
+  });
+
+  it('sends password reset request', async () => {
+    const setup = createSetup();
+
+    await setup.sendPasswordReset(5);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      '/employees/5/password-reset',
+      {},
+      { params: {} },
+    );
+    expect(notifySuccess).toHaveBeenCalledWith('employees.passwordReset.success');
+  });
+});

--- a/frontend/tests/unit/tenants.owner-actions.test.ts
+++ b/frontend/tests/unit/tenants.owner-actions.test.ts
@@ -1,0 +1,131 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const { notifySuccess, notifyError, swalFire, swalShowValidationMessage } = vi.hoisted(() => ({
+  notifySuccess: vi.fn(),
+  notifyError: vi.fn(),
+  swalFire: vi.fn(),
+  swalShowValidationMessage: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/plugins/notify', () => ({
+  useNotify: () => ({ success: notifySuccess, error: notifyError }),
+}));
+
+vi.mock('sweetalert2', () => ({
+  __esModule: true,
+  default: {
+    fire: swalFire,
+    showValidationMessage: swalShowValidationMessage,
+  },
+}));
+
+import TenantsList from '@/views/tenants/TenantsList.vue';
+import api from '@/services/api';
+import { useAuthStore } from '@/stores/auth';
+import { useTenantStore } from '@/stores/tenant';
+
+function createSetup() {
+  const ctx = { attrs: {}, slots: {}, emit: () => {}, expose: () => {} };
+  return (TenantsList as any).setup?.(undefined, ctx) as any;
+}
+
+describe('TenantsList owner management actions', () => {
+  let getSpy: ReturnType<typeof vi.spyOn>;
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    notifySuccess.mockReset();
+    notifyError.mockReset();
+    swalFire.mockReset();
+    swalShowValidationMessage.mockReset();
+
+    const auth = useAuthStore();
+    auth.abilities = ['tenants.manage'];
+    auth.user = { roles: [] } as any;
+
+    const tenantStore = useTenantStore();
+    tenantStore.tenants = [];
+    tenantStore.currentTenantId = '' as any;
+    tenantStore.loadTenants = vi.fn().mockResolvedValue(undefined) as any;
+
+    getSpy = vi.spyOn(api, 'get').mockImplementation((url: string) => {
+      if (url === '/tenants') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: 1,
+                name: 'Tenant One',
+                feature_count: null,
+                features_count: null,
+                features: null,
+                phone: null,
+                address: null,
+              },
+            ],
+            meta: { last_page: 1 },
+          },
+        } as any);
+      }
+      if (url === '/tenants/1/owner') {
+        return Promise.resolve({ data: { data: { id: 99, email: 'owner@example.com' } } } as any);
+      }
+      return Promise.resolve({ data: { data: [] } } as any);
+    });
+    postSpy = vi.spyOn(api, 'post').mockResolvedValue({ data: {} } as any);
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+    postSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('resends tenant owner invite', async () => {
+    const setup = createSetup();
+
+    await setup.resendOwnerInvite(3);
+
+    expect(postSpy).toHaveBeenCalledWith('/tenants/3/owner/invite-resend');
+    expect(notifySuccess).toHaveBeenCalledWith('tenants.owner.inviteResent');
+  });
+
+  it('sends tenant owner password reset email', async () => {
+    const setup = createSetup();
+
+    await setup.sendOwnerPasswordReset(4);
+
+    expect(postSpy).toHaveBeenCalledWith('/tenants/4/owner/password-reset');
+    expect(notifySuccess).toHaveBeenCalledWith('tenants.owner.passwordReset.success');
+  });
+
+  it('submits tenant owner email reset', async () => {
+    swalFire.mockResolvedValue({ isConfirmed: true, value: 'updated@example.com' });
+
+    const setup = createSetup();
+    setup.all.value = [
+      {
+        id: 5,
+        name: 'Tenant Five',
+        owner: { id: 6, email: 'old@example.com' },
+      },
+    ];
+
+    await setup.resetOwnerEmail(5);
+
+    expect(swalFire).toHaveBeenCalled();
+    expect(postSpy).toHaveBeenCalledWith('/tenants/5/owner/email-reset', { email: 'updated@example.com' });
+    expect(notifySuccess).toHaveBeenCalledWith('tenants.owner.resetEmail.success');
+  });
+});


### PR DESCRIPTION
## Summary
- add reset email and password reset actions to the employee list UI and handlers
- surface tenant owner metadata so matching management actions can call the shared endpoints
- extend translations and unit coverage to exercise the new menu items and API calls

## Testing
- pnpm vitest run tests/unit/employees.actions.test.ts tests/unit/tenants.owner-actions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9a9fd6e4c832382c0b595c3ec68da