### PR TITLE
Remove duplicate clients label from client modal

### DIFF
--- a/frontend/src/views/clients/ClientForm.vue
+++ b/frontend/src/views/clients/ClientForm.vue
@@ -6,10 +6,6 @@
     sizeClass="max-w-3xl"
     @close="closeModal"
   >
-    <p class="text-slate-600 mb-6">
-      {{ t('routes.clients') }}
-    </p>
-
     <div
       v-if="initializing"
       class="flex justify-center py-10"


### PR DESCRIPTION
## Summary
- remove the redundant clients label shown beneath the client modal title

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cceeda13ac83238d6ccb787d0b0e14