### PR TITLE
Add tenant archiving and bulk management endpoints

### DIFF
--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\App;
 use App\Models\Client;
 use App\Models\Task;
@@ -11,6 +12,8 @@ use App\Support\AbilityNormalizer;
 
 class Tenant extends Model
 {
+    use SoftDeletes;
+
     protected static ?Tenant $current = null;
     protected $fillable = [
         'name',
@@ -19,11 +22,13 @@ class Tenant extends Model
         'feature_abilities',
         'phone',
         'address',
+        'archived_at',
     ];
 
     protected $casts = [
         'features' => 'array',
         'feature_abilities' => 'array',
+        'archived_at' => 'datetime',
     ];
 
     protected static function booted(): void

--- a/backend/database/migrations/2025_01_02_000000_add_archiving_to_tenants.php
+++ b/backend/database/migrations/2025_01_02_000000_add_archiving_to_tenants.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            if (! Schema::hasColumn('tenants', 'archived_at')) {
+                $table->timestamp('archived_at')->nullable()->after('address');
+            }
+
+            if (! Schema::hasColumn('tenants', 'deleted_at')) {
+                $table->softDeletes();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            if (Schema::hasColumn('tenants', 'archived_at')) {
+                $table->dropColumn('archived_at');
+            }
+
+            if (Schema::hasColumn('tenants', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};

--- a/backend/database/seeders/InitialSystemSeeder.php
+++ b/backend/database/seeders/InitialSystemSeeder.php
@@ -23,6 +23,8 @@ class InitialSystemSeeder extends Seeder
                 'features' => $features,
                 'phone' => '123-456-7890',
                 'address' => '123 Main St',
+                'archived_at' => null,
+                'deleted_at' => null,
             ]
         );
 

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -44,6 +44,8 @@ class TenantBootstrapSeeder extends Seeder
                 'features' => json_encode($defaultFeatures),
                 'phone' => '555-123-4567',
                 'address' => '1 Pet Street',
+                'archived_at' => null,
+                'deleted_at' => null,
                 'created_at' => now(),
                 'updated_at' => now(),
             ]

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -76,6 +76,21 @@ Route::middleware(['auth:sanctum'])->group(function () {
         'update' => Ability::class . ':tenants.update',
         'destroy' => Ability::class . ':tenants.delete',
     ]);
+    Route::post('tenants/{tenant}/restore', [TenantController::class, 'restore'])
+        ->middleware(Ability::class . ':tenants.update')
+        ->whereNumber('tenant');
+    Route::post('tenants/{tenant}/archive', [TenantController::class, 'archive'])
+        ->middleware(Ability::class . ':tenants.update')
+        ->whereNumber('tenant');
+    Route::delete('tenants/{tenant}/archive', [TenantController::class, 'unarchive'])
+        ->middleware(Ability::class . ':tenants.update')
+        ->whereNumber('tenant');
+    Route::post('tenants/bulk-archive', [TenantController::class, 'bulkArchive'])
+        ->middleware(Ability::class . ':tenants.update');
+    Route::post('tenants/bulk-delete', [TenantController::class, 'bulkDestroy'])
+        ->middleware(Ability::class . ':tenants.delete');
+    Route::post('tenants/bulk-restore', [TenantController::class, 'bulkRestore'])
+        ->middleware(Ability::class . ':tenants.update');
     Route::post('tenants/{tenant}/impersonate', [TenantController::class, 'impersonate'])
         ->middleware(Ability::class . ':tenants.manage');
 });

--- a/backend/tests/Feature/TenantArchiveTest.php
+++ b/backend/tests/Feature/TenantArchiveTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TenantArchiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsSuperAdmin(array $abilities = ['*']): array
+    {
+        $homeTenant = Tenant::create(['name' => 'Home Tenant']);
+
+        $role = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'tenant_id' => $homeTenant->id,
+            'abilities' => $abilities,
+            'level' => 0,
+        ]);
+
+        $user = User::create([
+            'name' => 'Root User',
+            'email' => 'root@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $homeTenant->id,
+            'phone' => '1234567890',
+            'address' => 'Main Street',
+        ]);
+
+        $user->roles()->attach($role->id, ['tenant_id' => $homeTenant->id]);
+
+        Sanctum::actingAs($user);
+
+        return [$user, $homeTenant];
+    }
+
+    private function actingAsRegularUser(Tenant $tenant): User
+    {
+        $user = User::create([
+            'name' => 'Regular User',
+            'email' => 'user@example.com',
+            'password' => Hash::make('secret'),
+            'tenant_id' => $tenant->id,
+            'phone' => '5551112222',
+            'address' => 'Side Street',
+        ]);
+
+        Sanctum::actingAs($user);
+
+        return $user;
+    }
+
+    public function test_super_admin_can_archive_and_unarchive_tenant(): void
+    {
+        $this->actingAsSuperAdmin(['tenants.update', 'tenants.view']);
+
+        $tenant = Tenant::create(['name' => 'Archive Target']);
+
+        $this->postJson("/api/tenants/{$tenant->id}/archive")
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $tenant->id]);
+
+        $this->assertNotNull($tenant->refresh()->archived_at);
+
+        $this->deleteJson("/api/tenants/{$tenant->id}/archive")
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $tenant->id]);
+
+        $this->assertNull($tenant->refresh()->archived_at);
+    }
+
+    public function test_super_admin_can_soft_delete_and_restore_tenant(): void
+    {
+        $this->actingAsSuperAdmin(['tenants.update', 'tenants.delete']);
+
+        $tenant = Tenant::create(['name' => 'Delete Target']);
+
+        $this->deleteJson("/api/tenants/{$tenant->id}")
+            ->assertStatus(204);
+
+        $trashed = Tenant::withTrashed()->find($tenant->id);
+        $this->assertNotNull($trashed);
+        $this->assertNotNull($trashed->deleted_at);
+
+        $this->postJson("/api/tenants/{$tenant->id}/restore")
+            ->assertStatus(200)
+            ->assertJsonFragment(['id' => $tenant->id]);
+
+        $restored = Tenant::find($tenant->id);
+        $this->assertNotNull($restored);
+        $this->assertNull($restored->deleted_at);
+        $this->assertNull($restored->archived_at);
+    }
+
+    public function test_super_admin_can_bulk_archive_and_restore_tenants(): void
+    {
+        $this->actingAsSuperAdmin(['tenants.update']);
+
+        $tenantA = Tenant::create(['name' => 'Tenant A']);
+        $tenantB = Tenant::create(['name' => 'Tenant B']);
+        $tenantC = Tenant::create(['name' => 'Tenant C']);
+
+        $this->postJson('/api/tenants/bulk-archive', ['ids' => [$tenantA->id, $tenantB->id]])
+            ->assertStatus(200)
+            ->assertJsonCount(2);
+
+        $this->assertNotNull($tenantA->refresh()->archived_at);
+        $this->assertNotNull($tenantB->refresh()->archived_at);
+        $this->assertNull($tenantC->refresh()->archived_at);
+
+        $tenantB->delete();
+        $this->assertNotNull(Tenant::withTrashed()->find($tenantB->id)->deleted_at);
+
+        $this->postJson('/api/tenants/bulk-restore', ['ids' => [$tenantA->id, $tenantB->id]])
+            ->assertStatus(200)
+            ->assertJsonCount(2);
+
+        $this->assertNull($tenantA->refresh()->archived_at);
+        $restoredB = Tenant::find($tenantB->id);
+        $this->assertNotNull($restoredB);
+        $this->assertNull($restoredB->archived_at);
+        $this->assertNull($restoredB->deleted_at);
+    }
+
+    public function test_super_admin_can_bulk_destroy_tenants(): void
+    {
+        $this->actingAsSuperAdmin(['tenants.delete']);
+
+        $tenantA = Tenant::create(['name' => 'Tenant A']);
+        $tenantB = Tenant::create(['name' => 'Tenant B']);
+
+        $this->postJson('/api/tenants/bulk-delete', ['ids' => [$tenantA->id, $tenantB->id]])
+            ->assertStatus(200)
+            ->assertJsonCount(2);
+
+        $this->assertNotNull(Tenant::withTrashed()->find($tenantA->id)->deleted_at);
+        $this->assertNotNull(Tenant::withTrashed()->find($tenantB->id)->deleted_at);
+    }
+
+    public function test_non_super_admin_cannot_archive_tenant(): void
+    {
+        [, $homeTenant] = $this->actingAsSuperAdmin(['tenants.update']);
+
+        $targetTenant = Tenant::create(['name' => 'Target Tenant']);
+
+        // Switch to a regular user without SuperAdmin role
+        $this->actingAsRegularUser($homeTenant);
+
+        $this->postJson("/api/tenants/{$targetTenant->id}/archive")
+            ->assertStatus(403);
+
+        $this->assertNull($targetTenant->refresh()->archived_at);
+    }
+
+    public function test_super_admin_can_filter_archived_and_trashed_tenants(): void
+    {
+        $this->actingAsSuperAdmin(['tenants.view']);
+
+        $active = Tenant::create(['name' => 'Active Tenant']);
+        $archived = Tenant::create(['name' => 'Archived Tenant', 'archived_at' => now()]);
+        $trashed = Tenant::create(['name' => 'Trashed Tenant']);
+        $trashed->delete();
+
+        $this->getJson('/api/tenants?archived=only')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonFragment(['id' => $archived->id]);
+
+        $this->getJson('/api/tenants?archived=all')
+            ->assertStatus(200)
+            ->assertJsonCount(3, 'data');
+
+        $this->getJson('/api/tenants?trashed=only')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonFragment(['id' => $trashed->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration that introduces archived_at timestamps and soft deletes to tenants
- update the tenant model, controller, routes, and seeders to support archiving, restoring, and bulk actions
- add feature coverage ensuring super admins can manage archived or trashed tenants and other users are forbidden

## Testing
- php artisan test --filter=TenantArchiveTest

------
https://chatgpt.com/codex/tasks/task_e_68cd875de26c8323918cb59cc81a8021