### PR TITLE
Keep quick client modal URL in sync

### DIFF
--- a/frontend/src/components/ui/Header/Navtools/AddNew.vue
+++ b/frontend/src/components/ui/Header/Navtools/AddNew.vue
@@ -53,7 +53,7 @@ const items = computed(() =>
 
 const go = (name: string) => {
   if (name === 'clients.create') {
-    clientModal.open();
+    clientModal.open(router.resolve({ name }));
     return;
   }
 

--- a/frontend/src/stores/clientModal.ts
+++ b/frontend/src/stores/clientModal.ts
@@ -1,19 +1,113 @@
 import { defineStore } from 'pinia';
+import type { RouteLocationRaw } from 'vue-router';
+import router from '@/router';
 
 interface ClientModalState {
   isOpen: boolean;
+  previousUrl: string | null;
+  targetUrl: string | null;
+  historyStateId: string | null;
+  popstateAttached: boolean;
 }
 
 export const useClientModalStore = defineStore('clientModal', {
   state: (): ClientModalState => ({
     isOpen: false,
+    previousUrl: null,
+    targetUrl: null,
+    historyStateId: null,
+    popstateAttached: false,
   }),
   actions: {
-    open(): void {
+    open(target?: RouteLocationRaw | { href: string }): void {
+      if (this.isOpen) {
+        return;
+      }
+
       this.isOpen = true;
+
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      const resolved =
+        target && 'href' in target
+          ? target
+          : router.resolve(target ?? { name: 'clients.create' });
+
+      const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      this.previousUrl = currentUrl;
+      this.targetUrl = resolved.href;
+
+      if (currentUrl !== resolved.href) {
+        const stateId = `client-modal-${Date.now()}`;
+        const state =
+          window.history.state && typeof window.history.state === 'object'
+            ? { ...window.history.state }
+            : {};
+        state.__clientModalStateId = stateId;
+        this.historyStateId = stateId;
+        window.history.pushState(state, '', resolved.href);
+      } else {
+        this.historyStateId = null;
+      }
+
+      if (!this.popstateAttached) {
+        window.addEventListener('popstate', this.handlePopState);
+        this.popstateAttached = true;
+      }
     },
-    close(): void {
+    close(options?: { triggeredByPopstate?: boolean }): void {
+      if (!this.isOpen) {
+        return;
+      }
+
       this.isOpen = false;
+
+      if (typeof window !== 'undefined' && this.popstateAttached) {
+        window.removeEventListener('popstate', this.handlePopState);
+        this.popstateAttached = false;
+      }
+
+      const previousUrl = this.previousUrl;
+      const targetUrl = this.targetUrl;
+      this.previousUrl = null;
+      this.targetUrl = null;
+      this.historyStateId = null;
+
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      if (options?.triggeredByPopstate) {
+        return;
+      }
+
+      if (previousUrl && targetUrl && previousUrl !== targetUrl) {
+        const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+        if (currentUrl === targetUrl) {
+          window.history.back();
+        } else if (currentUrl !== previousUrl) {
+          window.history.replaceState(window.history.state, '', previousUrl);
+        }
+      }
+    },
+    handlePopState(event: PopStateEvent): void {
+      if (!this.isOpen) {
+        return;
+      }
+
+      const stateId =
+        event.state && typeof event.state === 'object'
+          ? (event.state as Record<string, any>).__clientModalStateId
+          : null;
+
+      if (stateId && this.historyStateId && stateId === this.historyStateId) {
+        return;
+      }
+
+      this.close({ triggeredByPopstate: true });
     },
   },
 });


### PR DESCRIPTION
## Summary
- extend the client modal store to track history details, push the create route into the browser history, and restore the previous URL on close or browser back
- close the modal when the browser back button is used and avoid duplicate listeners
- resolve the create-client route when opening the quick-create modal from the header

## Testing
- pnpm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfb26b5d083238a91f481089108b5