### PR TITLE
Use public identifiers in task feature tests

### DIFF
--- a/backend/tests/Feature/TaskSlaOverrideTest.php
+++ b/backend/tests/Feature/TaskSlaOverrideTest.php
@@ -76,12 +76,12 @@ class TaskSlaOverrideTest extends TestCase
 
     public function test_override_fields_ignored_without_ability_on_create(): void
     {
-        $this->makeType();
+        $type = $this->makeType();
         $this->makeUser(['tasks.create']);
 
         $response = $this->withHeader('X-Tenant-ID', 1)
             ->postJson('/api/tasks', [
-                'task_type_id' => 1,
+                'task_type_id' => $type->public_id,
                 'sla_start_at' => '2025-01-01T08:00:00Z',
                 'sla_end_at' => '2025-01-01T17:00:00Z',
             ]);
@@ -93,12 +93,12 @@ class TaskSlaOverrideTest extends TestCase
 
     public function test_override_fields_respected_with_ability_on_create(): void
     {
-        $this->makeType();
+        $type = $this->makeType();
         $this->makeUser(['tasks.create', 'tasks.sla.override']);
 
         $response = $this->withHeader('X-Tenant-ID', 1)
             ->postJson('/api/tasks', [
-                'task_type_id' => 1,
+                'task_type_id' => $type->public_id,
                 'sla_start_at' => '2025-01-01T08:00:00Z',
                 'sla_end_at' => '2025-01-01T17:00:00Z',
             ]);

--- a/backend/tests/Feature/TaskSlaPolicyAbilityTest.php
+++ b/backend/tests/Feature/TaskSlaPolicyAbilityTest.php
@@ -60,7 +60,7 @@ class TaskSlaPolicyAbilityTest extends TestCase
 
         Sanctum::actingAs($manager);
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson("/api/task-types/{$type->id}/sla-policies")
+            ->getJson("/api/task-types/{$type->public_id}/sla-policies")
             ->assertOk();
 
         $viewer = User::create([
@@ -76,7 +76,7 @@ class TaskSlaPolicyAbilityTest extends TestCase
 
         Sanctum::actingAs($viewer);
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson("/api/task-types/{$type->id}/sla-policies")
+            ->getJson("/api/task-types/{$type->public_id}/sla-policies")
             ->assertForbidden();
     }
 }

--- a/backend/tests/Feature/TaskSlaPolicyTest.php
+++ b/backend/tests/Feature/TaskSlaPolicyTest.php
@@ -52,7 +52,7 @@ class TaskSlaPolicyTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/task-types/{$type->id}/sla-policies", [
+            ->postJson("/api/task-types/{$type->public_id}/sla-policies", [
                 'priority' => 'high',
                 'resolve_within_mins' => 120,
                 'calendar_json' => [
@@ -68,7 +68,7 @@ class TaskSlaPolicyTest extends TestCase
 
         $task = $this->withHeader('X-Tenant-ID', $tenant->id)
             ->postJson('/api/tasks', [
-                'task_type_id' => $type->id,
+                'task_type_id' => $type->public_id,
                 'priority' => 'high',
                 'sla_start_at' => '2024-01-01T08:00:00Z',
                 'sla_end_at' => '2024-01-01T17:00:00Z',
@@ -114,14 +114,14 @@ class TaskSlaPolicyTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/task-types/{$type->id}/sla-policies", [
+            ->postJson("/api/task-types/{$type->public_id}/sla-policies", [
                 'priority' => 'high',
                 'resolve_within_mins' => 120,
             ])->assertCreated();
 
         $task = $this->withHeader('X-Tenant-ID', $tenant->id)
             ->postJson('/api/tasks', [
-                'task_type_id' => $type->id,
+                'task_type_id' => $type->public_id,
                 'priority' => 'high',
                 'sla_start_at' => '2025-01-01T08:00:00Z',
                 'sla_end_at' => '2025-01-01T17:00:00Z',
@@ -167,13 +167,13 @@ class TaskSlaPolicyTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/task-types/{$type->id}/sla-policies", [
+            ->postJson("/api/task-types/{$type->public_id}/sla-policies", [
                 'priority' => 'low',
                 'response_within_mins' => 60,
             ])->assertCreated();
 
         $list = $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->getJson("/api/task-types/{$type->id}/sla-policies")
+            ->getJson("/api/task-types/{$type->public_id}/sla-policies")
             ->assertOk()
             ->json('data');
 

--- a/backend/tests/Feature/TaskTypeAbilityTest.php
+++ b/backend/tests/Feature/TaskTypeAbilityTest.php
@@ -80,7 +80,7 @@ class TaskTypeAbilityTest extends TestCase
         return [
             'automations store' => [
                 'POST',
-                fn($type) => ["/api/task-types/{$type->id}/automations", [
+                fn($type) => ["/api/task-types/{$type->public_id}/automations", [
                     'event' => 'status_changed',
                     'conditions_json' => null,
                     'actions_json' => [['type' => 'noop']],

--- a/backend/tests/Feature/TaskTypeBulkActionsTest.php
+++ b/backend/tests/Feature/TaskTypeBulkActionsTest.php
@@ -63,7 +63,7 @@ class TaskTypeBulkActionsTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson('/api/task-types/bulk-delete', ['ids' => [$type1->id, $type2->id]])
+            ->postJson('/api/task-types/bulk-delete', ['ids' => [$type1->public_id, $type2->public_id]])
             ->assertOk();
 
         $this->assertDatabaseMissing('task_types', ['id' => $type1->id]);
@@ -88,7 +88,7 @@ class TaskTypeBulkActionsTest extends TestCase
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
             ->postJson('/api/task-types/bulk-copy-to-tenant', [
-                'ids' => [$type1->id, $type2->id],
+                'ids' => [$type1->public_id, $type2->public_id],
                 'tenant_id' => $targetTenant->id,
             ])
             ->assertStatus(403);
@@ -140,7 +140,7 @@ class TaskTypeBulkActionsTest extends TestCase
 
         $this->withHeader('X-Tenant-ID', $sourceTenant->id)
             ->postJson('/api/task-types/bulk-copy-to-tenant', [
-                'ids' => [$type1->id, $type2->id],
+                'ids' => [$type1->public_id, $type2->public_id],
                 'tenant_id' => $targetTenant->id,
             ])
             ->assertCreated();

--- a/backend/tests/Feature/TaskTypeCreateAbilityTest.php
+++ b/backend/tests/Feature/TaskTypeCreateAbilityTest.php
@@ -132,12 +132,12 @@ class TaskTypeCreateAbilityTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenantA->id)
-            ->getJson("/api/task-types/{$typeB->id}")
+            ->getJson("/api/task-types/{$typeB->public_id}")
             ->assertStatus(403);
 
         // ensure own type is accessible
         $this->withHeader('X-Tenant-ID', $tenantA->id)
-            ->getJson("/api/task-types/{$typeA->id}")
+            ->getJson("/api/task-types/{$typeA->public_id}")
             ->assertOk();
     }
 

--- a/backend/tests/Feature/TaskTypeImportExportTest.php
+++ b/backend/tests/Feature/TaskTypeImportExportTest.php
@@ -48,7 +48,7 @@ class TaskTypeImportExportTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/task-types/{$type->id}/export")
+            ->postJson("/api/task-types/{$type->public_id}/export")
             ->assertOk()
             ->assertJsonFragment(['name' => 'Type']);
 
@@ -101,7 +101,7 @@ class TaskTypeImportExportTest extends TestCase
         ]);
 
         $this->withHeader('X-Tenant-ID', $tenantA->id)
-            ->postJson("/api/task-types/{$otherType->id}/export")
+            ->postJson("/api/task-types/{$otherType->public_id}/export")
             ->assertStatus(403);
     }
 }

--- a/backend/tests/Feature/TaskTypeOptionsTest.php
+++ b/backend/tests/Feature/TaskTypeOptionsTest.php
@@ -98,9 +98,9 @@ class TaskTypeOptionsTest extends TestCase
         $type = TaskType::first();
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson('/api/tasks', ['task_type_id' => $type->id])
+            ->postJson('/api/tasks', ['task_type_id' => $type->public_id])
             ->assertCreated()
-            ->assertJsonPath('data.task_type_id', $type->id);
+            ->assertJsonPath('data.task_type_id', $type->public_id);
     }
 
     public function test_missing_ability_cannot_fetch_options(): void

--- a/backend/tests/Feature/TaskTypePreviewValidationTest.php
+++ b/backend/tests/Feature/TaskTypePreviewValidationTest.php
@@ -61,14 +61,14 @@ class TaskTypePreviewValidationTest extends TestCase
         ];
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/task-types/{$type->id}/validate", [
+            ->postJson("/api/task-types/{$type->public_id}/validate", [
                 'schema_json' => $schema,
                 'form_data' => ['f1' => 'ok'],
             ])
             ->assertOk();
 
         $this->withHeader('X-Tenant-ID', $tenant->id)
-            ->postJson("/api/task-types/{$type->id}/validate", [
+            ->postJson("/api/task-types/{$type->public_id}/validate", [
                 'schema_json' => $schema,
                 'form_data' => [],
             ])


### PR DESCRIPTION
## Summary
- Switch task type feature suites to use public ULID identifiers in API routes and payload assertions
- Update task SLA policy and override tests to reference task type public IDs throughout their requests

## Testing
- composer test *(fails: requires configured application environment and seeded data)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9d653440832391eb748c23b4e120