### PR TITLE
Fix BoardFilters debounce resync

### DIFF
--- a/frontend/src/components/Board/BoardFilters.vue
+++ b/frontend/src/components/Board/BoardFilters.vue
@@ -294,13 +294,17 @@ const filterControlClasses = (value: unknown, variant: FilterVariant = 'input') 
 let syncingFromProps = false;
 const syncLocalFromProps = (val: Filters) => {
   const incoming = normalizeFilters(val);
-  if (filtersEqual(lastSynced, incoming)) {
+  const matchesSynced = filtersEqual(lastSynced, incoming);
+  const matchesLocal = filtersEqual(normalizeFilters(local.value), incoming);
+
+  clearTimeout(timer);
+
+  if (matchesSynced && matchesLocal) {
     lastSynced = { ...incoming, typeIds: [...incoming.typeIds] };
     return;
   }
 
   syncingFromProps = true;
-  clearTimeout(timer);
   Object.assign(local.value, incoming);
   lastSynced = { ...incoming, typeIds: [...incoming.typeIds] };
 


### PR DESCRIPTION
## Summary
- ensure BoardFilters cancels pending debounce work and only skips syncing when the local filters already match incoming props

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc31002c2883238be6cf314e677162