### PR TITLE
Support string client identifiers across filters and validation

### DIFF
--- a/backend/app/Http/Controllers/Api/ReportController.php
+++ b/backend/app/Http/Controllers/Api/ReportController.php
@@ -23,9 +23,9 @@ class ReportController extends Controller
     protected function clientFilterRules(): array
     {
         return [
-            'client_id' => ['sometimes', 'integer', Rule::exists('clients', 'id')],
+            'client_id' => ['sometimes', 'string', 'ulid', Rule::exists('clients', 'public_id')],
             'client_ids' => ['sometimes', 'array'],
-            'client_ids.*' => ['integer', Rule::exists('clients', 'id')],
+            'client_ids.*' => ['string', 'ulid', Rule::exists('clients', 'public_id')],
         ];
     }
 

--- a/backend/app/Http/Controllers/Api/TaskBoardController.php
+++ b/backend/app/Http/Controllers/Api/TaskBoardController.php
@@ -45,9 +45,9 @@ class TaskBoardController extends Controller
             'breached_only' => ['sometimes', 'boolean'],
             'due_today' => ['sometimes', 'boolean'],
             'has_photos' => ['sometimes', 'boolean'],
-            'client_id' => ['sometimes', 'integer', Rule::exists('clients', 'id')],
+            'client_id' => ['sometimes', 'string', 'ulid', Rule::exists('clients', 'public_id')],
             'client_ids' => ['sometimes', 'array'],
-            'client_ids.*' => ['integer', Rule::exists('clients', 'id')],
+            'client_ids.*' => ['string', 'ulid', Rule::exists('clients', 'public_id')],
         ];
     }
 

--- a/backend/tests/Feature/TaskReportsTest.php
+++ b/backend/tests/Feature/TaskReportsTest.php
@@ -183,7 +183,7 @@ class TaskReportsTest extends TestCase
         Sanctum::actingAs($generalUser);
 
         $filteredResponse = $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson('/api/reports/materials?client_ids[]=' . $clientA->id . '&client_ids[]=' . $clientB->id);
+            ->getJson('/api/reports/materials?client_ids[]=' . $clientA->public_id . '&client_ids[]=' . $clientB->public_id);
         $filteredResponse->assertStatus(200);
         $filteredResponse->assertJsonFragment([
             'category' => 'Safety',
@@ -195,7 +195,7 @@ class TaskReportsTest extends TestCase
         ]);
 
         $singleClientResponse = $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson('/api/reports/materials?client_id=' . $clientB->id);
+            ->getJson('/api/reports/materials?client_id=' . $clientB->public_id);
         $singleClientResponse->assertStatus(200);
         $singleClientResponse->assertJsonCount(1);
         $singleClientResponse->assertJsonFragment([

--- a/backend/tests/Unit/Support/ClientFilterTest.php
+++ b/backend/tests/Unit/Support/ClientFilterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Models\Client;
+use App\Models\Tenant;
+use App\Support\ClientFilter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ClientFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_resolve_returns_internal_ids_for_public_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Acme Inc.']);
+        $client = Client::create(['tenant_id' => $tenant->id, 'name' => 'Client A']);
+
+        $request = Request::create('/reports', 'GET', [
+            'client_id' => $client->public_id,
+        ]);
+
+        $ids = ClientFilter::resolve($request);
+
+        $this->assertSame([$client->id], $ids);
+    }
+
+    public function test_resolve_filters_with_permitted_public_identifiers(): void
+    {
+        $tenant = Tenant::create(['name' => 'Acme Inc.']);
+        $clientA = Client::create(['tenant_id' => $tenant->id, 'name' => 'Client A']);
+        $clientB = Client::create(['tenant_id' => $tenant->id, 'name' => 'Client B']);
+
+        $request = Request::create('/reports', 'GET', [
+            'client_ids' => $clientA->public_id . ',' . $clientB->public_id,
+        ]);
+
+        $ids = ClientFilter::resolve($request, [$clientB->public_id]);
+
+        $this->assertSame([$clientB->id], $ids);
+    }
+}


### PR DESCRIPTION
## Summary
- update ClientFilter and ClientController logic to resolve client public IDs for filtering, restores, and bulk operations
- adjust client-related validation rules and request handling to accept ULID identifiers
- update task report filtering and TaskTypeController tenant handling, and add a unit test covering ClientFilter resolution

## Testing
- php artisan test tests/Unit/Support/ClientFilterTest.php
- php artisan test tests/Feature/TaskReportsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8c2773ac83239127a578dbccfecc