### PR TITLE
Add public IDs for API models

### DIFF
--- a/backend/app/Models/Branding.php
+++ b/backend/app/Models/Branding.php
@@ -2,14 +2,17 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Branding extends Model
 {
     use HasFactory;
+    use HasPublicId;
 
     protected $fillable = [
+        'public_id',
         'tenant_id',
         'name',
         'color',
@@ -21,5 +24,9 @@ class Branding extends Model
         'email_from',
         'footer_left',
         'footer_right',
+    ];
+
+    protected $casts = [
+        'public_id' => 'string',
     ];
 }

--- a/backend/app/Models/Client.php
+++ b/backend/app/Models/Client.php
@@ -2,16 +2,19 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Client extends Model
 {
     use SoftDeletes;
+    use HasPublicId;
 
     protected $fillable = [
+        'public_id',
         'tenant_id',
         'name',
         'email',
@@ -22,7 +25,7 @@ class Client extends Model
     ];
 
     protected $casts = [
-        'tenant_id' => 'integer',
+        'public_id' => 'string',
         'archived_at' => 'datetime',
     ];
 

--- a/backend/app/Models/Concerns/HasPublicId.php
+++ b/backend/app/Models/Concerns/HasPublicId.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Support\PublicIdGenerator;
+use Illuminate\Database\Eloquent\Model;
+
+trait HasPublicId
+{
+    public static function bootHasPublicId(): void
+    {
+        static::creating(function (Model $model): void {
+            if (empty($model->public_id)) {
+                $model->public_id = static::generatePublicId();
+            }
+        });
+    }
+
+    protected function initializeHasPublicId(): void
+    {
+        $casts = $this->casts ?? [];
+        $casts['public_id'] = 'string';
+        $this->casts = $casts;
+
+        $hidden = $this->hidden ?? [];
+        $hidden[] = 'id';
+        $this->hidden = array_values(array_unique($hidden));
+
+        if (is_array($this->fillable) && ! in_array('public_id', $this->fillable, true)) {
+            $this->fillable[] = 'public_id';
+        }
+    }
+
+    public static function generatePublicId(): string
+    {
+        return PublicIdGenerator::generate();
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'public_id';
+    }
+}

--- a/backend/app/Models/Consent.php
+++ b/backend/app/Models/Consent.php
@@ -2,17 +2,22 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 
 class Consent extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'user_id',
         'name',
         'granted_at',
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'granted_at' => 'datetime',
     ];
 }

--- a/backend/app/Models/File.php
+++ b/backend/app/Models/File.php
@@ -2,12 +2,16 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class File extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'path',
         'filename',
         'mime_type',
@@ -18,6 +22,7 @@ class File extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'variants' => 'array',
     ];
 

--- a/backend/app/Models/Manual.php
+++ b/backend/app/Models/Manual.php
@@ -3,12 +3,16 @@
 namespace App\Models;
 
 use App\Models\Client;
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Manual extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'tenant_id',
         'file_id',
         'category',
@@ -17,8 +21,8 @@ class Manual extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'tags' => 'array',
-        'client_id' => 'integer',
     ];
 
     public function file(): BelongsTo

--- a/backend/app/Models/Notification.php
+++ b/backend/app/Models/Notification.php
@@ -2,12 +2,16 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Notification extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'user_id',
         'category',
         'message',
@@ -16,6 +20,7 @@ class Notification extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'read_at' => 'datetime',
     ];
 

--- a/backend/app/Models/Role.php
+++ b/backend/app/Models/Role.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -9,7 +10,10 @@ use Illuminate\Support\Str;
 
 class Role extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'tenant_id',
         'name',
         'description',
@@ -19,6 +23,7 @@ class Role extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'abilities' => 'array',
         'description' => 'string',
     ];

--- a/backend/app/Models/Status.php
+++ b/backend/app/Models/Status.php
@@ -2,14 +2,17 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 
 class Status extends Model
 {
-    protected $fillable = ['name', 'tenant_id'];
+    use HasPublicId;
+
+    protected $fillable = ['public_id', 'name', 'tenant_id'];
 
     protected $casts = [
-        'tenant_id' => 'integer',
+        'public_id' => 'string',
     ];
 }
 

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -3,22 +3,26 @@
 namespace App\Models;
 
 use App\Models\Client;
+use App\Models\Concerns\HasPublicId;
 use App\Models\File;
+use App\Models\TaskAutomation;
+use App\Models\TaskSlaEvent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\App;
-use App\Models\TaskSlaEvent;
-use App\Models\TaskAutomation;
 
 class Task extends Model
 {
+    use HasPublicId;
+
     public const STATUS_DRAFT = 'draft';
     public const STATUS_IN_PROGRESS = 'in_progress';
     public const STATUS_COMPLETED = 'completed';
 
     protected $fillable = [
+        'public_id',
         'tenant_id',
         'user_id',
         'status',
@@ -44,6 +48,7 @@ class Task extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'scheduled_at' => 'datetime',
         'sla_start_at' => 'datetime',
         'sla_end_at' => 'datetime',
@@ -51,7 +56,6 @@ class Task extends Model
         'completed_at' => 'datetime',
         'form_data' => 'array',
         'due_at' => 'datetime',
-        'client_id' => 'integer',
     ];
 
     public function comments(): HasMany

--- a/backend/app/Models/TaskAutomation.php
+++ b/backend/app/Models/TaskAutomation.php
@@ -2,15 +2,19 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use App\Jobs\AutomationNotifyTeamJob;
+use App\Models\Concerns\HasPublicId;
 use App\Models\Task;
 use App\Models\TaskStatus;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TaskAutomation extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'task_type_id',
         'event',
         'conditions_json',
@@ -19,6 +23,7 @@ class TaskAutomation extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'conditions_json' => 'array',
         'actions_json' => 'array',
         'enabled' => 'boolean',

--- a/backend/app/Models/TaskComment.php
+++ b/backend/app/Models/TaskComment.php
@@ -2,16 +2,24 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class TaskComment extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'task_id',
         'user_id',
         'body',
+    ];
+
+    protected $casts = [
+        'public_id' => 'string',
     ];
 
     public function setBodyAttribute(string $value): void

--- a/backend/app/Models/TaskStatus.php
+++ b/backend/app/Models/TaskStatus.php
@@ -2,18 +2,26 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
 class TaskStatus extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'slug',
         'name',
         'tenant_id',
         'position',
         'color',
+    ];
+
+    protected $casts = [
+        'public_id' => 'string',
     ];
 
     public static function prefixSlug(string $slug, ?int $tenantId): string

--- a/backend/app/Models/TaskSubtask.php
+++ b/backend/app/Models/TaskSubtask.php
@@ -2,12 +2,16 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TaskSubtask extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'task_id',
         'title',
         'is_completed',
@@ -17,6 +21,7 @@ class TaskSubtask extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'is_completed' => 'boolean',
         'is_required' => 'boolean',
     ];

--- a/backend/app/Models/TaskType.php
+++ b/backend/app/Models/TaskType.php
@@ -2,19 +2,22 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Casts\Attribute;
+use App\Models\Concerns\HasPublicId;
 use App\Services\FormSchemaService;
-use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property array|null $schema_json Schema definition
  */
 class TaskType extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'name',
         'schema_json',
         'statuses',
@@ -26,11 +29,10 @@ class TaskType extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'schema_json' => 'array',
         'statuses' => 'array',
         'status_flow_json' => 'array',
-        'tenant_id' => 'integer',
-        'client_id' => 'integer',
         'require_subtasks_complete' => 'boolean',
         'abilities_json' => 'array',
     ];

--- a/backend/app/Models/TaskWatcher.php
+++ b/backend/app/Models/TaskWatcher.php
@@ -2,14 +2,22 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TaskWatcher extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'task_id',
         'user_id',
+    ];
+
+    protected $casts = [
+        'public_id' => 'string',
     ];
 
     public function task(): BelongsTo

--- a/backend/app/Models/Team.php
+++ b/backend/app/Models/Team.php
@@ -2,18 +2,26 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
+use App\Models\User as Employee;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use App\Models\User as Employee;
 
 class Team extends Model
 {
+    use HasPublicId;
+
     protected $fillable = [
+        'public_id',
         'tenant_id',
         'name',
         'description',
         'lead_id',
+    ];
+
+    protected $casts = [
+        'public_id' => 'string',
     ];
 
     public function tenant(): BelongsTo

--- a/backend/app/Models/Tenant.php
+++ b/backend/app/Models/Tenant.php
@@ -2,20 +2,23 @@
 
 namespace App\Models;
 
+use App\Models\Client;
+use App\Models\Concerns\HasPublicId;
+use App\Models\Task;
+use App\Support\AbilityNormalizer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\App;
-use App\Models\Client;
-use App\Models\Task;
-use App\Support\AbilityNormalizer;
 
 class Tenant extends Model
 {
     use SoftDeletes;
+    use HasPublicId;
 
     protected static ?Tenant $current = null;
     protected $fillable = [
+        'public_id',
         'name',
         'quota_storage_mb',
         'features',
@@ -27,6 +30,7 @@ class Tenant extends Model
     ];
 
     protected $casts = [
+        'public_id' => 'string',
         'features' => 'array',
         'feature_abilities' => 'array',
         'archived_at' => 'datetime',

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -10,9 +11,12 @@ use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, Notifiable;
+    use HasApiTokens;
+    use HasPublicId;
+    use Notifiable;
 
     protected $fillable = [
+        'public_id',
         'name',
         'email',
         'password',
@@ -33,6 +37,7 @@ class User extends Authenticatable
     protected $with = ['roles'];
 
     protected $casts = [
+        'public_id' => 'string',
         'theme_settings' => 'array',
         'type' => 'string',
         'last_login_at' => 'datetime',

--- a/backend/app/Support/PublicIdGenerator.php
+++ b/backend/app/Support/PublicIdGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+
+class PublicIdGenerator
+{
+    public static function generate(): string
+    {
+        return (string) Str::ulid();
+    }
+}

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Support\PublicIdGenerator;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -24,6 +25,7 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'public_id' => PublicIdGenerator::generate(),
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),

--- a/backend/database/migrations/2025_10_20_210000_add_public_ids_to_api_tables.php
+++ b/backend/database/migrations/2025_10_20_210000_add_public_ids_to_api_tables.php
@@ -1,0 +1,110 @@
+<?php
+
+use App\Support\PublicIdGenerator;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $tables = [
+        'tenants',
+        'users',
+        'clients',
+        'tasks',
+        'task_comments',
+        'task_subtasks',
+        'task_watchers',
+        'task_types',
+        'task_statuses',
+        'task_automations',
+        'manuals',
+        'notifications',
+        'teams',
+        'roles',
+        'files',
+        'brandings',
+        'statuses',
+        'consents',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (! Schema::hasTable($table) || Schema::hasColumn($table, 'public_id')) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $tableBlueprint) {
+                $tableBlueprint->ulid('public_id')->nullable()->unique();
+            });
+
+            DB::table($table)
+                ->orderBy('id')
+                ->whereNull('public_id')
+                ->chunkById(500, function ($rows) use ($table) {
+                    foreach ($rows as $row) {
+                        DB::table($table)
+                            ->where('id', $row->id)
+                            ->update(['public_id' => PublicIdGenerator::generate()]);
+                    }
+                });
+
+            $this->enforceNotNull($table);
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'public_id')) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $tableBlueprint) {
+                $tableBlueprint->dropColumn('public_id');
+            });
+        }
+    }
+
+    private function enforceNotNull(string $table): void
+    {
+        try {
+            Schema::table($table, function (Blueprint $tableBlueprint) {
+                $tableBlueprint->ulid('public_id')->nullable(false)->change();
+            });
+        } catch (\Throwable $exception) {
+            $connection = Schema::getConnection();
+            $grammar = $connection->getQueryGrammar();
+            $wrappedTable = $grammar->wrapTable($table);
+            $wrappedColumn = $grammar->wrap('public_id');
+            $driver = $connection->getDriverName();
+
+            if ($driver === 'mysql') {
+                DB::statement(sprintf(
+                    'ALTER TABLE %s MODIFY %s CHAR(26) NOT NULL',
+                    $wrappedTable,
+                    $wrappedColumn
+                ));
+
+                return;
+            }
+
+            if ($driver === 'pgsql') {
+                DB::statement(sprintf(
+                    'ALTER TABLE %s ALTER COLUMN %s SET NOT NULL',
+                    $wrappedTable,
+                    $wrappedColumn
+                ));
+
+                return;
+            }
+
+            throw $exception;
+        }
+    }
+};

--- a/backend/database/seeders/DefaultFeatureRolesSeeder.php
+++ b/backend/database/seeders/DefaultFeatureRolesSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Tenant;
+use App\Support\PublicIdGenerator;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -141,15 +142,21 @@ class DefaultFeatureRolesSeeder extends Seeder
                 $level = min($existing->level, $level);
             }
 
+            $payload = [
+                'name' => $role['name'],
+                'abilities' => json_encode($abilities),
+                'level' => $level,
+                'created_at' => $existing->created_at ?? now(),
+                'updated_at' => now(),
+            ];
+
+            if (! $existing) {
+                $payload['public_id'] = PublicIdGenerator::generate();
+            }
+
             DB::table('roles')->updateOrInsert(
                 ['tenant_id' => $tenant->id, 'slug' => $role['slug']],
-                [
-                    'name' => $role['name'],
-                    'abilities' => json_encode($abilities),
-                    'level' => $level,
-                    'created_at' => $existing->created_at ?? now(),
-                    'updated_at' => now(),
-                ]
+                $payload
             );
         }
 


### PR DESCRIPTION
## Summary
- Introduced a reusable HasPublicId concern and generator to assign ULIDs, hide numeric IDs, and bind routes by `public_id`.
- Applied the new trait across API-facing models while adding `public_id` fillable/casts and removing integer-only relationship casts.
- Added a follow-up migration plus factory and seeder updates to add/backfill `public_id` values for existing data and seed workflows.

## Testing
- composer test *(fails: numerous existing feature tests rely on full application setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5c38dcf8832384ee7cb93570e14b