### PR TITLE
Support hashed identifiers across tenant and team flows

### DIFF
--- a/backend/app/Http/Controllers/Api/TeamController.php
+++ b/backend/app/Http/Controllers/Api/TeamController.php
@@ -5,23 +5,38 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\TeamUpsertRequest;
 use App\Models\Team;
+use App\Models\Tenant;
 use App\Models\User;
 use Illuminate\Http\Request;
 use App\Http\Resources\TeamResource;
 use App\Support\ListQuery;
+use App\Support\PublicIdResolver;
+use Illuminate\Validation\ValidationException;
 
 class TeamController extends Controller
 {
     use ListQuery;
 
+    public function __construct(private PublicIdResolver $publicIdResolver)
+    {
+    }
+
     protected function getTenantId(Request $request): int
     {
         if ($request->user()->isSuperAdmin()) {
-            $tenantId = $request->query('tenant_id', $request->input('tenant_id', $request->header('X-Tenant-ID', app('tenant_id'))));
-            if (! $tenantId) {
+            $tenantIdentifier = $request->query('tenant_id', $request->input('tenant_id', $request->header('X-Tenant-ID', app('tenant_id'))));
+
+            if ($tenantIdentifier === null || $tenantIdentifier === '') {
                 abort(400, 'Tenant ID required');
             }
-            return (int) $tenantId;
+
+            $resolved = $this->resolveTenantIdentifier($tenantIdentifier);
+
+            if ($resolved === null) {
+                abort(404, 'Tenant not found');
+            }
+
+            return $resolved;
         }
 
         return (int) $request->user()->tenant_id;
@@ -35,7 +50,14 @@ class TeamController extends Controller
 
         if ($request->user()->isSuperAdmin()) {
             if ($request->has('tenant_id')) {
-                $query->where('tenant_id', $request->query('tenant_id'));
+                $tenantIdentifier = $request->query('tenant_id');
+                $tenantId = $this->resolveTenantIdentifier($tenantIdentifier);
+
+                if ($tenantId === null && $tenantIdentifier !== null && $tenantIdentifier !== '') {
+                    $query->whereRaw('1 = 0');
+                } elseif ($tenantId !== null) {
+                    $query->where('tenant_id', $tenantId);
+                }
             }
         } else {
             $query->where('tenant_id', $request->user()->tenant_id);
@@ -54,7 +76,11 @@ class TeamController extends Controller
 
         $data = $request->validated();
         $tenantId = $this->getTenantId($request);
-        $data['tenant_id'] = $request->user()->isSuperAdmin() ? ($data['tenant_id'] ?? $tenantId) : $tenantId;
+        if ($request->user()->isSuperAdmin()) {
+            $data['tenant_id'] = $data['tenant_id'] ?? $tenantId;
+        } else {
+            $data['tenant_id'] = $tenantId;
+        }
 
         if (isset($data['lead_id'])) {
             $leadId = User::where('id', $data['lead_id'])
@@ -135,12 +161,16 @@ class TeamController extends Controller
 
         $this->authorize('manageMembers', $team);
 
-        $data = $request->validate([
-            'employee_ids' => ['required', 'array'],
-            'employee_ids.*' => ['integer', 'exists:users,id'],
-        ]);
+        $identifiers = $this->validatedEmployeeIdentifiers($request);
+        $employeeIds = $this->resolveUserIdentifiers($identifiers);
 
-        $employeeIds = User::whereIn('id', $data['employee_ids'])
+        if (count($employeeIds) !== count($identifiers)) {
+            throw ValidationException::withMessages([
+                'employee_ids' => ['One or more employees are invalid.'],
+            ]);
+        }
+
+        $employeeIds = User::whereIn('id', $employeeIds)
             ->where('tenant_id', $tenantId)
             ->pluck('id')
             ->all();
@@ -148,5 +178,109 @@ class TeamController extends Controller
         $team->employees()->sync($employeeIds);
 
         return new TeamResource($team->load(['employees', 'tenant', 'lead']));
+    }
+
+    protected function resolveTenantIdentifier(mixed $identifier): ?int
+    {
+        if ($identifier instanceof Tenant) {
+            return (int) $identifier->getKey();
+        }
+
+        if (is_int($identifier)) {
+            return $identifier;
+        }
+
+        if (is_string($identifier)) {
+            $identifier = trim($identifier);
+
+            if ($identifier === '') {
+                return null;
+            }
+        }
+
+        if ($identifier === null || $identifier === '') {
+            return null;
+        }
+
+        return $this->publicIdResolver->resolve(Tenant::class, $identifier);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function validatedEmployeeIdentifiers(Request $request): array
+    {
+        $input = $request->all();
+
+        if (isset($input['employee_ids']) && is_array($input['employee_ids'])) {
+            $input['employee_ids'] = array_map(static function ($value) {
+                if (is_string($value)) {
+                    return trim($value);
+                }
+
+                return (string) $value;
+            }, $input['employee_ids']);
+        }
+
+        $data = validator($input, [
+            'employee_ids' => ['required', 'array'],
+            'employee_ids.*' => ['string'],
+        ])->validate();
+
+        return $this->normalizeIdentifiers($data['employee_ids']);
+    }
+
+    /**
+     * @param  array<int, string|int|null>  $identifiers
+     * @return array<int, int>
+     */
+    protected function resolveUserIdentifiers(array $identifiers): array
+    {
+        $resolved = [];
+
+        foreach ($identifiers as $identifier) {
+            if ($identifier instanceof User) {
+                $resolved[] = (int) $identifier->getKey();
+                continue;
+            }
+
+            if (is_int($identifier)) {
+                $resolved[] = $identifier;
+                continue;
+            }
+
+            if (is_string($identifier) && $identifier !== '') {
+                $id = $this->publicIdResolver->resolve(User::class, $identifier);
+
+                if ($id !== null) {
+                    $resolved[] = $id;
+                }
+            }
+        }
+
+        return array_values(array_unique($resolved));
+    }
+
+    /**
+     * @param  array<int, string|null>  $identifiers
+     * @return array<int, string>
+     */
+    protected function normalizeIdentifiers(array $identifiers): array
+    {
+        $normalized = [];
+
+        foreach ($identifiers as $identifier) {
+            if (is_string($identifier)) {
+                $identifier = trim($identifier);
+            }
+
+            if ($identifier === null || $identifier === '') {
+                continue;
+            }
+
+            $normalized[] = is_string($identifier) ? $identifier : (string) $identifier;
+        }
+
+        return array_values(array_unique($normalized));
     }
 }

--- a/backend/app/Http/Requests/TaskUpsertRequest.php
+++ b/backend/app/Http/Requests/TaskUpsertRequest.php
@@ -80,6 +80,33 @@ class TaskUpsertRequest extends FormRequest
         return $rules;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $assignee = $this->input('assignee');
+
+        if (is_array($assignee)) {
+            $id = $assignee['id'] ?? null;
+            $publicId = $assignee['public_id'] ?? null;
+
+            if ($publicId && ($id === null || is_numeric($id))) {
+                $assignee['id'] = $publicId;
+                $this->merge(['assignee' => $assignee]);
+            }
+        }
+
+        if ($this->has('assigned_user_id') && is_numeric($this->input('assigned_user_id'))) {
+            $this->merge(['assigned_user_id' => (string) $this->input('assigned_user_id')]);
+        }
+
+        if ($this->has('client_id') && is_numeric($this->input('client_id'))) {
+            $this->merge(['client_id' => (string) $this->input('client_id')]);
+        }
+
+        if ($this->has('task_type_id') && is_numeric($this->input('task_type_id'))) {
+            $this->merge(['task_type_id' => (string) $this->input('task_type_id')]);
+        }
+    }
+
     public function attributes(): array
     {
         return [

--- a/backend/app/Support/PublicIdResolver.php
+++ b/backend/app/Support/PublicIdResolver.php
@@ -3,6 +3,7 @@
 namespace App\Support;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class PublicIdResolver
 {
@@ -41,7 +42,13 @@ class PublicIdResolver
         }
 
         /** @var class-string<Model> $modelClass */
-        return $this->cache[$cacheKey] = $modelClass::query()
+        $query = $modelClass::query();
+
+        if (in_array(SoftDeletes::class, class_uses_recursive($modelClass), true)) {
+            $query->withTrashed();
+        }
+
+        return $this->cache[$cacheKey] = $query
             ->where('public_id', $identifier)
             ->value('id');
     }


### PR DESCRIPTION
## Summary
- resolve public identifier lookups against soft-deleted records so hashed IDs map reliably
- normalize tenant and employee identifiers throughout tenant and team controllers, including bulk operations and scoped guards
- preprocess task upsert payloads so numeric identifiers are treated as hashed public IDs before validation

## Testing
- `php artisan test` *(fails: existing suite still reports authorization- and environment-related errors)*
- `php artisan test --filter=TaskTypeOptionsTest` *(fails: routes still respond with 404/403 pending broader ability wiring)*
- `php artisan test --filter=TeamsTest`
- `php artisan test --filter=TaskWatcherTest`
- `php artisan test --filter=AssigneesExcludeTenantTest` *(fails: lookup ability expectations unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68cea16231848323bd63122b4d3f57c1