### PR TITLE
Align feature tests with hashed identifiers

### DIFF
--- a/backend/tests/CreatesApplication.php
+++ b/backend/tests/CreatesApplication.php
@@ -55,4 +55,30 @@ trait CreatesApplication
 
         return $ids;
     }
+
+    /**
+     * Resolve a hashed public identifier back to its underlying numeric id.
+     *
+     * @template TModel of Model
+     *
+     * @param class-string<TModel> $modelClass
+     */
+    protected function idFromPublicId(string $modelClass, string $publicId): int
+    {
+        /** @var TModel|null $model */
+        $model = $modelClass::query()->where('public_id', $publicId)->first();
+
+        $this->assertNotNull(
+            $model,
+            sprintf('Failed to resolve public identifier [%s] for model [%s].', $publicId, $modelClass)
+        );
+
+        $this->assertSame(
+            $publicId,
+            $model->getAttribute('public_id'),
+            'Resolved model public identifier does not match the provided hash.'
+        );
+
+        return (int) $model->getKey();
+    }
 }

--- a/backend/tests/Feature/TaskCreationTest.php
+++ b/backend/tests/Feature/TaskCreationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Role;
+use App\Models\Task;
 use App\Models\Tenant;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -42,7 +43,14 @@ class TaskCreationTest extends TestCase
             ->assertJsonPath('data.status', 'draft')
             ->assertJsonPath('data.status_slug', 'draft');
 
-        $taskId = $response->json('data.id');
+        $taskPublicId = $response->json('data.id');
+        $this->assertIsString($taskPublicId);
+
+        $taskId = $this->idFromPublicId(Task::class, $taskPublicId);
+        $task = Task::query()->find($taskId);
+        $this->assertNotNull($task);
+        $this->assertSame($taskId, $task->getKey());
+        $this->assertSame($taskPublicId, $task->public_id);
 
         $this->assertDatabaseHas('tasks', [
             'id' => $taskId,


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve hashed public identifiers back to numeric model keys in the testing framework
- update role, client, task, and comment feature tests to expect hashed identifiers in API responses while asserting database state with numeric keys
- ensure route payloads use hashed identifiers and verify decoded hashes map to the created models to guard against regressions

## Testing
- composer test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ce80bd1b448323a691875d5c88f541