### PR TITLE
Add initials avatar to clients table name column

### DIFF
--- a/frontend/src/components/clients/ClientsTable.vue
+++ b/frontend/src/components/clients/ClientsTable.vue
@@ -53,11 +53,16 @@
         @on-selected-rows-change="onSelectedRowsChange"
       >
         <template #table-row="rowProps">
-          <div v-if="rowProps.column.field === 'name'" class="flex flex-col">
+          <div
+            v-if="rowProps.column.field === 'name'"
+            class="flex items-center gap-3"
+          >
+            <div
+              class="flex h-9 w-9 items-center justify-center rounded-full bg-slate-200 text-sm font-medium text-slate-600"
+            >
+              {{ getInitials(rowProps.row.name) }}
+            </div>
             <span class="text-sm font-medium">{{ rowProps.row.name }}</span>
-            <span v-if="rowProps.row.email" class="text-xs text-slate-500">
-              {{ rowProps.row.email }}
-            </span>
           </div>
           <span v-else-if="rowProps.column.field === 'email'">
             {{ rowProps.row.email || '—' }}
@@ -375,6 +380,16 @@ const togglingStatusSet = computed(() => {
 const canView = computed(() => can('clients.view'));
 const canEdit = computed(() => can('clients.manage'));
 const canDelete = computed(() => can('clients.delete') || can('clients.manage'));
+
+function getInitials(name: string) {
+  return (name || '')
+    .split(' ')
+    .filter(Boolean)
+    .map((n) => n[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
 
 watch(
   () => props.search,


### PR DESCRIPTION
## Summary
- display each client name with a circular avatar that shows their initials in the clients table
- remove the duplicated email text from the name column since email already has its own column

## Testing
- pnpm lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ccee43c6748323bd530b858ab47e1c