### PR TITLE
Separate client abilities in auth context

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -10,6 +10,7 @@ use App\Services\PermittedClientResolver;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password as PasswordRule;
 use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -142,9 +143,27 @@ class AuthController extends Controller
                 ->all();
         }
 
+        $allAbilities = $this->abilityService->resolveAbilities($user);
+
+        $abilities = [];
+        $clientAbilities = [];
+
+        foreach ($allAbilities as $ability) {
+            if (! is_string($ability)) {
+                continue;
+            }
+
+            if (Str::contains($ability, '.client.')) {
+                $clientAbilities[] = $ability;
+            } else {
+                $abilities[] = $ability;
+            }
+        }
+
         return response()->json([
             'user' => $user,
-            'abilities' => $this->abilityService->resolveAbilities($user),
+            'abilities' => $abilities,
+            'client_abilities' => $clientAbilities,
             'features' => $features,
             'permitted_client_ids' => $this->clientResolver->resolve($user),
         ]);

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -3,6 +3,16 @@ info:
   title: Asbuild API
   version: '1.0'
 paths:
+  /me:
+    get:
+      summary: Get authenticated user context
+      responses:
+        '200':
+          description: Authenticated user context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthMeResponse'
   /tasks:
     get:
       summary: List tasks
@@ -1575,6 +1585,29 @@ components:
       properties:
         message:
           type: string
+    AuthMeResponse:
+      type: object
+      properties:
+        user:
+          type: object
+          description: Authenticated user with assigned roles and tenant context.
+        abilities:
+          type: array
+          items:
+            type: string
+        client_abilities:
+          type: array
+          items:
+            type: string
+        features:
+          type: array
+          items:
+            type: string
+        permitted_client_ids:
+          type: array
+          nullable: true
+          items:
+            type: integer
     Client:
       type: object
       properties:

--- a/backend/tests/Feature/AuthMeClientAbilitiesTest.php
+++ b/backend/tests/Feature/AuthMeClientAbilitiesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AuthMeClientAbilitiesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_client_scoped_abilities_are_partitioned(): void
+    {
+        $tenant = Tenant::create([
+            'name' => 'Client Tenant',
+            'features' => ['dashboard', 'tasks', 'reports'],
+            'quota_storage_mb' => 0,
+            'phone' => '123-456-7890',
+            'address' => '123 Main St',
+        ]);
+
+        $user = User::create([
+            'name' => 'Client User',
+            'email' => 'client@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '123456789',
+            'address' => '123 Main St',
+        ]);
+
+        $role = Role::where('tenant_id', $tenant->id)
+            ->where('slug', 'client_contributor')
+            ->firstOrFail();
+
+        $role->users()->attach($user->id, ['tenant_id' => $tenant->id]);
+
+        Sanctum::actingAs($user);
+
+        $data = $this->getJson('/api/me')->assertOk()->json();
+
+        $this->assertSame([], $data['abilities']);
+        $this->assertEqualsCanonicalizing([
+            'dashboard.client.view',
+            'tasks.client.view',
+            'tasks.client.create',
+            'tasks.client.update',
+            'reports.client.view',
+        ], $data['client_abilities']);
+    }
+}


### PR DESCRIPTION
## Summary
- split AuthController::me abilities payload into general and client-specific arrays
- add PHPUnit coverage to confirm client-scoped roles receive the correct response shape
- document the auth context response including client_abilities in the OpenAPI spec

## Testing
- ./vendor/bin/phpunit --filter AuthMeClientAbilitiesTest

------
https://chatgpt.com/codex/tasks/task_e_68cc70284fd483238af3bb2d65e2f13a