### PR TITLE
Expose hashed IDs in feature test helper factories

### DIFF
--- a/backend/tests/CreatesApplication.php
+++ b/backend/tests/CreatesApplication.php
@@ -4,6 +4,8 @@ namespace Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
 
 trait CreatesApplication
 {
@@ -14,5 +16,43 @@ trait CreatesApplication
         $app->make(Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    /**
+     * Retrieve the hashed public identifier for the provided model instance.
+     */
+    protected function publicIdFor(Model $model): string
+    {
+        if (! $model->getAttribute('public_id')) {
+            $model->refresh();
+        }
+
+        $publicId = $model->getAttribute('public_id');
+
+        if (! is_string($publicId) || $publicId === '') {
+            throw new RuntimeException(sprintf(
+                'Model %s does not have a public identifier available for hashing tests.',
+                $model::class
+            ));
+        }
+
+        return $publicId;
+    }
+
+    /**
+     * Map a list of models to their hashed public identifiers.
+     *
+     * @param iterable<Model> $models
+     * @return array<int, string>
+     */
+    protected function publicIdsFor(iterable $models): array
+    {
+        $ids = [];
+
+        foreach ($models as $model) {
+            $ids[] = $this->publicIdFor($model);
+        }
+
+        return $ids;
     }
 }

--- a/backend/tests/Feature/ClientManagementTest.php
+++ b/backend/tests/Feature/ClientManagementTest.php
@@ -17,6 +17,9 @@ class ClientManagementTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @return array{0: Tenant, 1: User, tenant_public_id: string, user_public_id: string}
+     */
     protected function createTenantUserWithAbilities(array $abilities = []): array
     {
         $tenant = Tenant::create(['name' => 'Tenant', 'features' => ['clients', 'tasks', 'task_types']]);
@@ -41,7 +44,12 @@ class ClientManagementTest extends TestCase
 
         Sanctum::actingAs($user);
 
-        return [$tenant, $user];
+        return [
+            $tenant,
+            $user,
+            'tenant_public_id' => $this->publicIdFor($tenant),
+            'user_public_id' => $this->publicIdFor($user),
+        ];
     }
 
     public function test_client_creation_can_send_welcome_email(): void

--- a/backend/tests/Feature/EmployeeAccountActionsTest.php
+++ b/backend/tests/Feature/EmployeeAccountActionsTest.php
@@ -91,7 +91,7 @@ class EmployeeAccountActionsTest extends TestCase
     }
 
     /**
-     * @return array{0: Tenant, 1: User}
+     * @return array{0: Tenant, 1: User, tenant_public_id: string, admin_public_id: string}
      */
     protected function createTenantAdmin(array $abilities): array
     {
@@ -117,7 +117,12 @@ class EmployeeAccountActionsTest extends TestCase
 
         $role->users()->attach($admin->id, ['tenant_id' => $tenant->id]);
 
-        return [$tenant, $admin];
+        return [
+            $tenant,
+            $admin,
+            'tenant_public_id' => $this->publicIdFor($tenant),
+            'admin_public_id' => $this->publicIdFor($admin),
+        ];
     }
 
     protected function createEmployee(Tenant $tenant, string $name, string $email): User

--- a/backend/tests/Feature/TeamsTest.php
+++ b/backend/tests/Feature/TeamsTest.php
@@ -54,7 +54,7 @@ class TeamsTest extends TestCase
     }
 
     /**
-     * @return array{0: Tenant, 1: User}
+     * @return array{0: Tenant, 1: User, tenant_public_id: string, admin_public_id: string}
      */
     protected function createTenantUser(array $abilities): array
     {
@@ -79,7 +79,12 @@ class TeamsTest extends TestCase
 
         $admin->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
 
-        return [$tenant, $admin];
+        return [
+            $tenant,
+            $admin,
+            'tenant_public_id' => $this->publicIdFor($tenant),
+            'admin_public_id' => $this->publicIdFor($admin),
+        ];
     }
 
     protected function createEmployee(Tenant $tenant, string $name, string $email): User

--- a/backend/tests/Feature/TenantArchiveTest.php
+++ b/backend/tests/Feature/TenantArchiveTest.php
@@ -14,6 +14,9 @@ class TenantArchiveTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @return array{0: User, 1: Tenant, user_public_id: string, tenant_public_id: string}
+     */
     private function actingAsSuperAdmin(array $abilities = ['*']): array
     {
         $homeTenant = Tenant::create(['name' => 'Home Tenant']);
@@ -39,7 +42,12 @@ class TenantArchiveTest extends TestCase
 
         Sanctum::actingAs($user);
 
-        return [$user, $homeTenant];
+        return [
+            $user,
+            $homeTenant,
+            'user_public_id' => $this->publicIdFor($user),
+            'tenant_public_id' => $this->publicIdFor($homeTenant),
+        ];
     }
 
     private function actingAsRegularUser(Tenant $tenant): User

--- a/backend/tests/Feature/TenantManagementTest.php
+++ b/backend/tests/Feature/TenantManagementTest.php
@@ -17,6 +17,9 @@ class TenantManagementTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @return array{0: User, 1: Tenant, user_public_id: string, tenant_public_id: string}
+     */
     private function actingAsSuperAdmin(): array
     {
         $homeTenant = Tenant::create([
@@ -48,7 +51,12 @@ class TenantManagementTest extends TestCase
 
         Sanctum::actingAs($user);
 
-        return [$user, $homeTenant];
+        return [
+            $user,
+            $homeTenant,
+            'user_public_id' => $this->publicIdFor($user),
+            'tenant_public_id' => $this->publicIdFor($homeTenant),
+        ];
     }
 
     public function test_super_admin_creating_tenant_sends_reset_link_when_notify_owner_enabled(): void

--- a/backend/tests/Feature/TenantOwnerAccountActionsTest.php
+++ b/backend/tests/Feature/TenantOwnerAccountActionsTest.php
@@ -100,7 +100,14 @@ class TenantOwnerAccountActionsTest extends TestCase
     }
 
     /**
-     * @return array{0: Tenant, 1: User, 2: User}
+     * @return array{
+     *     0: Tenant,
+     *     1: User,
+     *     2: User,
+     *     tenant_public_id: string,
+     *     owner_public_id: string,
+     *     admin_public_id: string,
+     * }
      */
     protected function createTenantWithOwner(array $adminAbilities): array
     {
@@ -152,6 +159,13 @@ class TenantOwnerAccountActionsTest extends TestCase
 
         $adminRole->users()->attach($admin->id, ['tenant_id' => $tenant->id]);
 
-        return [$tenant, $owner, $admin];
+        return [
+            $tenant,
+            $owner,
+            $admin,
+            'tenant_public_id' => $this->publicIdFor($tenant),
+            'owner_public_id' => $this->publicIdFor($owner),
+            'admin_public_id' => $this->publicIdFor($admin),
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- add shared helpers in `CreatesApplication` to pull a model's hashed public identifier for tests
- extend tenant/user factory helpers in feature suites to expose both model instances and their hashed IDs via documented return shapes
- update docblocks to highlight the availability of hashed identifiers for future payload builders

## Testing
- composer test *(fails: application requires seeded environment/.env and numerous feature tests are currently marked incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7ec4c4bc8323a81571566f940fd2