### PR TITLE
Seed demo clients for tenant bootstrap

### DIFF
--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -111,6 +111,39 @@ class TenantBootstrapSeeder extends Seeder
         );
         $agentId = DB::table('users')->where('email', 'agent@acme.test')->value('id');
 
+        // Clients
+        $clients = [
+            [
+                'name' => 'Bella Barker',
+                'email' => 'bella.barker@example.test',
+                'phone' => '555-200-0001',
+                'notes' => 'Owner of two golden retrievers.',
+            ],
+            [
+                'name' => 'Charlie Cat',
+                'phone' => '555-200-0002',
+                'notes' => 'Prefers evening appointments and quiet rooms.',
+            ],
+            [
+                'name' => 'Oscar Otter',
+                'email' => 'oscar.otter@example.test',
+                'notes' => 'New client referred by Bella Barker.',
+            ],
+        ];
+
+        foreach ($clients as $client) {
+            DB::table('clients')->updateOrInsert(
+                ['tenant_id' => $tenantId, 'name' => $client['name']],
+                [
+                    'email' => $client['email'] ?? null,
+                    'phone' => $client['phone'] ?? null,
+                    'notes' => $client['notes'] ?? null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            );
+        }
+
         // Assign existing feature roles to employees
         $managerRoleIds = DB::table('roles')
             ->where('tenant_id', $tenantId)

--- a/backend/tests/Feature/TenantBootstrapSeederTest.php
+++ b/backend/tests/Feature/TenantBootstrapSeederTest.php
@@ -34,5 +34,17 @@ class TenantBootstrapSeederTest extends TestCase
         $this->assertTrue(in_array(['review', 'redo'], $edges, true));
         $this->assertTrue(in_array(['review', 'rejected'], $edges, true));
         $this->assertTrue(in_array(['redo', 'in_progress'], $edges, true));
+
+        $this->assertDatabaseCount('clients', 3);
+        $this->assertDatabaseHas('clients', [
+            'tenant_id' => 1,
+            'name' => 'Bella Barker',
+            'email' => 'bella.barker@example.test',
+        ]);
+        $this->assertDatabaseHas('clients', [
+            'tenant_id' => 1,
+            'name' => 'Charlie Cat',
+            'phone' => '555-200-0002',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- add representative demo clients with contact details to `TenantBootstrapSeeder`
- assert demo clients exist in `TenantBootstrapSeederTest`

## Testing
- php artisan test --filter=TenantBootstrapSeederTest

------
https://chatgpt.com/codex/tasks/task_e_68cc6e57cb548323be02673b562ddfa1