### PR TITLE
Normalize hashed identifier handling for task statuses and roles

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskSubtaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskSubtaskController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Task;
 use App\Models\TaskSubtask;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class TaskSubtaskController extends Controller
 {
@@ -16,9 +18,12 @@ class TaskSubtaskController extends Controller
         $data = $request->validate([
             'title' => 'required|string',
             'is_completed' => 'boolean',
-            'assigned_user_id' => 'nullable|integer',
+            'assigned_user_id' => ['nullable', 'string', 'ulid', Rule::exists('users', 'public_id')],
             'is_required' => 'boolean',
         ]);
+        if (! empty($data['assigned_user_id'])) {
+            $data['assigned_user_id'] = User::where('public_id', $data['assigned_user_id'])->value('id');
+        }
         $data['position'] = ($task->subtasks()->max('position') ?? 0) + 1;
         $subtask = $task->subtasks()->create($data);
         return response()->json($subtask, 201);
@@ -33,9 +38,14 @@ class TaskSubtaskController extends Controller
         $data = $request->validate([
             'title' => 'sometimes|required|string',
             'is_completed' => 'sometimes|boolean',
-            'assigned_user_id' => 'nullable|integer',
+            'assigned_user_id' => ['nullable', 'string', 'ulid', Rule::exists('users', 'public_id')],
             'is_required' => 'sometimes|boolean',
         ]);
+        if (array_key_exists('assigned_user_id', $data)) {
+            $data['assigned_user_id'] = $data['assigned_user_id']
+                ? User::where('public_id', $data['assigned_user_id'])->value('id')
+                : null;
+        }
         $subtask->update($data);
         return response()->json($subtask);
     }
@@ -55,10 +65,12 @@ class TaskSubtaskController extends Controller
         $this->authorize('update', $task);
         $data = $request->validate([
             'order' => 'required|array',
-            'order.*' => 'integer',
+            'order.*' => ['string', 'ulid', Rule::exists('task_subtasks', 'public_id')],
         ]);
         foreach ($data['order'] as $index => $id) {
-            $task->subtasks()->where('id', $id)->update(['position' => $index + 1]);
+            $task->subtasks()
+                ->where('public_id', $id)
+                ->update(['position' => $index + 1]);
         }
         return response()->json(['message' => 'reordered']);
     }

--- a/backend/app/Http/Resources/RoleResource.php
+++ b/backend/app/Http/Resources/RoleResource.php
@@ -11,13 +11,15 @@ class RoleResource extends JsonResource
 
     public function toArray($request): array
     {
+        $this->resource->loadMissing('tenant');
+
         return $this->formatDates([
-            'id' => $this->id,
+            'id' => $this->public_id,
             'name' => $this->name,
             'description' => $this->description,
             'slug' => $this->slug,
             'abilities' => $this->abilities,
-            'tenant_id' => $this->tenant_id,
+            'tenant_id' => $this->tenant?->public_id,
             'level' => $this->level,
             'users_count' => $this->users_count ?? 0,
             'created_at' => $this->created_at,

--- a/backend/app/Http/Resources/TaskStatusResource.php
+++ b/backend/app/Http/Resources/TaskStatusResource.php
@@ -12,9 +12,18 @@ class TaskStatusResource extends JsonResource
 
     public function toArray($request): array
     {
-        $data = parent::toArray($request);
-        $data['slug'] = TaskStatus::stripPrefix($data['slug']);
+        $this->resource->loadMissing('tenant');
 
-        return $this->formatDates($data);
+        return $this->formatDates([
+            'id' => $this->public_id,
+            'name' => $this->name,
+            'slug' => TaskStatus::stripPrefix($this->slug),
+            'color' => $this->color,
+            'position' => $this->position,
+            'tenant_id' => $this->tenant?->public_id,
+            'tasks_count' => $this->tasks_count ?? 0,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ]);
     }
 }

--- a/backend/app/Models/TaskStatus.php
+++ b/backend/app/Models/TaskStatus.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
@@ -47,5 +48,10 @@ class TaskStatus extends Model
     public function tasks(): HasMany
     {
         return $this->hasMany(Task::class, 'status_slug', 'slug');
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
     }
 }


### PR DESCRIPTION
## Summary
- resolve task status tenant filters and copy endpoints against public IDs while returning hashed identifiers in responses
- surface role and assignment lookups through hashed IDs and expose tenant public IDs via the resource layer
- expose TaskStatus->tenant relationships and update subtask endpoints to accept hashed identifiers end-to-end

## Testing
- `composer test` *(fails: multiple feature suites expect seeded fixtures and .env configuration that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6c45655c832390e8a40aefe12b63