### PR TITLE
feat: enhance clients table and filters

### DIFF
--- a/frontend/src/components/clients/ClientOwnerSelect.vue
+++ b/frontend/src/components/clients/ClientOwnerSelect.vue
@@ -1,0 +1,79 @@
+<template>
+  <Select
+    v-bind="forwardedAttrs"
+    v-model="model"
+    :options="normalizedOptions"
+    :placeholder="placeholder"
+    :classInput="classInput"
+    :disabled="disabled"
+    :aria-label="resolvedAriaLabel"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue';
+import Select from '@/components/ui/Select/index.vue';
+
+type Option = {
+  value: string | number;
+  label: string;
+  disabled?: boolean;
+};
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string;
+    options?: Option[];
+    placeholder?: string;
+    classInput?: string;
+    disabled?: boolean;
+    ariaLabel?: string;
+  }>(),
+  {
+    modelValue: '',
+    options: () => [],
+    placeholder: '',
+    classInput: 'text-xs !h-9',
+    disabled: false,
+    ariaLabel: '',
+  },
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+
+const normalizedOptions = computed(() =>
+  (props.options || []).map((option) => ({
+    ...option,
+    value:
+      typeof option.value === 'number'
+        ? String(option.value)
+        : option.value ?? '',
+  })),
+);
+
+const model = computed({
+  get: () => props.modelValue ?? '',
+  set: (value: string | number) => {
+    emit('update:modelValue', typeof value === 'number' ? String(value) : value);
+  },
+});
+
+const attrs = useAttrs();
+
+const forwardedAttrs = computed(() => {
+  const result: Record<string, unknown> = {};
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (key !== 'aria-label') {
+      result[key] = value;
+    }
+  });
+  return result;
+});
+
+const resolvedAriaLabel = computed(() => {
+  const attrLabel = attrs['aria-label'] as string | undefined;
+  return props.ariaLabel || attrLabel || props.placeholder || '';
+});
+</script>

--- a/frontend/src/components/clients/ClientSortSelect.vue
+++ b/frontend/src/components/clients/ClientSortSelect.vue
@@ -1,0 +1,79 @@
+<template>
+  <Select
+    v-bind="forwardedAttrs"
+    v-model="model"
+    :options="normalizedOptions"
+    :placeholder="placeholder"
+    :classInput="classInput"
+    :disabled="disabled"
+    :aria-label="resolvedAriaLabel"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue';
+import Select from '@/components/ui/Select/index.vue';
+
+type Option = {
+  value: string | number;
+  label: string;
+  disabled?: boolean;
+};
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string;
+    options?: Option[];
+    placeholder?: string;
+    classInput?: string;
+    disabled?: boolean;
+    ariaLabel?: string;
+  }>(),
+  {
+    modelValue: '',
+    options: () => [],
+    placeholder: '',
+    classInput: 'text-xs !h-9',
+    disabled: false,
+    ariaLabel: '',
+  },
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+
+const normalizedOptions = computed(() =>
+  (props.options || []).map((option) => ({
+    ...option,
+    value:
+      typeof option.value === 'number'
+        ? String(option.value)
+        : option.value ?? '',
+  })),
+);
+
+const model = computed({
+  get: () => props.modelValue ?? '',
+  set: (value: string | number) => {
+    emit('update:modelValue', typeof value === 'number' ? String(value) : value);
+  },
+});
+
+const attrs = useAttrs();
+
+const forwardedAttrs = computed(() => {
+  const result: Record<string, unknown> = {};
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (key !== 'aria-label') {
+      result[key] = value;
+    }
+  });
+  return result;
+});
+
+const resolvedAriaLabel = computed(() => {
+  const attrLabel = attrs['aria-label'] as string | undefined;
+  return props.ariaLabel || attrLabel || props.placeholder || '';
+});
+</script>

--- a/frontend/src/components/clients/ClientTenantSelect.vue
+++ b/frontend/src/components/clients/ClientTenantSelect.vue
@@ -1,0 +1,79 @@
+<template>
+  <Select
+    v-bind="forwardedAttrs"
+    v-model="model"
+    :options="normalizedOptions"
+    :placeholder="placeholder"
+    :classInput="classInput"
+    :disabled="disabled"
+    :aria-label="resolvedAriaLabel"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue';
+import Select from '@/components/ui/Select/index.vue';
+
+type Option = {
+  value: string | number;
+  label: string;
+  disabled?: boolean;
+};
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string;
+    options?: Option[];
+    placeholder?: string;
+    classInput?: string;
+    disabled?: boolean;
+    ariaLabel?: string;
+  }>(),
+  {
+    modelValue: '',
+    options: () => [],
+    placeholder: '',
+    classInput: 'text-xs !h-9',
+    disabled: false,
+    ariaLabel: '',
+  },
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+
+const normalizedOptions = computed(() =>
+  (props.options || []).map((option) => ({
+    ...option,
+    value:
+      typeof option.value === 'number'
+        ? String(option.value)
+        : option.value ?? '',
+  })),
+);
+
+const model = computed({
+  get: () => props.modelValue ?? '',
+  set: (value: string | number) => {
+    emit('update:modelValue', typeof value === 'number' ? String(value) : value);
+  },
+});
+
+const attrs = useAttrs();
+
+const forwardedAttrs = computed(() => {
+  const result: Record<string, unknown> = {};
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (key !== 'aria-label') {
+      result[key] = value;
+    }
+  });
+  return result;
+});
+
+const resolvedAriaLabel = computed(() => {
+  const attrLabel = attrs['aria-label'] as string | undefined;
+  return props.ariaLabel || attrLabel || props.placeholder || '';
+});
+</script>

--- a/frontend/src/components/clients/ClientsStatusFilters.vue
+++ b/frontend/src/components/clients/ClientsStatusFilters.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="flex flex-wrap items-center gap-4 pt-2">
+    <Checkbox
+      v-model="includeArchivedModel"
+      :label="includeArchivedLabel"
+      :aria-label="includeArchivedLabel"
+    />
+    <Checkbox
+      v-model="archivedOnlyModel"
+      :label="archivedOnlyLabel"
+      :aria-label="archivedOnlyLabel"
+      :disabled="archivedOnlyDisabled"
+    />
+    <Checkbox
+      v-model="includeTrashedModel"
+      :label="includeTrashedLabel"
+      :aria-label="includeTrashedLabel"
+    />
+    <Checkbox
+      v-model="trashedOnlyModel"
+      :label="trashedOnlyLabel"
+      :aria-label="trashedOnlyLabel"
+      :disabled="trashedOnlyDisabled"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Checkbox from '@/components/ui/Checkbox/index.vue';
+
+const props = withDefaults(
+  defineProps<{
+    includeArchived?: boolean;
+    archivedOnly?: boolean;
+    includeTrashed?: boolean;
+    trashedOnly?: boolean;
+    includeArchivedLabel?: string;
+    archivedOnlyLabel?: string;
+    includeTrashedLabel?: string;
+    trashedOnlyLabel?: string;
+  }>(),
+  {
+    includeArchived: false,
+    archivedOnly: false,
+    includeTrashed: false,
+    trashedOnly: false,
+    includeArchivedLabel: '',
+    archivedOnlyLabel: '',
+    includeTrashedLabel: '',
+    trashedOnlyLabel: '',
+  },
+);
+
+const emit = defineEmits<{
+  (e: 'update:include-archived', value: boolean): void;
+  (e: 'update:archived-only', value: boolean): void;
+  (e: 'update:include-trashed', value: boolean): void;
+  (e: 'update:trashed-only', value: boolean): void;
+}>();
+
+const { t } = useI18n();
+
+const includeArchivedModel = computed({
+  get: () => props.includeArchived,
+  set: (value: boolean) => emit('update:include-archived', value),
+});
+
+const archivedOnlyModel = computed({
+  get: () => props.archivedOnly,
+  set: (value: boolean) => emit('update:archived-only', value),
+});
+
+const includeTrashedModel = computed({
+  get: () => props.includeTrashed,
+  set: (value: boolean) => emit('update:include-trashed', value),
+});
+
+const trashedOnlyModel = computed({
+  get: () => props.trashedOnly,
+  set: (value: boolean) => emit('update:trashed-only', value),
+});
+
+const includeArchivedLabel = computed(
+  () => props.includeArchivedLabel || t('clients.filters.includeArchived'),
+);
+const archivedOnlyLabel = computed(
+  () => props.archivedOnlyLabel || t('clients.filters.archivedOnly'),
+);
+const includeTrashedLabel = computed(
+  () => props.includeTrashedLabel || t('clients.filters.includeTrashed'),
+);
+const trashedOnlyLabel = computed(
+  () => props.trashedOnlyLabel || t('clients.filters.trashedOnly'),
+);
+
+const archivedOnlyDisabled = computed(() => !includeArchivedModel.value);
+const trashedOnlyDisabled = computed(() => !includeTrashedModel.value);
+</script>

--- a/frontend/src/components/clients/ClientsTable.vue
+++ b/frontend/src/components/clients/ClientsTable.vue
@@ -12,7 +12,7 @@
             prependIcon="heroicons-outline:search"
             merged
             classInput="text-xs !h-8"
-            @update:modelValue="onSearch"
+            @update:model-value="onSearch"
           />
         </div>
       </div>

--- a/frontend/src/views/clients/ClientsList.vue
+++ b/frontend/src/views/clients/ClientsList.vue
@@ -48,46 +48,32 @@
 
       <template #filters>
         <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <Select
+          <ClientOwnerSelect
             v-model="ownerFilter"
             :options="ownerOptions"
-            classInput="text-xs !h-9"
+            :placeholder="t('clients.filters.owner')"
             :aria-label="t('clients.filters.owner')"
           />
-          <Select
+          <ClientTenantSelect
             v-if="auth.isSuperAdmin"
             v-model="tenantFilter"
             :options="tenantOptions"
-            classInput="text-xs !h-9"
+            :placeholder="t('clients.filters.tenant')"
             :aria-label="t('clients.filters.tenant')"
           />
-          <Select
+          <ClientSortSelect
             v-model="sortSelection"
             :options="sortOptions"
-            classInput="text-xs !h-9"
+            :placeholder="t('clients.filters.sort.label')"
             :aria-label="t('clients.filters.sort.label')"
           />
         </div>
-        <div class="flex flex-wrap items-center gap-4 pt-2">
-          <Checkbox
-            v-model="includeArchived"
-            :label="t('clients.filters.includeArchived')"
-          />
-          <Checkbox
-            v-model="archivedOnly"
-            :label="t('clients.filters.archivedOnly')"
-            :disabled="!includeArchived"
-          />
-          <Checkbox
-            v-model="includeTrashed"
-            :label="t('clients.filters.includeTrashed')"
-          />
-          <Checkbox
-            v-model="trashedOnly"
-            :label="t('clients.filters.trashedOnly')"
-            :disabled="!includeTrashed"
-          />
-        </div>
+        <ClientsStatusFilters
+          v-model:include-archived="includeArchived"
+          v-model:archived-only="archivedOnly"
+          v-model:include-trashed="includeTrashed"
+          v-model:trashed-only="trashedOnly"
+        />
       </template>
     </ClientsTable>
 
@@ -139,11 +125,14 @@ import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import Swal from 'sweetalert2';
 import ClientsTable from '@/components/clients/ClientsTable.vue';
+import ClientOwnerSelect from '@/components/clients/ClientOwnerSelect.vue';
+import ClientTenantSelect from '@/components/clients/ClientTenantSelect.vue';
+import ClientSortSelect from '@/components/clients/ClientSortSelect.vue';
+import ClientsStatusFilters from '@/components/clients/ClientsStatusFilters.vue';
 import SkeletonTable from '@/components/ui/Skeleton/Table.vue';
 import Alert from '@/components/ui/Alert/index.vue';
 import Button from '@/components/ui/Button';
 import Select from '@/components/ui/Select/index.vue';
-import Checkbox from '@/components/ui/Checkbox/index.vue';
 import Modal from '@/components/ui/Modal/index.vue';
 import { useClientsStore } from '@/stores/clients';
 import { useTenantStore } from '@/stores/tenant';


### PR DESCRIPTION
## Summary
- add reusable client-specific select components and grouped status filters built on existing UI atoms
- integrate the new filter components into the clients list view to keep filters responsive and declarative
- align the clients table search event with linting expectations for hyphenated update events

## Testing
- pnpm exec eslint src/components/clients --ext .vue
- pnpm exec eslint src/views/clients/ClientsList.vue
- pnpm lint *(fails: existing lint issues outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc01985ff08323ad464f73ebe38027