### PR TITLE
Add client-scoped abilities and roles

### DIFF
--- a/backend/app/Services/AbilityService.php
+++ b/backend/app/Services/AbilityService.php
@@ -87,7 +87,18 @@ class AbilityService
             return true;
         }
 
-        $prefix = explode('.', $code)[0] . '.manage';
+        $parts = explode('.', $code);
+
+        if (count($parts) >= 2) {
+            $clientParts = array_merge([$parts[0], 'client'], array_slice($parts, 1));
+            $clientAbility = implode('.', $clientParts);
+
+            if (in_array($clientAbility, $abilities, true)) {
+                return true;
+            }
+        }
+
+        $prefix = $parts[0] . '.manage';
 
         return in_array($prefix, $abilities, true);
     }

--- a/backend/config/feature_map.php
+++ b/backend/config/feature_map.php
@@ -5,14 +5,18 @@ return [
         'label' => 'Dashboard',
         'abilities' => [
             'dashboard.view',
+            'dashboard.client.view',
         ],
     ],
     'tasks' => [
         'label' => 'Tasks',
         'abilities' => [
             'tasks.view',
+            'tasks.client.view',
             'tasks.create',
+            'tasks.client.create',
             'tasks.update',
+            'tasks.client.update',
             'tasks.delete',
             'tasks.assign',
             'tasks.status.update',
@@ -50,6 +54,7 @@ return [
         'label' => 'Reports',
         'abilities' => [
             'reports.view',
+            'reports.client.view',
             'reports.manage',
         ],
     ],


### PR DESCRIPTION
## Summary
- add client-focused ability codes to the feature map so they surface in the global abilities list
- allow AbilityService::abilityMatches to treat client-scoped permissions as satisfying core gate checks
- seed dedicated client_viewer and client_contributor roles with the new abilities and cover them in unit tests

## Testing
- ./vendor/bin/phpunit tests/Unit/AbilityServiceTest.php tests/Unit/Config/AbilitiesConfigTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cc372da6cc8323b4764ddaaacb42eb