### PR TITLE
feat: open client modal from header quick menu

### DIFF
--- a/frontend/src/Layout/DashcodeLayout.vue
+++ b/frontend/src/Layout/DashcodeLayout.vue
@@ -60,6 +60,7 @@
       v-if="window.width > 768"
       :class="window.width > 1280 ? switchHeaderClass() : ''"
     />
+    <ClientQuickCreateModal />
   </main>
 </template>
 <script>
@@ -71,6 +72,7 @@ import Sidebar from './Sidebar.vue';
 import window from "@/mixins/window";
 import MobileSidebar from "@/components/ui/Sidebar/MobileSidebar.vue";
 import FooterMenu from "@/components/ui/Footer/FooterMenu.vue";
+import ClientQuickCreateModal from "@/components/clients/ClientQuickCreateModal.vue";
 
 export default {
   components: {
@@ -81,6 +83,7 @@ export default {
     Breadcrumbs,
     FooterMenu,
     MobileSidebar,
+    ClientQuickCreateModal,
   },
   mixins: [window],
   methods: {

--- a/frontend/src/components/clients/ClientQuickCreateModal.vue
+++ b/frontend/src/components/clients/ClientQuickCreateModal.vue
@@ -1,0 +1,16 @@
+<template>
+  <ClientForm v-if="isOpen" force-modal @close="close" />
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import ClientForm from '@/views/clients/ClientForm.vue';
+import { useClientModalStore } from '@/stores/clientModal';
+
+const clientModal = useClientModalStore();
+const { isOpen } = storeToRefs(clientModal);
+
+const close = () => {
+  clientModal.close();
+};
+</script>

--- a/frontend/src/components/ui/Header/Navtools/AddNew.vue
+++ b/frontend/src/components/ui/Header/Navtools/AddNew.vue
@@ -34,9 +34,11 @@ import Dropdown from '@/components/Dropdown';
 import Icon from '@/components/Icon';
 import { addNewOptions } from '@/constants/menu';
 import { useAuthStore } from '@/stores/auth';
+import { useClientModalStore } from '@/stores/clientModal';
 
 const router = useRouter();
 const auth = useAuthStore();
+const clientModal = useClientModalStore();
 
 const items = computed(() =>
   addNewOptions.filter((i) => {
@@ -50,6 +52,11 @@ const items = computed(() =>
 );
 
 const go = (name: string) => {
+  if (name === 'clients.create') {
+    clientModal.open();
+    return;
+  }
+
   router.push({ name });
 };
 </script>

--- a/frontend/src/stores/clientModal.ts
+++ b/frontend/src/stores/clientModal.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia';
+
+interface ClientModalState {
+  isOpen: boolean;
+}
+
+export const useClientModalStore = defineStore('clientModal', {
+  state: (): ClientModalState => ({
+    isOpen: false,
+  }),
+  actions: {
+    open(): void {
+      this.isOpen = true;
+    },
+    close(): void {
+      this.isOpen = false;
+    },
+  },
+});

--- a/frontend/src/views/clients/ClientForm.vue
+++ b/frontend/src/views/clients/ClientForm.vue
@@ -251,6 +251,9 @@ import { can, useAuthStore } from '@/stores/auth';
 import { useNotify } from '@/plugins/notify';
 import { extractFormErrors } from '@/services/api';
 
+const props = defineProps<{ forceModal?: boolean }>();
+const emit = defineEmits<{ (event: 'close'): void }>();
+
 const route = useRoute();
 const router = useRouter();
 const clientsStore = useClientsStore();
@@ -260,7 +263,8 @@ const notify = useNotify();
 const { t } = useI18n();
 
 const isEdit = computed(() => route.name === 'clients.edit');
-const isModal = computed(() => Boolean(route.meta?.modal));
+const isForcedModal = computed(() => Boolean(props.forceModal));
+const isModal = computed(() => isForcedModal.value || Boolean(route.meta?.modal));
 const canAccess = computed(() =>
   isEdit.value ? can('clients.manage') : can('clients.create') || can('clients.manage'),
 );
@@ -424,6 +428,11 @@ async function submit() {
 }
 
 function navigateToList() {
+  if (isForcedModal.value) {
+    emit('close');
+    return;
+  }
+
   if (route.name !== 'clients.list') {
     router.push({ name: 'clients.list' });
   }


### PR DESCRIPTION
## Summary
- allow the client form to operate as a forced modal and emit a close event when used outside the client routes
- add a global client quick-create modal that can be toggled from anywhere in the app
- wire the header "Add Client" quick action to open the modal instead of navigating away

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf3669ca48323806b631bca9b3137