### PR TITLE
Update feature tests to use public identifiers

### DIFF
--- a/backend/tests/Feature/AssigneesExcludeTenantTest.php
+++ b/backend/tests/Feature/AssigneesExcludeTenantTest.php
@@ -54,7 +54,7 @@ class AssigneesExcludeTenantTest extends TestCase
         $employee->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($employee);
 
-        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/lookups/assignees?type=employees');
 
         $response->assertStatus(200);

--- a/backend/tests/Feature/AutomationsPolicyTest.php
+++ b/backend/tests/Feature/AutomationsPolicyTest.php
@@ -59,8 +59,8 @@ class AutomationsPolicyTest extends TestCase
         $manager->roles()->attach($managerRole->id, ['tenant_id' => $tenant->id]);
 
         Sanctum::actingAs($manager);
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson("/api/task-types/{$type->id}/automations")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->getJson("/api/task-types/{$type->public_id}/automations")
             ->assertOk();
 
         $viewer = User::create([
@@ -75,8 +75,8 @@ class AutomationsPolicyTest extends TestCase
         $viewer->roles()->attach($viewerRole->id, ['tenant_id' => $tenant->id]);
 
         Sanctum::actingAs($viewer);
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson("/api/task-types/{$type->id}/automations")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->getJson("/api/task-types/{$type->public_id}/automations")
             ->assertForbidden();
     }
 }

--- a/backend/tests/Feature/BrandingRoutesTest.php
+++ b/backend/tests/Feature/BrandingRoutesTest.php
@@ -57,13 +57,13 @@ class BrandingRoutesTest extends TestCase
             'footer_left' => 'Left',
             'footer_right' => 'Right',
         ];
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->putJson('/api/branding', $payload)
             ->assertStatus(200)
             ->assertJsonPath('footer_left', 'Left')
             ->assertJsonPath('footer_right', 'Right');
 
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson('/api/branding')
             ->assertStatus(200)
             ->assertJsonPath('footer_left', 'Left')
@@ -98,7 +98,7 @@ class BrandingRoutesTest extends TestCase
         $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($user);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->putJson('/api/branding', ['footer_left' => 'Nope'])
             ->assertStatus(403);
     }

--- a/backend/tests/Feature/ClientManagementTest.php
+++ b/backend/tests/Feature/ClientManagementTest.php
@@ -67,7 +67,7 @@ class ClientManagementTest extends TestCase
             'clients.manage',
         ]);
 
-        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/clients', [
                 'name' => 'Acme Corp',
                 'email' => 'welcome@example.com',
@@ -96,7 +96,7 @@ class ClientManagementTest extends TestCase
             'clients.manage',
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/clients', [
                 'name' => 'Silent Corp',
                 'email' => 'silent@example.com',
@@ -115,7 +115,7 @@ class ClientManagementTest extends TestCase
             'clients.manage',
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/clients', [
                 'name' => 'Acme Corp',
                 'notify_client' => true,
@@ -136,7 +136,7 @@ class ClientManagementTest extends TestCase
             'clients.manage',
         ]);
 
-        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/clients', [
                 'name' => 'Acme Corp',
                 'email' => 'contact@acme.test',
@@ -161,48 +161,48 @@ class ClientManagementTest extends TestCase
             'archived_at' => null,
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/clients')
             ->assertOk()
             ->assertJsonPath('meta.total', 1)
             ->assertJsonPath('data.0.name', 'Acme Corp')
             ->assertJsonPath('data.0.id', $clientPublicId);
 
-        $archive = $this->withHeader('X-Tenant-ID', $tenant->id)
+        $archive = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson("/api/clients/{$clientPublicId}/archive")
             ->assertOk();
 
         $this->assertNotNull($archive->json('data.archived_at'));
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/clients')
             ->assertOk()
             ->assertJsonMissing(['id' => $clientPublicId]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/clients?archived=only')
             ->assertOk()
             ->assertJsonPath('meta.total', 1)
             ->assertJsonPath('data.0.id', $clientPublicId);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->deleteJson("/api/clients/{$clientPublicId}/archive")
             ->assertOk()
             ->assertJsonPath('data.archived_at', null);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->deleteJson("/api/clients/{$clientPublicId}")
             ->assertOk();
 
         $this->assertSoftDeleted('clients', ['id' => $clientId]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson("/api/clients/{$clientPublicId}/restore")
             ->assertOk();
 
         $this->assertDatabaseHas('clients', ['id' => $clientId, 'deleted_at' => null, 'user_id' => null]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson("/api/clients/{$clientPublicId}")
             ->assertOk()
             ->assertJsonMissingPath('data.owner');
@@ -228,14 +228,14 @@ class ClientManagementTest extends TestCase
             'email' => 'foreign@example.com',
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenantA->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantA))
             ->postJson('/api/task-types', [
                 'name' => 'Type With Client',
                 'client_id' => $foreignClient->public_id,
             ])
             ->assertStatus(422);
 
-        $this->withHeader('X-Tenant-ID', $tenantA->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantA))
             ->postJson('/api/tasks', [
                 'task_type_id' => null,
                 'client_id' => $foreignClient->public_id,
@@ -333,11 +333,11 @@ class ClientManagementTest extends TestCase
             'email' => 'tenant-b@example.com',
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenantB->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantB))
             ->getJson('/api/clients')
             ->assertForbidden();
 
-        $this->withHeader('X-Tenant-ID', $tenantA->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantA))
             ->getJson("/api/clients/{$clientB->public_id}")
             ->assertForbidden();
     }
@@ -382,7 +382,7 @@ class ClientManagementTest extends TestCase
 
         Sanctum::actingAs($super);
 
-        $taskType = $this->withHeader('X-Tenant-ID', $tenantB->id)
+        $taskType = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantB))
             ->postJson('/api/task-types', [
                 'name' => 'SA Type',
                 'client_id' => $clientB->public_id,
@@ -391,7 +391,7 @@ class ClientManagementTest extends TestCase
             ->assertCreated()
             ->json('data.id');
 
-        $task = $this->withHeader('X-Tenant-ID', $tenantB->id)
+        $task = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantB))
             ->postJson('/api/tasks', [
                 'task_type_id' => $taskType,
             ])
@@ -418,10 +418,10 @@ class ClientManagementTest extends TestCase
             ]);
         });
 
-        $ids = $clients->pluck('id')->all();
+        $clientPublicIds = $this->publicIdsFor($clients);
 
-        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson('/api/clients/bulk-archive', ['ids' => $ids])
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson('/api/clients/bulk-archive', ['ids' => $clientPublicIds])
             ->assertOk();
 
         $response->assertJsonCount(3, 'data');
@@ -458,8 +458,13 @@ class ClientManagementTest extends TestCase
             'email' => 'foreign@example.com',
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson('/api/clients/bulk-archive', ['ids' => [$ownClient->id, $foreignClient->id]])
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson('/api/clients/bulk-archive', [
+                'ids' => [
+                    $this->publicIdFor($ownClient),
+                    $this->publicIdFor($foreignClient),
+                ],
+            ])
             ->assertForbidden();
 
         $this->assertNull($ownClient->fresh()->archived_at);
@@ -483,9 +488,9 @@ class ClientManagementTest extends TestCase
             ]);
         });
 
-        $ids = $clients->pluck('id')->all();
+        $ids = $this->publicIdsFor($clients);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/clients/bulk-delete', ['ids' => $ids])
             ->assertOk()
             ->assertJson(['message' => 'deleted']);
@@ -522,8 +527,13 @@ class ClientManagementTest extends TestCase
             'email' => 'foreign@example.com',
         ]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson('/api/clients/bulk-delete', ['ids' => [$ownClient->id, $foreignClient->id]])
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson('/api/clients/bulk-delete', [
+                'ids' => [
+                    $this->publicIdFor($ownClient),
+                    $this->publicIdFor($foreignClient),
+                ],
+            ])
             ->assertForbidden();
 
         $this->assertDatabaseHas('clients', ['id' => $ownClient->id, 'deleted_at' => null]);

--- a/backend/tests/Feature/EmployeeAccountActionsTest.php
+++ b/backend/tests/Feature/EmployeeAccountActionsTest.php
@@ -25,8 +25,8 @@ class EmployeeAccountActionsTest extends TestCase
 
         Password::shouldReceive('sendResetLink')->never();
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/employees/{$employee->id}/password-reset")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/employees/{$employee->public_id}/password-reset")
             ->assertStatus(403);
     }
 
@@ -42,8 +42,8 @@ class EmployeeAccountActionsTest extends TestCase
             ->with(['email' => $employee->email])
             ->andReturn(Password::RESET_LINK_SENT);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/employees/{$employee->id}/password-reset")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/employees/{$employee->public_id}/password-reset")
             ->assertStatus(200)
             ->assertJson(['status' => 'ok']);
     }
@@ -60,8 +60,8 @@ class EmployeeAccountActionsTest extends TestCase
             ->with(['email' => $employee->email])
             ->andReturn(Password::RESET_LINK_SENT);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/employees/{$employee->id}/invite-resend")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/employees/{$employee->public_id}/invite-resend")
             ->assertStatus(200)
             ->assertJson(['status' => 'ok']);
     }
@@ -78,8 +78,8 @@ class EmployeeAccountActionsTest extends TestCase
             ->with(['email' => 'updated@example.com'])
             ->andReturn(Password::RESET_LINK_SENT);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/employees/{$employee->id}/email-reset", [
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/employees/{$employee->public_id}/email-reset", [
                 'email' => 'updated@example.com',
             ])
             ->assertStatus(200)

--- a/backend/tests/Feature/EmployeeCreateAbilityTest.php
+++ b/backend/tests/Feature/EmployeeCreateAbilityTest.php
@@ -54,7 +54,7 @@ class EmployeeCreateAbilityTest extends TestCase
             'email' => 'employee@example.com',
         ];
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/employees', $payload)
             ->assertStatus(403);
     }
@@ -102,7 +102,7 @@ class EmployeeCreateAbilityTest extends TestCase
             'email' => 'created@example.com',
         ];
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/employees', $payload)
             ->assertStatus(201);
 

--- a/backend/tests/Feature/FeatureAbilitiesTest.php
+++ b/backend/tests/Feature/FeatureAbilitiesTest.php
@@ -45,7 +45,7 @@ class FeatureAbilitiesTest extends TestCase
         Sanctum::actingAs($user);
 
         // Missing ability
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson($route)
             ->assertStatus(403);
 
@@ -61,7 +61,7 @@ class FeatureAbilitiesTest extends TestCase
         $user->roles()->attach($abilityRole->id, ['tenant_id' => $tenant->id]);
         $user->refresh();
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson($route)
             ->assertStatus(200);
 

--- a/backend/tests/Feature/ImpersonationTokenTest.php
+++ b/backend/tests/Feature/ImpersonationTokenTest.php
@@ -54,7 +54,7 @@ class ImpersonationTokenTest extends TestCase
 
         $this->withHeaders([
             'Authorization' => 'Bearer ' . $token->plainTextToken,
-            'X-Tenant-ID' => $tenant->id,
+            'X-Tenant-ID' => $this->publicIdFor($tenant),
         ])->getJson('/api/lookups/features')
             ->assertStatus(200);
     }

--- a/backend/tests/Feature/LookupRoutesTest.php
+++ b/backend/tests/Feature/LookupRoutesTest.php
@@ -47,7 +47,7 @@ class LookupRoutesTest extends TestCase
 
     public function test_abilities_lookup_returns_list(): void
     {
-        $abilities = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $abilities = $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson('/api/lookups/abilities')
             ->assertStatus(200)
             ->json();
@@ -59,7 +59,7 @@ class LookupRoutesTest extends TestCase
     {
         $this->tenant->update(['features' => ['roles', 'teams', 'employees']]);
 
-        $abilities = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $abilities = $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson('/api/lookups/abilities?forTenant=1')
             ->assertStatus(200)
             ->json();
@@ -106,7 +106,7 @@ class LookupRoutesTest extends TestCase
         $superUser->roles()->attach($superRole->id, ['tenant_id' => $rootTenant->id]);
         Sanctum::actingAs($superUser);
 
-        $abilities = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $abilities = $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson('/api/lookups/abilities?forTenant=1')
             ->assertStatus(200)
             ->json();
@@ -116,7 +116,7 @@ class LookupRoutesTest extends TestCase
 
     public function test_features_lookup_returns_list(): void
     {
-        $features = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $features = $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson('/api/lookups/features')
             ->assertStatus(200)
             ->json();

--- a/backend/tests/Feature/RoleAbilityRestrictionTest.php
+++ b/backend/tests/Feature/RoleAbilityRestrictionTest.php
@@ -44,12 +44,12 @@ class RoleAbilityRestrictionTest extends TestCase
         $user->roles()->attach($viewRole->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($user);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/roles')
             ->assertStatus(200);
 
         $payload = ['name' => 'New', 'slug' => 'new', 'level' => 1];
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(403);
     }

--- a/backend/tests/Feature/RoleLevelTest.php
+++ b/backend/tests/Feature/RoleLevelTest.php
@@ -48,7 +48,7 @@ class RoleLevelTest extends TestCase
     public function test_can_create_role_with_custom_level(): void
     {
         $payload = ['name' => 'Support', 'slug' => 'support', 'level' => 5];
-        $rolePublicId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $rolePublicId = $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
             ->assertJsonPath('data.level', 5)
@@ -78,7 +78,7 @@ class RoleLevelTest extends TestCase
             'level' => 1,
         ]);
 
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->patchJson("/api/roles/{$role->public_id}", ['name' => 'Agent', 'slug' => 'agent', 'level' => 4])
             ->assertStatus(200)
             ->assertJsonPath('data.level', 4);

--- a/backend/tests/Feature/RoleRoutesTest.php
+++ b/backend/tests/Feature/RoleRoutesTest.php
@@ -47,13 +47,13 @@ class RoleRoutesTest extends TestCase
 
     public function test_crud_routes_work(): void
     {
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson('/api/roles')
             ->assertStatus(200)
             ->assertJsonPath('data.0.abilities.0', 'roles.manage');
 
         $payload = ['name' => 'Tester', 'slug' => 'tester', 'level' => 1, 'description' => 'Test role'];
-        $rolePublicId = $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $rolePublicId = $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
             ->assertJsonStructure([
@@ -74,7 +74,7 @@ class RoleRoutesTest extends TestCase
         $this->assertSame($roleId, $role->getKey());
         $this->assertSame($rolePublicId, $role->public_id);
 
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->getJson("/api/roles/{$rolePublicId}")
             ->assertStatus(200)
             ->assertJsonStructure([
@@ -85,7 +85,7 @@ class RoleRoutesTest extends TestCase
             ->assertJsonMissingPath('data.updated_at');
 
         $update = ['name' => 'Updated', 'slug' => 'updated', 'level' => 2, 'description' => 'Updated role'];
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->putJson("/api/roles/{$rolePublicId}", $update)
             ->assertStatus(200)
             ->assertJsonStructure([
@@ -98,7 +98,7 @@ class RoleRoutesTest extends TestCase
             ->assertJsonMissingPath('data.created_at')
             ->assertJsonMissingPath('data.updated_at');
 
-        $this->withHeader('X-Tenant-ID', $this->tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($this->tenant))
             ->deleteJson("/api/roles/{$rolePublicId}")
             ->assertStatus(200);
     }

--- a/backend/tests/Feature/RoleValidationTest.php
+++ b/backend/tests/Feature/RoleValidationTest.php
@@ -48,13 +48,13 @@ class RoleValidationTest extends TestCase
             'level' => 1,
         ];
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(422);
 
         $tenant->update(['features' => ['tasks', 'task_statuses']]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
             ->assertJsonFragment(['abilities' => ['task_statuses.manage']]);

--- a/backend/tests/Feature/RolesTest.php
+++ b/backend/tests/Feature/RolesTest.php
@@ -55,11 +55,11 @@ class RolesTest extends TestCase
         $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($admin);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/roles')
             ->assertStatus(200)
             ->assertJsonFragment([
-                'id' => $role->id,
+                'id' => $this->publicIdFor($role),
                 'users_count' => 1,
             ])
             ->assertJsonStructure([
@@ -109,8 +109,11 @@ class RolesTest extends TestCase
         $admin->roles()->attach($adminRole->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($admin);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/roles/{$role->id}/assign", ['user_id' => $user->id])
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson(
+                "/api/roles/{$this->publicIdFor($role)}/assign",
+                ['user_id' => $this->publicIdFor($user)]
+            )
             ->assertStatus(200);
 
         $this->assertTrue(
@@ -148,7 +151,7 @@ class RolesTest extends TestCase
             'name' => 'Types Manager',
             'slug' => 'task_types.manager',
             'abilities' => ['task_types.manage'],
-            'tenant_id' => $tenant->id,
+            'tenant_id' => $this->publicIdFor($tenant),
             'level' => 1,
         ];
 
@@ -190,13 +193,13 @@ class RolesTest extends TestCase
             'level' => 1,
         ];
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(422);
 
         $tenant->update(['features' => ['tasks', 'task_types']]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
             ->assertJsonFragment(['abilities' => ['task_types.manage']]);

--- a/backend/tests/Feature/SuperAdminBypassTest.php
+++ b/backend/tests/Feature/SuperAdminBypassTest.php
@@ -35,7 +35,7 @@ class SuperAdminBypassTest extends TestCase
             'name' => 'Root',
             'email' => 'root@example.com',
             'password' => Hash::make('secret'),
-            'tenant_id' => $tenant->id,
+            'tenant_id' => $this->publicIdFor($tenant),
             'phone' => '123456',
             'address' => 'Street 1',
         ]);

--- a/backend/tests/Feature/SuperAdminCreatesTaskForTenantTest.php
+++ b/backend/tests/Feature/SuperAdminCreatesTaskForTenantTest.php
@@ -45,10 +45,10 @@ class SuperAdminCreatesTaskForTenantTest extends TestCase
         $user->roles()->attach($role->id, ['tenant_id' => $tenantA->id]);
         Sanctum::actingAs($user);
 
-        $response = $this->withHeader('X-Tenant-ID', $tenantB->id)
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantB))
             ->postJson('/api/tasks', [])
             ->assertStatus(201);
 
-        $this->assertEquals($tenantB->id, $response->json('data.tenant_id'));
+        $this->assertEquals($this->publicIdFor($tenantB), $response->json('data.tenant_id'));
     }
 }

--- a/backend/tests/Feature/SuperAdminRoleVisibilityTest.php
+++ b/backend/tests/Feature/SuperAdminRoleVisibilityTest.php
@@ -60,7 +60,7 @@ class SuperAdminRoleVisibilityTest extends TestCase
         $response = $this->getJson('/api/roles')
             ->assertStatus(200);
 
-        $response->assertJsonFragment(['tenant_id' => $tenantA->id, 'name' => 'ClientAdmin']);
-        $response->assertJsonFragment(['tenant_id' => $tenantB->id, 'name' => 'ClientAdmin']);
+        $response->assertJsonFragment(['tenant_id' => $this->publicIdFor($tenantA), 'name' => 'ClientAdmin']);
+        $response->assertJsonFragment(['tenant_id' => $this->publicIdFor($tenantB), 'name' => 'ClientAdmin']);
     }
 }

--- a/backend/tests/Feature/SuperAdminTenantAccessTest.php
+++ b/backend/tests/Feature/SuperAdminTenantAccessTest.php
@@ -51,10 +51,13 @@ class SuperAdminTenantAccessTest extends TestCase
 
         Sanctum::actingAs($user);
 
-        $this->withHeader('X-Tenant-ID', $tenantB->id)
-            ->getJson('/api/roles?tenant_id=' . $tenantB->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantB))
+            ->getJson('/api/roles?tenant_id=' . $this->publicIdFor($tenantB))
             ->assertStatus(200)
-            ->assertJsonFragment(['id' => $roleB->id, 'tenant_id' => $tenantB->id]);
+            ->assertJsonFragment([
+                'id' => $this->publicIdFor($roleB),
+                'tenant_id' => $this->publicIdFor($tenantB),
+            ]);
     }
 
     public function test_super_admin_can_update_role_for_any_tenant(): void
@@ -93,13 +96,17 @@ class SuperAdminTenantAccessTest extends TestCase
 
         Sanctum::actingAs($user);
 
-        $this->withHeader('X-Tenant-ID', $tenantB->id)
-            ->putJson("/api/roles/{$roleB->id}", [
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenantB))
+            ->putJson("/api/roles/{$this->publicIdFor($roleB)}", [
                 'name' => 'Updated',
                 'slug' => 'updated',
             ])
             ->assertStatus(200)
-            ->assertJsonFragment(['id' => $roleB->id, 'name' => 'Updated', 'slug' => 'updated']);
+            ->assertJsonFragment([
+                'id' => $this->publicIdFor($roleB),
+                'name' => 'Updated',
+                'slug' => 'updated',
+            ]);
 
         $this->assertDatabaseHas('roles', [
             'id' => $roleB->id,

--- a/backend/tests/Feature/TeamsTest.php
+++ b/backend/tests/Feature/TeamsTest.php
@@ -27,9 +27,9 @@ class TeamsTest extends TestCase
 
         Sanctum::actingAs($admin);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/teams/{$team->id}/employees", [
-                'employee_ids' => [$member->id],
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/teams/{$team->public_id}/employees", [
+                'employee_ids' => [$this->publicIdFor($member)],
             ])
             ->assertStatus(403);
 
@@ -48,9 +48,12 @@ class TeamsTest extends TestCase
 
         Sanctum::actingAs($admin);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/teams/{$team->id}/employees", [
-                'employee_ids' => [$memberOne->id, $memberTwo->id],
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/teams/{$team->public_id}/employees", [
+                'employee_ids' => [
+                    $this->publicIdFor($memberOne),
+                    $this->publicIdFor($memberTwo),
+                ],
             ])
             ->assertStatus(200);
 

--- a/backend/tests/Feature/TenantListFilterTest.php
+++ b/backend/tests/Feature/TenantListFilterTest.php
@@ -56,14 +56,14 @@ class TenantListFilterTest extends TestCase
 
         $this->actAsSuperAdminForTenant($tenantA);
 
-        $this->getJson('/api/tenants?tenant_id=' . $tenantB->id)
+        $this->getJson('/api/tenants?tenant_id=' . $this->publicIdFor($tenantB))
             ->assertStatus(200)
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment([
-                'id' => $tenantB->id,
+                'public_id' => $this->publicIdFor($tenantB),
                 'name' => 'Beta',
             ])
-            ->assertJsonMissing(['id' => $tenantA->id])
+            ->assertJsonMissing(['public_id' => $this->publicIdFor($tenantA)])
             ->assertJsonPath('meta.total', 1)
             ->assertJsonPath('meta.page', 1)
             ->assertJsonPath('meta.per_page', 15);
@@ -90,7 +90,7 @@ class TenantListFilterTest extends TestCase
             ->assertStatus(200)
             ->assertJsonCount(1, 'data')
             ->assertJsonFragment([
-                'id' => $tenantB->id,
+                'public_id' => $this->publicIdFor($tenantB),
                 'name' => 'Beta Logistics',
             ])
             ->assertJsonMissing(['name' => 'Alpha Manufacturing'])

--- a/backend/tests/Feature/TenantManagementTest.php
+++ b/backend/tests/Feature/TenantManagementTest.php
@@ -99,7 +99,10 @@ class TenantManagementTest extends TestCase
                 'tasks.client.update',
             ]);
 
-        $tenantId = $response->json('id');
+        $tenantPublicId = $response->json('public_id');
+        $this->assertIsString($tenantPublicId);
+
+        $tenantId = $this->idFromPublicId(Tenant::class, $tenantPublicId);
 
         $this->assertDatabaseHas('roles', [
             'tenant_id' => $tenantId,
@@ -144,7 +147,10 @@ class TenantManagementTest extends TestCase
         ])->assertCreated()
             ->assertJsonPath('feature_abilities.reports', ['reports.manage']);
 
-        $tenantId = $response->json('id');
+        $tenantPublicId = $response->json('public_id');
+        $this->assertIsString($tenantPublicId);
+
+        $tenantId = $this->idFromPublicId(Tenant::class, $tenantPublicId);
 
         $this->assertDatabaseHas('roles', [
             'tenant_id' => $tenantId,
@@ -177,7 +183,7 @@ class TenantManagementTest extends TestCase
 
         DefaultFeatureRolesSeeder::syncDefaultRolesForFeatures($tenant, $tenant->selectedFeatureAbilities());
 
-        $this->putJson("/api/tenants/{$tenant->id}", [
+        $this->putJson("/api/tenants/{$this->publicIdFor($tenant)}", [
             'features' => ['tasks', 'clients'],
             'feature_abilities' => [
                 'tasks' => ['tasks.view', 'tasks.update'],

--- a/backend/tests/Feature/TenantOwnerAccountActionsTest.php
+++ b/backend/tests/Feature/TenantOwnerAccountActionsTest.php
@@ -22,11 +22,11 @@ class TenantOwnerAccountActionsTest extends TestCase
 
         Sanctum::actingAs($admin);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson("/api/tenants/{$tenant->id}/owner")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->getJson("/api/tenants/{$tenant->public_id}/owner")
             ->assertStatus(200)
             ->assertJsonPath('data.email', $owner->email)
-            ->assertJsonPath('data.id', $owner->id);
+            ->assertJsonPath('data.id', $this->publicIdFor($owner));
     }
 
     public function test_owner_password_reset_requires_manage_ability(): void
@@ -37,8 +37,8 @@ class TenantOwnerAccountActionsTest extends TestCase
 
         Password::shouldReceive('sendResetLink')->never();
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/tenants/{$tenant->id}/owner/password-reset")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/tenants/{$tenant->public_id}/owner/password-reset")
             ->assertStatus(403);
     }
 
@@ -53,8 +53,8 @@ class TenantOwnerAccountActionsTest extends TestCase
             ->with(['email' => $owner->email])
             ->andReturn(Password::RESET_LINK_SENT);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/tenants/{$tenant->id}/owner/password-reset")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/tenants/{$tenant->public_id}/owner/password-reset")
             ->assertStatus(200)
             ->assertJson(['status' => 'ok']);
     }
@@ -70,8 +70,8 @@ class TenantOwnerAccountActionsTest extends TestCase
             ->with(['email' => $owner->email])
             ->andReturn(Password::RESET_LINK_SENT);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/tenants/{$tenant->id}/owner/invite-resend")
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/tenants/{$tenant->public_id}/owner/invite-resend")
             ->assertStatus(200)
             ->assertJson(['status' => 'ok']);
     }
@@ -87,8 +87,8 @@ class TenantOwnerAccountActionsTest extends TestCase
             ->with(['email' => 'new-owner@example.com'])
             ->andReturn(Password::RESET_LINK_SENT);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/tenants/{$tenant->id}/owner/email-reset", [
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
+            ->postJson("/api/tenants/{$tenant->public_id}/owner/email-reset", [
                 'email' => 'new-owner@example.com',
             ])
             ->assertStatus(200)

--- a/backend/tests/Feature/TenantRoleAbilityRestrictionTest.php
+++ b/backend/tests/Feature/TenantRoleAbilityRestrictionTest.php
@@ -51,13 +51,13 @@ class TenantRoleAbilityRestrictionTest extends TestCase
             'level' => 1,
         ];
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(422);
 
         $tenant->update(['features' => ['tasks', 'task_types']]);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/roles', $payload)
             ->assertStatus(201)
             ->assertJsonFragment(['abilities' => ['task_types.manage']]);

--- a/backend/tests/Feature/TenantScopeTest.php
+++ b/backend/tests/Feature/TenantScopeTest.php
@@ -69,7 +69,7 @@ class TenantScopeTest extends TestCase
         $user->roles()->attach($role->id, ['tenant_id' => $tenant1->id]);
         Sanctum::actingAs($user);
 
-        $this->withHeader('X-Tenant-ID', $tenant2->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant2))
             ->getJson('/api/roles')
             ->assertStatus(403);
     }

--- a/backend/tests/Feature/ThemeSettingsRoutesTest.php
+++ b/backend/tests/Feature/ThemeSettingsRoutesTest.php
@@ -39,7 +39,7 @@ class ThemeSettingsRoutesTest extends TestCase
         $user->roles()->attach($role->id, ['tenant_id' => $tenant->id]);
         Sanctum::actingAs($user);
 
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->getJson('/api/settings/theme')
             ->assertStatus(200)
             ->assertExactJson([]);

--- a/backend/tests/Feature/UploadControllerTest.php
+++ b/backend/tests/Feature/UploadControllerTest.php
@@ -49,7 +49,7 @@ class UploadControllerTest extends TestCase
         $file = UploadedFile::fake()->image('test.jpg', 100, 100)->size(100);
         Storage::put('files/test.jpg', file_get_contents($file->getRealPath()));
 
-        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/uploads/abc/finalize', [
                 'filename' => 'test.jpg',
                 'task_id' => $task->public_id,
@@ -95,7 +95,7 @@ class UploadControllerTest extends TestCase
         Sanctum::actingAs($user);
 
         $badMime = UploadedFile::fake()->create('bad.txt', 10, 'text/plain');
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->post('/api/uploads/chunk', [
                 'upload_id' => '1',
                 'index' => 0,
@@ -106,7 +106,7 @@ class UploadControllerTest extends TestCase
             ->assertStatus(422);
 
         $big = UploadedFile::fake()->create('big.jpg', config('security.max_upload_size') + 1000);
-        $this->withHeader('X-Tenant-ID', $tenant->id)
+        $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->post('/api/uploads/chunk', [
                 'upload_id' => '2',
                 'index' => 0,

--- a/backend/tests/Feature/UploadFinalizeTest.php
+++ b/backend/tests/Feature/UploadFinalizeTest.php
@@ -54,7 +54,7 @@ class UploadFinalizeTest extends TestCase
         $file = UploadedFile::fake()->image('final.jpg', 10, 10)->size(10);
         Storage::put('files/final.jpg', file_get_contents($file->getRealPath()));
 
-        $response = $this->withHeader('X-Tenant-ID', $tenant->id)
+        $response = $this->withHeader('X-Tenant-ID', $this->publicIdFor($tenant))
             ->postJson('/api/uploads/xyz/finalize', [
                 'filename' => 'final.jpg',
                 'task_id' => $task->public_id,


### PR DESCRIPTION
## Summary
- refactor non-task feature tests to use model public IDs in headers, payloads, and JSON assertions
- ensure relationship and bulk operation helpers resolve hashed identifiers back to numeric IDs for database checks
- verify tenant- and role-focused scenarios expect public identifier fields while preserving authorization coverage

## Testing
- composer test *(fails: backend still expects numeric identifiers; see console for failing suites such as AssigneesExcludeTenantTest, ClientManagementTest, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ce987f4dc4832383a709fbbb69100a