### PR TITLE
refactor: validate requests using public IDs

### DIFF
--- a/backend/app/Http/Requests/Concerns/ResolvesPublicIds.php
+++ b/backend/app/Http/Requests/Concerns/ResolvesPublicIds.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait ResolvesPublicIds
+{
+    /**
+     * Cache for resolved public IDs.
+     *
+     * @var array<string, int|null>
+     */
+    protected array $resolvedPublicIds = [];
+
+    /**
+     * Resolve a model's public identifier to its internal numeric id.
+     */
+    protected function resolvePublicId(string $modelClass, ?string $publicId): ?int
+    {
+        if ($publicId === null || $publicId === '') {
+            return null;
+        }
+
+        $cacheKey = $modelClass.'|'.$publicId;
+
+        if (array_key_exists($cacheKey, $this->resolvedPublicIds)) {
+            return $this->resolvedPublicIds[$cacheKey];
+        }
+
+        /** @var Model $modelClass */
+        return $this->resolvedPublicIds[$cacheKey] = $modelClass::query()
+            ->where('public_id', $publicId)
+            ->value('id');
+    }
+}

--- a/backend/app/Http/Requests/TeamUpsertRequest.php
+++ b/backend/app/Http/Requests/TeamUpsertRequest.php
@@ -2,11 +2,16 @@
 
 namespace App\Http\Requests;
 
+use App\Http\Requests\Concerns\ResolvesPublicIds;
+use App\Models\Tenant;
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
 class TeamUpsertRequest extends FormRequest
 {
+    use ResolvesPublicIds;
+
     public function authorize(): bool
     {
         return true;
@@ -15,9 +20,22 @@ class TeamUpsertRequest extends FormRequest
     public function rules(): array
     {
         $teamId = $this->route('team')?->id;
-        $tenantId = $this->user() && $this->user()->hasRole('SuperAdmin')
-            ? ($this->input('tenant_id') ?? app('tenant_id'))
-            : $this->user()->tenant_id;
+        $tenantId = null;
+
+        if ($this->user() && $this->user()->hasRole('SuperAdmin')) {
+            $tenantId = $this->resolvePublicId(Tenant::class, $this->input('tenant_id'));
+
+            if ($tenantId === null && app()->bound('tenant_id')) {
+                $appTenant = app('tenant_id');
+                if (is_string($appTenant) && ! is_numeric($appTenant)) {
+                    $tenantId = $this->resolvePublicId(Tenant::class, $appTenant);
+                } else {
+                    $tenantId = $appTenant;
+                }
+            }
+        } else {
+            $tenantId = $this->user()?->tenant_id;
+        }
 
         return [
             'name' => [
@@ -27,8 +45,8 @@ class TeamUpsertRequest extends FormRequest
                 Rule::unique('teams')->where(fn ($q) => $q->where('tenant_id', $tenantId))->ignore($teamId),
             ],
             'description' => ['nullable', 'string'],
-            'tenant_id' => ['nullable', 'exists:tenants,id'],
-            'lead_id' => ['nullable', 'integer', 'exists:users,id'],
+            'tenant_id' => ['nullable', 'string', 'ulid', Rule::exists('tenants', 'public_id')],
+            'lead_id' => ['nullable', 'string', 'ulid', Rule::exists('users', 'public_id')],
         ];
     }
 
@@ -49,7 +67,23 @@ class TeamUpsertRequest extends FormRequest
             'string' => 'The :attribute must be a string.',
             'max' => 'The :attribute may not be greater than :max characters.',
             'exists' => 'The selected :attribute is invalid.',
+            'ulid' => 'The :attribute must be a valid identifier.',
             'unique' => 'The :attribute has already been taken.',
         ];
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $data = parent::validated($key, $default);
+
+        if (array_key_exists('tenant_id', $data)) {
+            $data['tenant_id'] = $this->resolvePublicId(Tenant::class, $data['tenant_id']);
+        }
+
+        if (array_key_exists('lead_id', $data)) {
+            $data['lead_id'] = $this->resolvePublicId(User::class, $data['lead_id']);
+        }
+
+        return $data;
     }
 }

--- a/backend/tests/Unit/Http/Requests/HashedIdentifierRequestTest.php
+++ b/backend/tests/Unit/Http/Requests/HashedIdentifierRequestTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use App\Http\Requests\RoleUpsertRequest;
+use App\Http\Requests\TaskStatusUpsertRequest;
+use App\Http\Requests\TaskTypeRequest;
+use App\Http\Requests\TaskUpsertRequest;
+use App\Http\Requests\TeamUpsertRequest;
+use App\Http\Requests\TypeUpsertRequest;
+use App\Models\Client;
+use App\Models\Role;
+use App\Models\TaskType;
+use App\Models\Team;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Redirector;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class HashedIdentifierRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Tenant $tenant;
+
+    private User $superAdmin;
+
+    private User $regularUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = Tenant::create(['name' => 'Acme Inc.']);
+
+        $this->regularUser = $this->createUser([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        $this->superAdmin = $this->createUser([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        $superRole = Role::create([
+            'name' => 'SuperAdmin',
+            'slug' => 'super_admin',
+            'level' => 0,
+            'abilities' => [],
+        ]);
+
+        $this->superAdmin->roles()->attach($superRole);
+    }
+
+    public function test_role_upsert_request_translates_tenant_public_id(): void
+    {
+        $request = RoleUpsertRequest::create('/roles', 'POST', [
+            'name' => 'Manager',
+            'slug' => 'manager',
+            'abilities' => [],
+            'tenant_id' => $this->tenant->public_id,
+        ]);
+
+        $validated = $this->validateRequest($request, $this->superAdmin);
+
+        $this->assertSame($this->tenant->id, $validated['tenant_id']);
+    }
+
+    public function test_team_upsert_request_translates_public_ids(): void
+    {
+        $lead = $this->createUser(['tenant_id' => $this->tenant->id]);
+
+        $request = TeamUpsertRequest::create('/teams', 'POST', [
+            'name' => 'Support',
+            'tenant_id' => $this->tenant->public_id,
+            'lead_id' => $lead->public_id,
+        ]);
+
+        $validated = $this->validateRequest($request, $this->superAdmin);
+
+        $this->assertSame($this->tenant->id, $validated['tenant_id']);
+        $this->assertSame($lead->id, $validated['lead_id']);
+    }
+
+    public function test_task_type_request_translates_public_ids(): void
+    {
+        $client = Client::create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Globex',
+            'email' => 'client@example.com',
+            'phone' => '1234567890',
+        ]);
+
+        $request = TaskTypeRequest::create('/task-types', 'POST', [
+            'name' => 'Onboarding',
+            'schema_json' => json_encode(['sections' => []]),
+            'statuses' => json_encode(['draft']),
+            'tenant_id' => $this->tenant->public_id,
+            'client_id' => $client->public_id,
+        ]);
+
+        $validated = $this->validateRequest($request, $this->superAdmin);
+
+        $this->assertSame($this->tenant->id, $validated['tenant_id']);
+        $this->assertSame($client->id, $validated['client_id']);
+        $this->assertIsArray($validated['statuses']);
+    }
+
+    public function test_task_upsert_request_translates_nested_public_ids(): void
+    {
+        $taskType = TaskType::create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'General',
+            'statuses' => ['open'],
+        ]);
+
+        $assignee = $this->createUser(['tenant_id' => $this->tenant->id]);
+        $team = Team::create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'QA',
+        ]);
+        $client = Client::create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Wayne Enterprises',
+            'email' => 'wayne@example.com',
+            'phone' => '9876543210',
+        ]);
+
+        $request = TaskUpsertRequest::create('/tasks', 'POST', [
+            'task_type_id' => $taskType->public_id,
+            'assignee' => ['id' => $assignee->public_id],
+            'assigned_user_id' => $assignee->public_id,
+            'reviewer' => ['kind' => 'team', 'id' => $team->public_id],
+            'client_id' => $client->public_id,
+        ]);
+
+        $validated = $this->validateRequest($request, $this->regularUser);
+
+        $this->assertSame($taskType->id, $validated['task_type_id']);
+        $this->assertSame($assignee->id, $validated['assigned_user_id']);
+        $this->assertSame($assignee->id, $validated['assignee']['id']);
+        $this->assertSame($team->id, $validated['reviewer']['id']);
+        $this->assertSame($client->id, $validated['client_id']);
+    }
+
+    public function test_task_status_upsert_request_translates_public_tenant_id(): void
+    {
+        $request = TaskStatusUpsertRequest::create('/task-statuses', 'POST', [
+            'name' => 'In Progress',
+            'tenant_id' => $this->tenant->public_id,
+        ]);
+
+        $validated = $this->validateRequest($request, $this->superAdmin);
+
+        $this->assertSame($this->tenant->id, $validated['tenant_id']);
+        $this->assertStringContainsString((string) $this->tenant->id, $validated['slug']);
+    }
+
+    public function test_type_upsert_request_translates_public_tenant_id(): void
+    {
+        $request = TypeUpsertRequest::create('/types', 'POST', [
+            'name' => 'Document',
+            'statuses' => json_encode(['draft']),
+            'tenant_id' => $this->tenant->public_id,
+        ]);
+
+        $validated = $this->validateRequest($request, $this->superAdmin);
+
+        $this->assertSame($this->tenant->id, $validated['tenant_id']);
+        $this->assertIsArray($validated['statuses']);
+    }
+
+    private function validateRequest(FormRequest $request, User $user, array $routeParameters = []): array
+    {
+        $request->setContainer(app());
+        $request->setRedirector(app(Redirector::class));
+        $request->setUserResolver(fn () => $user);
+        $request->setRouteResolver(fn () => new class($routeParameters)
+        {
+            public function __construct(private array $parameters)
+            {
+            }
+
+            public function parameter(string $key, $default = null)
+            {
+                return $this->parameters[$key] ?? $default;
+            }
+        });
+
+        $request->validateResolved();
+
+        return $request->validated();
+    }
+
+    private function createUser(array $attributes = []): User
+    {
+        return User::create(array_merge([
+            'name' => 'User ' . Str::random(6),
+            'email' => Str::random(10) . '@example.com',
+            'password' => bcrypt('password'),
+            'tenant_id' => $this->tenant->id,
+            'phone' => '1234567890',
+            'address' => '123 Main St',
+            'type' => 'employee',
+            'department' => 'Ops',
+            'status' => 'active',
+        ], $attributes));
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `ResolvesPublicIds` concern for converting public identifiers to internal IDs during request validation
- update the role, task, task type, task status, team, and type FormRequests to accept ULID strings, check `public_id` columns, and translate the values in `validated`
- add unit coverage that exercises each request with hashed identifiers to ensure validation and translation succeed

## Testing
- php artisan test tests/Unit/Http/Requests/HashedIdentifierRequestTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ce67319b348323b0a45d34f5304e91