### PR TITLE
Remove client owner relationship and references

### DIFF
--- a/backend/app/Http/Controllers/Api/ClientRequest.php
+++ b/backend/app/Http/Controllers/Api/ClientRequest.php
@@ -3,9 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Models\Client;
-use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Validation\Rule;
 
 class ClientRequest extends FormRequest
 {
@@ -31,29 +29,13 @@ class ClientRequest extends FormRequest
             'phone' => ['nullable', 'string', 'max:255'],
             'notes' => ['nullable', 'string'],
             'tenant_id' => $tenantRules,
-            'owner_id' => ['nullable', 'integer', Rule::exists('users', 'id')],
-        ];
-    }
-
-    public function attributes(): array
-    {
-        return [
-            'owner_id' => 'owner',
         ];
     }
 
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {
-            $ownerId = $this->input('owner_id');
             $tenantId = $this->determineTargetTenant();
-
-            if ($ownerId) {
-                $owner = User::query()->find($ownerId);
-                if (! $owner || ($tenantId !== null && (int) $owner->tenant_id !== (int) $tenantId)) {
-                    $validator->errors()->add('owner_id', 'The selected owner is invalid.');
-                }
-            }
 
             if ($this->isMethod('post') && $tenantId === null) {
                 $validator->errors()->add('tenant_id', 'The tenant field is required.');

--- a/backend/app/Http/Controllers/Api/ClientResource.php
+++ b/backend/app/Http/Controllers/Api/ClientResource.php
@@ -11,16 +11,6 @@ class ClientResource extends JsonResource
 
     public function toArray($request): array
     {
-        $owner = null;
-        if ($this->relationLoaded('owner') || $this->owner) {
-            $owner = $this->owner
-                ? [
-                    'id' => $this->owner->id,
-                    'name' => $this->owner->name,
-                ]
-                : null;
-        }
-
         return $this->formatDates([
             'id' => $this->id,
             'tenant_id' => $this->tenant_id,
@@ -30,7 +20,6 @@ class ClientResource extends JsonResource
             'notes' => $this->notes,
             'archived_at' => $this->archived_at,
             'deleted_at' => $this->deleted_at,
-            'owner' => $owner,
         ]);
     }
 }

--- a/backend/app/Models/Client.php
+++ b/backend/app/Models/Client.php
@@ -13,7 +13,6 @@ class Client extends Model
 
     protected $fillable = [
         'tenant_id',
-        'user_id',
         'name',
         'email',
         'phone',
@@ -23,18 +22,12 @@ class Client extends Model
 
     protected $casts = [
         'tenant_id' => 'integer',
-        'user_id' => 'integer',
         'archived_at' => 'datetime',
     ];
 
     public function tenant(): BelongsTo
     {
         return $this->belongsTo(Tenant::class);
-    }
-
-    public function owner(): BelongsTo
-    {
-        return $this->belongsTo(User::class, 'user_id');
     }
 
     public function taskTypes(): HasMany

--- a/backend/app/Policies/ClientPolicy.php
+++ b/backend/app/Policies/ClientPolicy.php
@@ -51,8 +51,4 @@ class ClientPolicy extends TenantOwnedPolicy
         return $this->update($user, $client);
     }
 
-    public function transfer(User $user, Client $client): bool
-    {
-        return Gate::allows('clients.manage') && parent::update($user, $client);
-    }
 }

--- a/backend/asbuild.postman_collection.json
+++ b/backend/asbuild.postman_collection.json
@@ -492,7 +492,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Acme Corp\",\n  \"email\": \"contact@example.com\",\n  \"phone\": \"+1-555-1234\",\n  \"notes\": \"Important client\",\n  \"owner_id\": 10\n}",
+              "raw": "{\n  \"name\": \"Acme Corp\",\n  \"email\": \"contact@example.com\",\n  \"phone\": \"+1-555-1234\",\n  \"notes\": \"Important client\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -548,7 +548,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Acme Corp\",\n  \"email\": \"ops@example.com\",\n  \"phone\": \"+1-555-9876\",\n  \"notes\": \"Updated contact\",\n  \"owner_id\": 12\n}",
+              "raw": "{\n  \"name\": \"Acme Corp\",\n  \"email\": \"ops@example.com\",\n  \"phone\": \"+1-555-9876\",\n  \"notes\": \"Updated contact\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -668,40 +668,6 @@
           },
           "response": []
         },
-        {
-          "name": "transfer",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "X-Tenant-ID",
-                "value": "{{tenant_id}}"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n  \"owner_id\": 15\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{base_url}}/api/clients/{client}/transfer",
-              "host": [
-                "{{base_url}}"
-              ],
-              "path": [
-                "api",
-                "clients",
-                "{client}",
-                "transfer"
-              ]
-            }
-          },
-          "response": []
-        }
       ]
     },
     {

--- a/backend/database/migrations/2025_10_20_000001_drop_client_owner_constraints.php
+++ b/backend/database/migrations/2025_10_20_000001_drop_client_owner_constraints.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            if (Schema::hasColumn('clients', 'user_id')) {
+                $table->dropForeign(['user_id']);
+                $table->dropIndex('clients_user_id_index');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            if (Schema::hasColumn('clients', 'user_id')) {
+                $table->foreign('user_id')->references('id')->on('users')->nullOnDelete();
+                $table->index('user_id');
+            }
+        });
+    }
+};

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -178,10 +178,6 @@ paths:
           schema:
             type: string
             enum: [with, only]
-        - name: owner_id
-          in: query
-          schema:
-            type: integer
         - name: tenant_id
           in: query
           schema:
@@ -222,9 +218,6 @@ paths:
                   type: string
                   nullable: true
                 tenant_id:
-                  type: integer
-                  nullable: true
-                owner_id:
                   type: integer
                   nullable: true
       responses:
@@ -278,9 +271,6 @@ paths:
                   type: string
                   nullable: true
                 tenant_id:
-                  type: integer
-                  nullable: true
-                owner_id:
                   type: integer
                   nullable: true
       responses:
@@ -351,32 +341,6 @@ paths:
       responses:
         '200':
           description: Restored client
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Client'
-  /clients/{client}/transfer:
-    post:
-      summary: Transfer client ownership
-      parameters:
-        - name: client
-          in: path
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                owner_id:
-                  type: integer
-                  nullable: true
-      responses:
-        '200':
-          description: Updated client owner
           content:
             application/json:
               schema:
@@ -1635,14 +1599,6 @@ components:
           type: string
           format: date-time
           nullable: true
-        owner:
-          type: object
-          nullable: true
-          properties:
-            id:
-              type: integer
-            name:
-              type: string
     ClientSummary:
       type: object
       properties:

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -104,9 +104,6 @@ Route::middleware(['auth:sanctum', EnsureTenantScope::class])->group(function ()
     Route::delete('clients/{client}/archive', [ClientController::class, 'unarchive'])
         ->middleware(Ability::class . ':clients.update')
         ->whereNumber('client');
-    Route::post('clients/{client}/transfer', [ClientController::class, 'transfer'])
-        ->middleware(Ability::class . ':clients.manage')
-        ->whereNumber('client');
     Route::patch('tasks/{task}/assign', [TaskController::class, 'assign'])
         ->middleware(Ability::class . ':tasks.assign');
     Route::post('tasks/{task}/status', [TaskController::class, 'updateStatus'])


### PR DESCRIPTION
## Summary
- drop the clients.user_id foreign key and index with a new migration
- remove client owner fillable fields, controller logic, policy gate, routes, and resource output
- update validation, API docs, Postman examples, and feature tests to reflect ownerless clients

## Testing
- APP_ENV=local DB_CONNECTION=sqlite php artisan migrate --no-interaction
- APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=ClientManagementTest

------
https://chatgpt.com/codex/tasks/task_e_68cc507e2d9c8323ad9aaf9362a189ae