### PR TITLE
Support numeric identifiers across controller bindings

### DIFF
--- a/backend/app/Http/Resources/TaskCommentResource.php
+++ b/backend/app/Http/Resources/TaskCommentResource.php
@@ -12,14 +12,14 @@ class TaskCommentResource extends JsonResource
     public function toArray($request): array
     {
         return $this->formatDates([
-            'id' => $this->id,
+            'id' => $this->public_id,
             'body' => $this->body,
             'user' => [
-                'id' => $this->user->id,
+                'id' => $this->user->public_id,
                 'name' => $this->user->name,
             ],
             'mentions' => $this->mentions->map(fn ($u) => [
-                'id' => $u->id,
+                'id' => $u->public_id,
                 'name' => $u->name,
             ])->values(),
             'created_at' => $this->created_at,

--- a/backend/app/Http/Resources/TaskResource.php
+++ b/backend/app/Http/Resources/TaskResource.php
@@ -14,6 +14,7 @@ class TaskResource extends JsonResource
     public function toArray($request): array
     {
         $data = parent::toArray($request);
+        $data['id'] = $this->public_id;
         $data['status_slug'] = TaskStatus::stripPrefix($data['status_slug'] ?? '');
         $data['previous_status_slug'] = isset($data['previous_status_slug'])
             ? TaskStatus::stripPrefix($data['previous_status_slug'])
@@ -21,7 +22,7 @@ class TaskResource extends JsonResource
 
         if ($this->assignee) {
             $data['assignee'] = [
-                'id' => $this->assignee->id,
+                'id' => $this->assignee->public_id,
                 'name' => $this->assignee->name,
             ];
         } else {
@@ -33,7 +34,7 @@ class TaskResource extends JsonResource
         if ($this->relationLoaded('client') || $this->client) {
             $data['client'] = $this->client
                 ? [
-                    'id' => $this->client->id,
+                    'id' => $this->client->public_id,
                     'name' => $this->client->name,
                 ]
                 : null;

--- a/backend/app/Support/PublicIdResolver.php
+++ b/backend/app/Support/PublicIdResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PublicIdResolver
+{
+    /**
+     * Cache of resolved identifiers to internal ids.
+     *
+     * @var array<string, int|null>
+     */
+    protected array $cache = [];
+
+    /**
+     * Resolve a model identifier that may be a hashed public id or numeric id.
+     */
+    public function resolve(string $modelClass, string|int|null $identifier): ?int
+    {
+        if ($identifier === null || $identifier === '') {
+            return null;
+        }
+
+        if (is_int($identifier)) {
+            return $identifier;
+        }
+
+        if (is_string($identifier) && ctype_digit($identifier)) {
+            return (int) $identifier;
+        }
+
+        if (! is_string($identifier)) {
+            return null;
+        }
+
+        $cacheKey = $modelClass.'|'.$identifier;
+
+        if (array_key_exists($cacheKey, $this->cache)) {
+            return $this->cache[$cacheKey];
+        }
+
+        /** @var class-string<Model> $modelClass */
+        return $this->cache[$cacheKey] = $modelClass::query()
+            ->where('public_id', $identifier)
+            ->value('id');
+    }
+}

--- a/backend/tests/Unit/Services/FormSchemaServiceTest.php
+++ b/backend/tests/Unit/Services/FormSchemaServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Team;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\FormSchemaService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class FormSchemaServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = Tenant::create(['name' => 'Acme Inc.']);
+    }
+
+    public function test_map_assignee_resolves_public_id_from_form_data(): void
+    {
+        $user = User::create([
+            'name' => 'Jane Doe',
+            'email' => 'jane@example.com',
+            'password' => bcrypt('password'),
+            'tenant_id' => $this->tenant->id,
+            'phone' => '1234567890',
+            'address' => '123 Main St',
+            'type' => 'employee',
+            'department' => 'Ops',
+            'status' => 'active',
+        ]);
+
+        $schema = [
+            'sections' => [[
+                'fields' => [[
+                    'key' => 'assignee_field',
+                    'type' => 'assignee',
+                ]],
+            ]],
+        ];
+
+        $payload = [
+            'form_data' => [
+                'assignee_field' => ['id' => $user->public_id],
+            ],
+        ];
+
+        $service = app(FormSchemaService::class);
+        $service->mapAssignee($schema, $payload);
+
+        $this->assertSame($user->id, $payload['assigned_user_id']);
+        $this->assertArrayNotHasKey('assignee_field', $payload['form_data']);
+    }
+
+    public function test_map_reviewer_resolves_public_id_from_form_data(): void
+    {
+        $team = Team::create([
+            'name' => 'Support',
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        $schema = [
+            'sections' => [[
+                'fields' => [[
+                    'key' => 'reviewer_field',
+                    'type' => 'reviewer',
+                ]],
+            ]],
+        ];
+
+        $payload = [
+            'form_data' => [
+                'reviewer_field' => [
+                    'kind' => 'team',
+                    'id' => $team->public_id,
+                ],
+            ],
+        ];
+
+        $service = app(FormSchemaService::class);
+        $service->mapReviewer($schema, $payload);
+
+        $this->assertSame(Team::class, $payload['reviewer_type']);
+        $this->assertSame($team->id, $payload['reviewer_id']);
+        $this->assertArrayNotHasKey('reviewer_field', $payload['form_data']);
+    }
+
+    public function test_map_assignee_throws_for_invalid_identifier(): void
+    {
+        $schema = [
+            'sections' => [[
+                'fields' => [[
+                    'key' => 'assignee_field',
+                    'type' => 'assignee',
+                ]],
+            ]],
+        ];
+
+        $payload = [
+            'form_data' => [
+                'assignee_field' => ['id' => 'invalid'],
+            ],
+        ];
+
+        $service = app(FormSchemaService::class);
+
+        $this->expectException(ValidationException::class);
+        $service->mapAssignee($schema, $payload);
+    }
+}


### PR DESCRIPTION
## Summary
- inject the shared `PublicIdResolver` into the task status, task subtask, and role controllers so hashed or numeric identifiers are decoded before database work
- normalize task subtask validation to coerce identifier inputs to strings, reuse the resolver, and raise consistent validation errors when lookups fail
- update role assignment handling to validate raw identifiers and resolve user and tenant keys through the shared helper

## Testing
- `./vendor/bin/phpunit --filter FormSchemaServiceTest`
- `composer test` *(fails: suite still relies on seeded fixtures, .env, and numeric identifiers across many feature tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ce739de8c88323b699a226da8e1674