### PR TITLE
Fix nullish coalescing usage in client params

### DIFF
--- a/frontend/src/stores/clients.ts
+++ b/frontend/src/stores/clients.ts
@@ -194,7 +194,7 @@ export const useClientsStore = defineStore('clients', {
       const params: ClientListParams = {
         page,
         per_page: perPage,
-        search: overrides.search ?? this.search || undefined,
+        search: overrides.search ?? (this.search || undefined),
         sort: overrides.sort ?? this.sort,
         dir: overrides.dir ?? this.direction,
       };


### PR DESCRIPTION
## Summary
- wrap the search fallback expression with parentheses so nullish coalescing no longer conflicts with logical OR

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc0adf82e08323acc05fc5437ae915