### PR TITLE
Support hashed task identifiers in upload and board flows

### DIFF
--- a/backend/tests/Feature/TaskAutomationTest.php
+++ b/backend/tests/Feature/TaskAutomationTest.php
@@ -80,7 +80,7 @@ class TaskAutomationTest extends TestCase
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
             ->patchJson('/api/task-board/move', [
-                'task_id' => $task->id,
+                'task_id' => $task->public_id,
                 'status_slug' => 'completed',
                 'index' => 0,
             ])->assertOk();

--- a/backend/tests/Feature/TaskBoardMoveTest.php
+++ b/backend/tests/Feature/TaskBoardMoveTest.php
@@ -82,22 +82,22 @@ class TaskBoardMoveTest extends TestCase
         $task = $this->makeTask($user);
 
         $this->withHeader('X-Tenant-ID', 1)
-            ->patchJson('/api/task-board/move', ['task_id' => $task->id, 'status_slug' => 'assigned', 'index' => 0])
+            ->patchJson('/api/task-board/move', ['task_id' => $task->public_id, 'status_slug' => 'assigned', 'index' => 0])
             ->assertStatus(200);
 
         $this->withHeader('X-Tenant-ID', 1)
-            ->patchJson('/api/task-board/move', ['task_id' => $task->id, 'status_slug' => 'draft', 'index' => 0])
+            ->patchJson('/api/task-board/move', ['task_id' => $task->public_id, 'status_slug' => 'draft', 'index' => 0])
             ->assertStatus(200);
 
         $this->withHeader('X-Tenant-ID', 1)
-            ->patchJson('/api/task-board/move', ['task_id' => $task->id, 'status_slug' => 'assigned', 'index' => 0])
+            ->patchJson('/api/task-board/move', ['task_id' => $task->public_id, 'status_slug' => 'assigned', 'index' => 0])
             ->assertStatus(200);
         $this->withHeader('X-Tenant-ID', 1)
-            ->patchJson('/api/task-board/move', ['task_id' => $task->id, 'status_slug' => 'in_progress', 'index' => 0])
+            ->patchJson('/api/task-board/move', ['task_id' => $task->public_id, 'status_slug' => 'in_progress', 'index' => 0])
             ->assertStatus(200);
 
         $this->withHeader('X-Tenant-ID', 1)
-            ->patchJson('/api/task-board/move', ['task_id' => $task->id, 'status_slug' => 'draft', 'index' => 0])
+            ->patchJson('/api/task-board/move', ['task_id' => $task->public_id, 'status_slug' => 'draft', 'index' => 0])
             ->assertStatus(422);
     }
 
@@ -107,7 +107,7 @@ class TaskBoardMoveTest extends TestCase
         $task = $this->makeTask($user);
 
         $this->withHeader('X-Tenant-ID', 1)
-            ->patchJson('/api/task-board/move', ['task_id' => $task->id, 'status_slug' => 'completed', 'index' => 0])
+            ->patchJson('/api/task-board/move', ['task_id' => $task->public_id, 'status_slug' => 'completed', 'index' => 0])
             ->assertStatus(200)
             ->assertJsonPath('data.status_slug', 'completed');
     }
@@ -156,7 +156,7 @@ class TaskBoardMoveTest extends TestCase
 
         $this->withHeader('X-Tenant-ID', 1)
             ->patchJson('/api/task-board/move', [
-                'task_id' => $taskA->id,
+                'task_id' => $taskA->public_id,
                 'status_slug' => 'draft',
                 'index' => 2,
             ])


### PR DESCRIPTION
## Summary
- allow the upload finalize flow to resolve hashed task identifiers and surface the stored file public id in responses
- resolve hashed task identifiers in the task board move endpoint before applying business logic
- update upload and task board feature tests to exercise hashed identifiers and assert hashed ids are returned

## Testing
- composer test *(fails: numerous pre-existing feature and policy tests that rely on broader fixtures/env setup)*
- php artisan test tests/Feature/UploadControllerTest.php tests/Feature/UploadFinalizeTest.php tests/Feature/TaskBoardMoveTest.php tests/Feature/TaskAutomationTest.php *(fails: storage variant generation in FileStorageService cannot write webp files when directories are missing in the fake disk)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8ad708ec832382443411ba59781c