### PR TITLE
refactor: normalize store IDs to strings

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -87,7 +87,7 @@ export const useAuthStore = defineStore('auth', {
     abilities: [] as string[],
     clientAbilities: [] as string[],
     features: [] as string[],
-    permittedClientIds: [] as Array<string | number>,
+    permittedClientIds: [] as string[],
   }),
   getters: {
     isAuthenticated: (state) => !!state.accessToken,
@@ -142,7 +142,7 @@ export const useAuthStore = defineStore('auth', {
         return {
           ...params,
           client_ids: [...state.permittedClientIds],
-        } as T & { client_ids: Array<string | number> };
+        } as T & { client_ids: string[] };
       };
     },
   },
@@ -166,7 +166,7 @@ export const useAuthStore = defineStore('auth', {
       this.clientAbilities = data.client_abilities || [];
       this.features = data.features || [];
       this.permittedClientIds = Array.isArray(data.permitted_client_ids)
-        ? data.permitted_client_ids
+        ? data.permitted_client_ids.map((id: string | number) => String(id))
         : [];
       const tenantStore = useTenantStore();
       const tenantId = data.user?.tenant_id || '';

--- a/frontend/src/stores/manuals.ts
+++ b/frontend/src/stores/manuals.ts
@@ -32,9 +32,10 @@ export const useManualsStore = defineStore('manuals', {
         this.manuals = [];
       }
     },
-    async get(id: string) {
+    async get(id: string | number) {
       if (!this.manuals.length) await this.fetch();
-      return this.manuals.find((m: any) => m.id == id);
+      const identifier = String(id);
+      return this.manuals.find((m: any) => String(m.id) === identifier);
     },
     async downloadPdf(id: string) {
       const { data } = await api.get(`/manuals/${id}/download`, {

--- a/frontend/src/stores/notifications.ts
+++ b/frontend/src/stores/notifications.ts
@@ -31,9 +31,10 @@ export const useNotificationStore = defineStore('notifications', {
         (n: Notification) => !n.read_at,
       ).length;
     },
-    async markRead(id: number) {
-      await api.post(`/notifications/${id}/read`);
-      const notif = this.notifications.find((n) => n.id === id);
+    async markRead(id: string | number) {
+      const identifier = String(id);
+      await api.post(`/notifications/${identifier}/read`);
+      const notif = this.notifications.find((n) => String(n.id) === identifier);
       if (notif) {
         notif.read_at = new Date().toISOString();
       }

--- a/frontend/src/stores/roles.ts
+++ b/frontend/src/stores/roles.ts
@@ -20,7 +20,10 @@ export const useRolesStore = defineStore('roles', {
   }),
   actions: {
     async fetch(params: ListParams = {}) {
-      const qp = withListParams(params);
+      const qp = withListParams({ ...params });
+      if (qp.tenant_id != null) {
+        qp.tenant_id = String(qp.tenant_id);
+      }
       // When requesting all roles as a super admin we should not
       // send the tenant_id parameter. Providing it would instruct
       // the backend to limit the results to that tenant, preventing
@@ -36,28 +39,31 @@ export const useRolesStore = defineStore('roles', {
       const { data } = await api.post('/roles', payload);
       return data as Role;
     },
-    async update(id: number, payload: RolePayload) {
-      const { data } = await api.patch(`/roles/${id}`, payload);
+    async update(id: string | number, payload: RolePayload) {
+      const identifier = String(id);
+      const { data } = await api.patch(`/roles/${identifier}`, payload);
       return data as Role;
     },
-    async remove(id: number) {
-      await api.delete(`/roles/${id}`);
-      this.roles = this.roles.filter((r: Role) => r.id !== id);
+    async remove(id: string | number) {
+      const identifier = String(id);
+      await api.delete(`/roles/${identifier}`);
+      this.roles = this.roles.filter((r: Role) => String(r.id) !== identifier);
     },
-    async deleteMany(ids: number[]) {
-      await Promise.all(ids.map((id) => api.delete(`/roles/${id}`)));
-      this.roles = this.roles.filter((r: Role) => !ids.includes(r.id as number));
+    async deleteMany(ids: Array<string | number>) {
+      const identifiers = ids.map((id) => String(id));
+      await Promise.all(identifiers.map((id) => api.delete(`/roles/${id}`)));
+      this.roles = this.roles.filter((r: Role) => !identifiers.includes(String(r.id)));
     },
-    async assignUser(roleId: number, payload: AssignPayload) {
-      await api.post(`/roles/${roleId}/assign`, payload);
+    async assignUser(roleId: string | number, payload: AssignPayload) {
+      await api.post(`/roles/${String(roleId)}/assign`, payload);
     },
-    async copyToTenant(id: number, tenantId?: string | number) {
+    async copyToTenant(id: string | number, tenantId?: string | number) {
       const payload: any = {};
-      if (tenantId) payload.tenant_id = tenantId;
-      const { data } = await api.post(`/roles/${id}/copy-to-tenant`, payload);
+      if (tenantId) payload.tenant_id = String(tenantId);
+      const { data } = await api.post(`/roles/${String(id)}/copy-to-tenant`, payload);
       return data as Role;
     },
-    async copyManyToTenant(ids: number[], tenantId?: string | number) {
+    async copyManyToTenant(ids: Array<string | number>, tenantId?: string | number) {
       for (const id of ids) {
         await this.copyToTenant(id, tenantId);
       }

--- a/frontend/src/stores/taskStatuses.ts
+++ b/frontend/src/stores/taskStatuses.ts
@@ -19,30 +19,35 @@ export const useTaskStatusesStore = defineStore('taskStatuses', {
       let query: any;
       if (typeof scopeOrParams === 'string') {
         query = withListParams({ scope: scopeOrParams, ...params });
-        if (tenantId) query.tenant_id = tenantId;
+        if (tenantId) query.tenant_id = String(tenantId);
       } else {
-        query = withListParams(scopeOrParams);
+        query = withListParams({
+          ...scopeOrParams,
+          ...(scopeOrParams.tenant_id != null
+            ? { tenant_id: String(scopeOrParams.tenant_id) }
+            : {}),
+        });
       }
       const { data } = await api.get('/task-statuses', { params: query });
       return data;
     },
-    async fetchTransitions(id: number) {
-      const { data } = await api.get(`/task-statuses/${id}/transitions`);
+    async fetchTransitions(id: string | number) {
+      const { data } = await api.get(`/task-statuses/${String(id)}/transitions`);
       return data;
     },
-    async copyToTenant(id: number, tenantId?: string | number) {
+    async copyToTenant(id: string | number, tenantId?: string | number) {
       const payload: any = {};
-      if (tenantId) payload.tenant_id = tenantId;
-      const { data } = await api.post(`/task-statuses/${id}/copy-to-tenant`, payload);
+      if (tenantId) payload.tenant_id = String(tenantId);
+      const { data } = await api.post(`/task-statuses/${String(id)}/copy-to-tenant`, payload);
       return data;
     },
-    async copyManyToTenant(ids: number[], tenantId?: string | number) {
+    async copyManyToTenant(ids: Array<string | number>, tenantId?: string | number) {
       for (const id of ids) {
         await this.copyToTenant(id, tenantId);
       }
     },
-    async deleteMany(ids: number[]) {
-      await Promise.all(ids.map((id) => api.delete(`/task-statuses/${id}`)));
+    async deleteMany(ids: Array<string | number>) {
+      await Promise.all(ids.map((id) => api.delete(`/task-statuses/${String(id)}`)));
     },
   },
 });

--- a/frontend/src/stores/taskTypes.ts
+++ b/frontend/src/stores/taskTypes.ts
@@ -10,28 +10,30 @@ export const useTaskTypesStore = defineStore('taskTypes', {
       params: ListParams = {},
     ) {
       const query: any = withListParams({ scope, ...params });
-      if (tenantId) query.tenant_id = tenantId;
+      if (tenantId) query.tenant_id = String(tenantId);
       const { data } = await api.get('/task-types', { params: query });
       return data;
     },
-    async copyToTenant(id: number, tenantId?: string | number) {
+    async copyToTenant(id: string | number, tenantId?: string | number) {
       const payload: any = {};
-      if (tenantId) payload.tenant_id = tenantId;
-      const { data } = await api.post(`/task-types/${id}/copy-to-tenant`, payload);
+      if (tenantId) payload.tenant_id = String(tenantId);
+      const { data } = await api.post(`/task-types/${String(id)}/copy-to-tenant`, payload);
       return data;
     },
-    async copyManyToTenant(ids: number[], tenantId?: string | number) {
-      const payload: any = { ids };
-      if (tenantId) payload.tenant_id = tenantId;
+    async copyManyToTenant(ids: Array<string | number>, tenantId?: string | number) {
+      const payload: any = { ids: ids.map((value) => String(value)) };
+      if (tenantId) payload.tenant_id = String(tenantId);
       const { data } = await api.post('/task-types/bulk-copy-to-tenant', payload);
       return data;
     },
-    async deleteMany(ids: number[]) {
-      const { data } = await api.post('/task-types/bulk-delete', { ids });
+    async deleteMany(ids: Array<string | number>) {
+      const { data } = await api.post('/task-types/bulk-delete', {
+        ids: ids.map((value) => String(value)),
+      });
       return data;
     },
-    async export(id: number) {
-      const { data } = await api.post(`/task-types/${id}/export`);
+    async export(id: string | number) {
+      const { data } = await api.post(`/task-types/${String(id)}/export`);
       return data;
     },
     async import(payload: any) {

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -43,9 +43,10 @@ export const useTasksStore = defineStore('tasks', {
         this.tasks = [];
       }
     },
-    async get(id: string) {
+    async get(id: string | number) {
       if (!this.tasks.length) await this.fetch();
-      return this.tasks.find((a: any) => a.id == id);
+      const identifier = String(id);
+      return this.tasks.find((a: any) => String(a.id) === identifier);
     },
     async create(payload: any) {
       const res = await api.post('/tasks', this.toPayload(payload));
@@ -53,10 +54,11 @@ export const useTasksStore = defineStore('tasks', {
       this.tasks.push(task);
       return task;
     },
-    async update(id: string, payload: any) {
-      const { data: updated } = await api.patch(`/tasks/${id}`, this.toPayload(payload));
+    async update(id: string | number, payload: any) {
+      const identifier = String(id);
+      const { data: updated } = await api.patch(`/tasks/${identifier}`, this.toPayload(payload));
       const task = this.normalize(updated);
-      this.tasks = this.tasks.map((a: any) => (a.id === id ? task : a));
+      this.tasks = this.tasks.map((a: any) => (String(a.id) === identifier ? task : a));
       return task;
     },
   },


### PR DESCRIPTION
## Summary
- remove numeric coercion from the clients store and send tenant IDs as raw strings
- ensure stores handling roles, teams, tasks, notifications, and manuals compare and forward IDs using string equality
- persist permitted client identifiers as strings to match regenerated API typings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cebe39ebf483238230d8bfd08aac83