### PR TITLE
Ensure demo clients seed with active status

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,10 +6,16 @@ This demo application is multi-tenant. Requests include the tenant context via t
 
 Teams group employees within a tenant. Users are attached to teams through the `team_employee` pivot table and gain role abilities via `role_user` records. When creating resources that support assignment, include an `assignee` field in the payload with `{ id: number }` (or an `assigned_user_id` field directly). The backend maps this to an `assigned_user_id` column.
 
-Run the database migrations with seeding to populate a super admin account. To include the optional demo tenant with sample data, set `ENABLE_DEMO_SEEDER=true` in your `.env` file before running:
+Run the database migrations with seeding to populate a super admin account:
 
 ```bash
 php artisan migrate:fresh --seed
+```
+
+By default this seeds only the system essentials. To include the optional demo tenant with sample clients, enable the flag before seeding (for example `ENABLE_DEMO_SEEDER=true php artisan migrate:fresh --seed`) or run the demo seeder directly:
+
+```bash
+php artisan db:seed --class=Database\\Seeders\\TenantBootstrapSeeder
 ```
 
 ## Role Levels

--- a/backend/database/seeders/TenantBootstrapSeeder.php
+++ b/backend/database/seeders/TenantBootstrapSeeder.php
@@ -140,6 +140,9 @@ class TenantBootstrapSeeder extends Seeder
                     'email' => $client['email'] ?? null,
                     'phone' => $client['phone'] ?? null,
                     'notes' => $client['notes'] ?? null,
+                    'status' => 'active',
+                    'archived_at' => null,
+                    'deleted_at' => null,
                     'created_at' => now(),
                     'updated_at' => now(),
                 ]

--- a/backend/tests/Feature/TenantBootstrapSeederTest.php
+++ b/backend/tests/Feature/TenantBootstrapSeederTest.php
@@ -40,11 +40,25 @@ class TenantBootstrapSeederTest extends TestCase
             'tenant_id' => 1,
             'name' => 'Bella Barker',
             'email' => 'bella.barker@example.test',
+            'status' => 'active',
+            'archived_at' => null,
+            'deleted_at' => null,
         ]);
         $this->assertDatabaseHas('clients', [
             'tenant_id' => 1,
             'name' => 'Charlie Cat',
             'phone' => '555-200-0002',
+            'status' => 'active',
+            'archived_at' => null,
+            'deleted_at' => null,
+        ]);
+        $this->assertDatabaseHas('clients', [
+            'tenant_id' => 1,
+            'name' => 'Oscar Otter',
+            'email' => 'oscar.otter@example.test',
+            'status' => 'active',
+            'archived_at' => null,
+            'deleted_at' => null,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- ensure the demo clients seeded by `TenantBootstrapSeeder` include an active status and explicit null archive/delete timestamps
- document how to enable the optional demo seeder when running backend setup
- extend the seeder feature test to verify demo client records include the expected status and null timestamp fields

## Testing
- php artisan test --filter=TenantBootstrapSeederTest

------
https://chatgpt.com/codex/tasks/task_e_68cd9e4ddd9883238d40463407e88c0f