### PR TITLE
Normalize resource identifiers

### DIFF
--- a/backend/app/Http/Controllers/Api/ClientResource.php
+++ b/backend/app/Http/Controllers/Api/ClientResource.php
@@ -11,9 +11,17 @@ class ClientResource extends JsonResource
 
     public function toArray($request): array
     {
+        $this->resource->loadMissing('tenant');
+
         return $this->formatDates([
-            'id' => $this->id,
-            'tenant_id' => $this->tenant_id,
+            'id' => $this->public_id,
+            'tenant_id' => $this->tenant?->public_id,
+            'tenant' => $this->when($this->tenant, function () {
+                return [
+                    'id' => $this->tenant->public_id,
+                    'name' => $this->tenant->name,
+                ];
+            }),
             'name' => $this->name,
             'email' => $this->email,
             'phone' => $this->phone,

--- a/backend/app/Http/Resources/EmployeeResource.php
+++ b/backend/app/Http/Resources/EmployeeResource.php
@@ -11,11 +11,32 @@ class EmployeeResource extends JsonResource
 
     public function toArray($request): array
     {
-        $data = parent::toArray($request);
-        $data['status'] = $this->status;
-        $data['last_login_at'] = $this->last_login_at;
-        $data['department'] = $this->department;
+        $this->resource->loadMissing(['tenant', 'roles.tenant']);
 
-        return $this->formatDates($data);
+        return $this->formatDates([
+            'id' => $this->public_id,
+            'tenant_id' => $this->tenant?->public_id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'phone' => $this->phone,
+            'address' => $this->address,
+            'department' => $this->department,
+            'status' => $this->status,
+            'last_login_at' => $this->last_login_at,
+            'roles' => $this->roles->map(function ($role) {
+                return [
+                    'id' => $role->public_id,
+                    'name' => $role->name,
+                    'slug' => $role->slug,
+                    'description' => $role->description,
+                    'level' => $role->level,
+                    'abilities' => $role->abilities,
+                    'tenant_id' => $role->tenant?->public_id,
+                ];
+            })->values(),
+            'avatar' => $this->avatar,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ]);
     }
 }

--- a/backend/app/Http/Resources/ManualResource.php
+++ b/backend/app/Http/Resources/ManualResource.php
@@ -11,6 +11,31 @@ class ManualResource extends JsonResource
 
     public function toArray($request): array
     {
-        return $this->formatDates(parent::toArray($request));
+        $this->resource->loadMissing(['tenant', 'client', 'file']);
+
+        return $this->formatDates([
+            'id' => $this->public_id,
+            'tenant_id' => $this->tenant?->public_id,
+            'category' => $this->category,
+            'tags' => $this->tags ?? [],
+            'client_id' => $this->client?->public_id,
+            'client' => $this->when($this->client, function () {
+                return [
+                    'id' => $this->client->public_id,
+                    'name' => $this->client->name,
+                ];
+            }),
+            'file' => $this->when($this->file, function () {
+                return [
+                    'id' => $this->file->public_id,
+                    'filename' => $this->file->filename,
+                    'mime_type' => $this->file->mime_type,
+                    'size' => $this->file->size,
+                    'variants' => $this->file->variants,
+                ];
+            }),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ]);
     }
 }

--- a/backend/app/Http/Resources/NotificationResource.php
+++ b/backend/app/Http/Resources/NotificationResource.php
@@ -11,6 +11,14 @@ class NotificationResource extends JsonResource
 
     public function toArray($request): array
     {
-        return $this->formatDates(parent::toArray($request));
+        return $this->formatDates([
+            'id' => $this->public_id,
+            'category' => $this->category,
+            'message' => $this->message,
+            'link' => $this->link,
+            'read_at' => $this->read_at,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ]);
     }
 }

--- a/backend/app/Http/Resources/TaskResource.php
+++ b/backend/app/Http/Resources/TaskResource.php
@@ -13,12 +13,32 @@ class TaskResource extends JsonResource
 
     public function toArray($request): array
     {
+        $this->resource->loadMissing([
+            'tenant',
+            'type.tenant',
+            'type.client',
+            'client',
+            'assignee',
+            'user',
+            'reporter',
+        ]);
+
         $data = parent::toArray($request);
         $data['id'] = $this->public_id;
+        $data['tenant_id'] = $this->tenant?->public_id;
+        $data['user_id'] = $this->user?->public_id;
+        $data['reporter_user_id'] = $this->reporter?->public_id;
+        $data['task_type_id'] = $this->type?->public_id;
+        $data['client_id'] = $this->client?->public_id;
+        $data['assigned_user_id'] = $this->assignee?->public_id;
         $data['status_slug'] = TaskStatus::stripPrefix($data['status_slug'] ?? '');
         $data['previous_status_slug'] = isset($data['previous_status_slug'])
             ? TaskStatus::stripPrefix($data['previous_status_slug'])
             : null;
+
+        if ($this->relationLoaded('type') && $this->type) {
+            $data['type'] = (new TaskTypeResource($this->type))->toArray($request);
+        }
 
         if ($this->assignee) {
             $data['assignee'] = [
@@ -27,6 +47,20 @@ class TaskResource extends JsonResource
             ];
         } else {
             $data['assignee'] = null;
+        }
+
+        if ($this->relationLoaded('user') && $this->user) {
+            $data['user'] = [
+                'id' => $this->user->public_id,
+                'name' => $this->user->name,
+            ];
+        }
+
+        if ($this->relationLoaded('reporter') && $this->reporter) {
+            $data['reporter'] = [
+                'id' => $this->reporter->public_id,
+                'name' => $this->reporter->name,
+            ];
         }
 
         $data['status_color'] = $this->status->color ?? null;
@@ -55,6 +89,22 @@ class TaskResource extends JsonResource
         $data['is_watching'] = $this->relationLoaded('watchers')
             ? $this->watchers->contains('user_id', $request->user()->id)
             : false;
+
+        if ($this->relationLoaded('watchers')) {
+            $this->watchers->loadMissing('user');
+            $data['watchers'] = $this->watchers->map(function ($watcher) {
+                return [
+                    'id' => $watcher->public_id,
+                    'user_id' => $watcher->user?->public_id,
+                    'user' => $watcher->user
+                        ? [
+                            'id' => $watcher->user->public_id,
+                            'name' => $watcher->user->name,
+                        ]
+                        : null,
+                ];
+            })->values();
+        }
 
         if ($this->type && $this->type->schema_json) {
             $service = app(FormSchemaService::class);

--- a/backend/app/Http/Resources/TaskTypeResource.php
+++ b/backend/app/Http/Resources/TaskTypeResource.php
@@ -12,7 +12,12 @@ class TaskTypeResource extends JsonResource
 
     public function toArray($request): array
     {
+        $this->resource->loadMissing(['tenant', 'client']);
+
         $data = parent::toArray($request);
+        $data['id'] = $this->public_id;
+        $data['tenant_id'] = $this->tenant?->public_id;
+        $data['client_id'] = $this->client?->public_id;
         if (isset($data['schema_json'])) {
             $service = app(FormSchemaService::class);
             $data['schema_json'] = $service->filterSchemaForRoles(
@@ -23,8 +28,16 @@ class TaskTypeResource extends JsonResource
         if ($this->relationLoaded('client') || $this->client) {
             $data['client'] = $this->client
                 ? [
-                    'id' => $this->client->id,
+                    'id' => $this->client->public_id,
                     'name' => $this->client->name,
+                ]
+                : null;
+        }
+        if ($this->relationLoaded('tenant') || $this->tenant) {
+            $data['tenant'] = $this->tenant
+                ? [
+                    'id' => $this->tenant->public_id,
+                    'name' => $this->tenant->name,
                 ]
                 : null;
         }

--- a/backend/app/Http/Resources/TeamResource.php
+++ b/backend/app/Http/Resources/TeamResource.php
@@ -11,6 +11,36 @@ class TeamResource extends JsonResource
 
     public function toArray($request): array
     {
-        return $this->formatDates(parent::toArray($request));
+        $this->resource->loadMissing(['tenant', 'lead', 'employees']);
+
+        return $this->formatDates([
+            'id' => $this->public_id,
+            'tenant_id' => $this->tenant?->public_id,
+            'tenant' => $this->when($this->tenant, function () {
+                return [
+                    'id' => $this->tenant->public_id,
+                    'name' => $this->tenant->name,
+                ];
+            }),
+            'name' => $this->name,
+            'description' => $this->description,
+            'lead_id' => $this->lead?->public_id,
+            'lead' => $this->when($this->lead, function () {
+                return [
+                    'id' => $this->lead->public_id,
+                    'name' => $this->lead->name,
+                    'email' => $this->lead->email,
+                ];
+            }),
+            'employees' => $this->employees->map(function ($employee) {
+                return [
+                    'id' => $employee->public_id,
+                    'name' => $employee->name,
+                    'email' => $employee->email,
+                ];
+            })->values(),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ]);
     }
 }

--- a/backend/app/Http/Resources/TenantOwnerResource.php
+++ b/backend/app/Http/Resources/TenantOwnerResource.php
@@ -11,22 +11,24 @@ class TenantOwnerResource extends JsonResource
 
     public function toArray($request): array
     {
-        $data = [
-            'id' => $this->id,
+        $this->resource->loadMissing(['tenant', 'roles.tenant']);
+
+        return $this->formatDates([
+            'id' => $this->public_id,
+            'tenant_id' => $this->tenant?->public_id,
             'name' => $this->name,
             'email' => $this->email,
             'phone' => $this->phone,
             'address' => $this->address,
             'last_login_at' => $this->last_login_at,
-            'roles' => $this->whenLoaded('roles', function () {
-                return $this->roles->map(fn ($role) => [
-                    'id' => $role->id,
+            'roles' => $this->roles->map(function ($role) {
+                return [
+                    'id' => $role->public_id,
                     'name' => $role->name,
                     'slug' => $role->slug,
-                ]);
-            }),
-        ];
-
-        return $this->formatDates($data);
+                    'tenant_id' => $role->tenant?->public_id,
+                ];
+            })->values(),
+        ]);
     }
 }

--- a/backend/app/Models/Manual.php
+++ b/backend/app/Models/Manual.php
@@ -34,4 +34,9 @@ class Manual extends Model
     {
         return $this->belongsTo(Client::class);
     }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
 }

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Concerns\HasPublicId;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -42,6 +43,11 @@ class User extends Authenticatable
         'type' => 'string',
         'last_login_at' => 'datetime',
     ];
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
 
     public function roles(): BelongsToMany
     {

--- a/backend/tests/Unit/Http/Resources/ResourceSerializationTest.php
+++ b/backend/tests/Unit/Http/Resources/ResourceSerializationTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Controllers\Api\ClientResource as ApiClientResource;
+use App\Http\Resources\EmployeeResource;
+use App\Http\Resources\ManualResource;
+use App\Http\Resources\NotificationResource;
+use App\Http\Resources\TaskResource;
+use App\Http\Resources\TaskTypeResource;
+use App\Http\Resources\TeamResource;
+use App\Http\Resources\TenantOwnerResource;
+use App\Models\Client;
+use App\Models\File;
+use App\Models\Manual;
+use App\Models\Notification;
+use App\Models\Role;
+use App\Models\Task;
+use App\Models\TaskStatus;
+use App\Models\TaskType;
+use App\Models\TaskWatcher;
+use App\Models\Team;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ResourceSerializationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_employee_resource_uses_public_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $role = Role::create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Manager',
+            'slug' => 'manager',
+            'level' => 2,
+            'abilities' => ['employees.view'],
+        ]);
+        $employee = $this->createUser([
+            'tenant_id' => $tenant->id,
+        ]);
+        $employee->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+
+        $resource = new EmployeeResource($employee->fresh()->load('roles.tenant', 'tenant'));
+        $data = $resource->toArray(new Request());
+
+        $this->assertSame($employee->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $roleIds = collect($data['roles'])->pluck('id')->all();
+        $this->assertContains($role->public_id, $roleIds);
+        $this->assertNotContains($role->id, $roleIds);
+    }
+
+    public function test_team_resource_uses_public_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $lead = $this->createUser(['tenant_id' => $tenant->id]);
+        $member = $this->createUser(['tenant_id' => $tenant->id]);
+
+        $team = Team::create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Support',
+            'description' => 'Support team',
+            'lead_id' => $lead->id,
+        ]);
+        $team->employees()->attach([$lead->id, $member->id]);
+
+        $resource = new TeamResource($team->load(['tenant', 'lead', 'employees']));
+        $data = $resource->toArray(new Request());
+
+        $this->assertSame($team->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $this->assertSame($lead->public_id, $data['lead_id']);
+        $employeeIds = collect($data['employees'])->pluck('id')->all();
+        $this->assertEqualsCanonicalizing([
+            $lead->public_id,
+            $member->public_id,
+        ], $employeeIds);
+    }
+
+    public function test_manual_resource_includes_public_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $client = Client::create(['tenant_id' => $tenant->id, 'name' => 'ACME']);
+        $file = File::create([
+            'path' => 'manuals/file.pdf',
+            'filename' => 'file.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => 1024,
+        ]);
+        $manual = Manual::create([
+            'tenant_id' => $tenant->id,
+            'file_id' => $file->id,
+            'client_id' => $client->id,
+            'category' => 'safety',
+            'tags' => ['alpha'],
+        ]);
+
+        $resource = new ManualResource($manual->load(['tenant', 'client', 'file']));
+        $data = $resource->toArray(new Request());
+
+        $this->assertSame($manual->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $this->assertSame($client->public_id, $data['client_id']);
+        $this->assertSame($file->public_id, $data['file']['id']);
+        $this->assertArrayNotHasKey('file_id', $data);
+    }
+
+    public function test_notification_resource_uses_public_id(): void
+    {
+        $tenant = Tenant::create(['name' => 'Notifications']);
+        $user = $this->createUser(['tenant_id' => $tenant->id]);
+        $notification = Notification::create([
+            'user_id' => $user->id,
+            'category' => 'general',
+            'message' => 'Welcome',
+        ]);
+
+        $resource = new NotificationResource($notification);
+        $data = $resource->toArray(new Request());
+
+        $this->assertSame($notification->public_id, $data['id']);
+        $this->assertArrayNotHasKey('user_id', $data);
+    }
+
+    public function test_task_type_resource_converts_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $client = Client::create(['tenant_id' => $tenant->id, 'name' => 'ACME']);
+        $type = TaskType::create([
+            'tenant_id' => $tenant->id,
+            'client_id' => $client->id,
+            'name' => 'Install',
+        ]);
+
+        $request = Request::create('/', 'GET');
+        $request->setUserResolver(fn () => $this->createUser(['tenant_id' => $tenant->id]));
+
+        $resource = new TaskTypeResource($type->load(['tenant', 'client']));
+        $data = $resource->toArray($request);
+
+        $this->assertSame($type->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $this->assertSame($client->public_id, $data['client_id']);
+        $this->assertSame($client->public_id, $data['client']['id']);
+    }
+
+    public function test_task_resource_rewrites_identifier_fields(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $creator = $this->createUser(['tenant_id' => $tenant->id]);
+        $assignee = $this->createUser(['tenant_id' => $tenant->id]);
+        $client = Client::create(['tenant_id' => $tenant->id, 'name' => 'ACME']);
+        $type = TaskType::create([
+            'tenant_id' => $tenant->id,
+            'client_id' => $client->id,
+            'name' => 'Install',
+        ]);
+        $status = TaskStatus::create([
+            'tenant_id' => $tenant->id,
+            'name' => 'Open',
+            'slug' => TaskStatus::prefixSlug('open', $tenant->id),
+            'position' => 1,
+        ]);
+
+        $task = Task::create([
+            'tenant_id' => $tenant->id,
+            'user_id' => $creator->id,
+            'reporter_user_id' => $creator->id,
+            'status' => 'open',
+            'status_slug' => $status->slug,
+            'title' => 'Install router',
+            'task_type_id' => $type->id,
+            'client_id' => $client->id,
+            'assigned_user_id' => $assignee->id,
+        ]);
+        TaskWatcher::create([
+            'task_id' => $task->id,
+            'user_id' => $creator->id,
+        ]);
+
+        $task->load(['tenant', 'type.tenant', 'type.client', 'client', 'assignee', 'user', 'reporter', 'watchers.user']);
+        $task->loadCount(['comments', 'attachments', 'watchers', 'subtasks']);
+
+        $request = Request::create('/', 'GET');
+        $request->setUserResolver(fn () => $creator);
+
+        $resource = new TaskResource($task);
+        $data = $resource->toArray($request);
+
+        $this->assertSame($task->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $this->assertSame($type->public_id, $data['task_type_id']);
+        $this->assertSame($client->public_id, $data['client_id']);
+        $this->assertSame($assignee->public_id, $data['assigned_user_id']);
+        $this->assertSame($creator->public_id, $data['user_id']);
+        $this->assertSame($creator->public_id, $data['reporter_user_id']);
+        $this->assertSame($client->public_id, $data['client']['id']);
+        $this->assertSame($assignee->public_id, $data['assignee']['id']);
+        $this->assertSame($type->public_id, $data['type']['id']);
+        $this->assertSame($creator->public_id, $data['watchers'][0]['user_id']);
+    }
+
+    public function test_tenant_owner_resource_converts_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $role = $tenant->roles()->where('slug', 'tenant')->first();
+        $owner = $this->createUser([
+            'tenant_id' => $tenant->id,
+            'type' => 'tenant',
+        ]);
+        $owner->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
+
+        $resource = new TenantOwnerResource($owner->fresh()->load(['roles.tenant', 'tenant']));
+        $data = $resource->toArray(new Request());
+
+        $this->assertSame($owner->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $this->assertSame($role->public_id, $data['roles'][0]['id']);
+    }
+
+    public function test_client_resource_surfaces_public_id(): void
+    {
+        $tenant = Tenant::create(['name' => 'Tenant']);
+        $client = Client::create([
+            'tenant_id' => $tenant->id,
+            'name' => 'ACME',
+            'email' => 'client@example.com',
+        ]);
+
+        $resource = new ApiClientResource($client->load('tenant'));
+        $data = $resource->toArray(new Request());
+
+        $this->assertSame($client->public_id, $data['id']);
+        $this->assertSame($tenant->public_id, $data['tenant_id']);
+        $this->assertSame($tenant->public_id, $data['tenant']['id']);
+    }
+
+    private function createUser(array $attributes = []): User
+    {
+        $tenantId = $attributes['tenant_id'] ?? Tenant::create(['name' => 'Tenant ' . uniqid()])->id;
+
+        $defaults = [
+            'tenant_id' => $tenantId,
+            'name' => 'User ' . uniqid(),
+            'email' => uniqid('user', true) . '@example.com',
+            'password' => Hash::make('secret'),
+            'phone' => '1234567890',
+            'address' => '123 Main St',
+            'type' => 'employee',
+            'status' => 'active',
+        ];
+
+        return User::create(array_merge($defaults, $attributes));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure API resources expose hashed public identifiers and strip numeric keys across clients, employees, teams, manuals, notifications, tasks and tenant owners
- add tenant and role eager-loading helpers to support public identifier serialization
- cover the new serialization rules with dedicated unit tests for each resource

## Testing
- ./vendor/bin/phpunit --filter ResourceSerializationTest

------
https://chatgpt.com/codex/tasks/task_e_68ce87cc634c8323b3f9134fc578466a