### PR TITLE
Reset per-page pagination when page size changes

### DIFF
--- a/frontend/src/components/clients/ClientsTable.vue
+++ b/frontend/src/components/clients/ClientsTable.vue
@@ -446,12 +446,19 @@ function onPerPageChange({
 }
 
 interface PagerSlotHandlers {
+  pageChanged?: (payload: { currentPage: number }) => void;
   perPageChanged?: (payload: { currentPerPage: number }) => void;
 }
 
 function onPerPageSelect(value: number, pagerProps: PagerSlotHandlers) {
   if (!Number.isFinite(value) || value <= 0 || value === props.perPage) {
     return;
+  }
+  const firstPage = 1;
+  if (pagerProps.pageChanged) {
+    pagerProps.pageChanged({ currentPage: firstPage });
+  } else {
+    emit('update:page', firstPage);
   }
   pagerProps.perPageChanged?.({ currentPerPage: value });
 }


### PR DESCRIPTION
## Summary
- update the custom per-page selector to move the table back to the first page before applying a new page size
- fall back to emitting an update when the pager slot does not expose a pageChanged helper

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf8d7a73c832384d8b340e3d472f1