### PR TITLE
Normalize hashed ID handling across frontend

### DIFF
--- a/frontend/src/components/admin/TenantSwitcher.vue
+++ b/frontend/src/components/admin/TenantSwitcher.vue
@@ -26,9 +26,7 @@ const props = defineProps({
 // Initialize the selection with the current tenant. For super admins that
 // start without a tenant context this ensures the "Super Admin" option is
 // considered selected so choosing it again later is a no-op.
-const selected = ref<string | number | null>(
-  tenantStore.currentTenantId || 'super_admin',
-);
+const selected = ref<string>(tenantStore.currentTenantId || 'super_admin');
 const options = computed(() =>
   tenantStore.tenants.map((t) => ({ value: String(t.id), label: t.name })),
 );
@@ -49,7 +47,7 @@ watch(
 watch(selected, async (val) => {
   // Selecting the synthetic "Super Admin" tenant should not trigger an
   // impersonation request. Instead reset the tenant context.
-  if (String(val) === 'super_admin') {
+  if (val === 'super_admin') {
     tenantStore.setTenant('');
     if (props.impersonate && authStore.isImpersonating) {
       await authStore.unimpersonate();
@@ -58,7 +56,7 @@ watch(selected, async (val) => {
     return;
   }
 
-  const tenant = tenantStore.tenants.find((t) => String(t.id) === String(val));
+  const tenant = tenantStore.tenants.find((t) => String(t.id) === val);
   if (tenant && String(tenant.id) !== tenantStore.currentTenantId) {
     if (props.impersonate) {
       await authStore.impersonate(tenant.id, tenant.name);

--- a/frontend/src/components/employees/EmployeesTable.vue
+++ b/frontend/src/components/employees/EmployeesTable.vue
@@ -172,7 +172,7 @@ import api from '@/services/api';
 import { useNotify } from '@/plugins/notify';
 
 interface EmployeeRow {
-  id: number;
+  id: string;
   name: string;
   email: string;
   roles: string;
@@ -180,20 +180,20 @@ interface EmployeeRow {
   phone?: string | null;
   status?: string | null;
   last_login_at?: string | null;
-  tenant?: { id: number; name: string } | null;
-  tenant_id?: number | null;
+  tenant?: { id: string; name: string } | null;
+  tenant_id?: string | null;
   avatar?: string | null;
 }
 
 const props = defineProps<{ rows: EmployeeRow[] }>();
 const emit = defineEmits<{
-  (e: 'edit', id: number): void;
-  (e: 'delete', id: number): void;
-  (e: 'delete-selected', ids: number[]): void;
-  (e: 'impersonate', id: number): void;
-  (e: 'resend-invite', id: number): void;
-  (e: 'reset-email', id: number): void;
-  (e: 'send-password-reset', id: number): void;
+  (e: 'edit', id: string): void;
+  (e: 'delete', id: string): void;
+  (e: 'delete-selected', ids: string[]): void;
+  (e: 'impersonate', id: string): void;
+  (e: 'resend-invite', id: string): void;
+  (e: 'reset-email', id: string): void;
+  (e: 'send-password-reset', id: string): void;
 }>();
 
 const { t } = useI18n();
@@ -228,7 +228,7 @@ const columns = [
   { label: 'Actions', field: 'actions' },
 ];
 
-const selectedIds = ref<number[]>([]);
+const selectedIds = ref<string[]>([]);
 
 const filteredRows = computed(() => {
   const term = searchTerm.value.toLowerCase();
@@ -247,14 +247,15 @@ const filteredRows = computed(() => {
 });
 
 function onSelectedRowsChange(params: any) {
-  selectedIds.value = params.selectedRows.map((r: any) => r.id);
+  selectedIds.value = params.selectedRows.map((r: any) => String(r.id));
 }
 
 async function toggleStatus(row: EmployeeRow, val: boolean) {
   const previous = row.status;
   row.status = val ? 'active' : 'inactive';
   try {
-    const { data } = await api.patch(`/employees/${row.id}/toggle-status`);
+    const id = String(row.id);
+    const { data } = await api.patch(`/employees/${id}/toggle-status`);
     row.status = data.data?.status ?? row.status;
   } catch (e) {
     row.status = previous;

--- a/frontend/src/components/fields/PhotoRepeater.vue
+++ b/frontend/src/components/fields/PhotoRepeater.vue
@@ -53,7 +53,7 @@ import InputGroup from '@dc/components/InputGroup';
 import Icon from '@dc/components/Icon';
 import { resolveI18n } from '@/utils/i18n';
 
-const props = defineProps<{ photo: any; sectionKey: string; taskId: number; modelValue: any[] }>();
+const props = defineProps<{ photo: any; sectionKey: string; taskId: string; modelValue: any[] }>();
 const emit = defineEmits<{ (e: 'update:modelValue', v: any[]): void }>();
 const { t, locale } = useI18n();
 

--- a/frontend/src/components/fields/PhotoUpload.vue
+++ b/frontend/src/components/fields/PhotoUpload.vue
@@ -50,7 +50,7 @@ import InputGroup from '@dc/components/InputGroup';
 import Icon from '@dc/components/Icon';
 import { resolveI18n } from '@/utils/i18n';
 
-const props = defineProps<{ photo: any; sectionKey: string; taskId: number; modelValue: any }>();
+const props = defineProps<{ photo: any; sectionKey: string; taskId: string; modelValue: any }>();
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>();
 const { t, locale } = useI18n();
 

--- a/frontend/src/components/forms/JsonSchemaForm.vue
+++ b/frontend/src/components/forms/JsonSchemaForm.vue
@@ -22,7 +22,7 @@ import { reactive, watch } from 'vue';
 import SectionCard from '@/components/tasks/SectionCard.vue';
 import { evaluateLogic } from '@/utils/logic';
 
-const props = defineProps<{ schema: any; modelValue: any; taskId: number; readonly?: boolean }>();
+const props = defineProps<{ schema: any; modelValue: any; taskId: string; readonly?: boolean }>();
 const emit = defineEmits<{ (e: 'update:modelValue', value: any): void }>();
 
 const form = reactive<any>({ ...props.modelValue });

--- a/frontend/src/components/roles/RolesTable.vue
+++ b/frontend/src/components/roles/RolesTable.vue
@@ -159,26 +159,26 @@ import { useI18n } from 'vue-i18n';
 import { useAuthStore, can } from '@/stores/auth';
 
 interface RoleRow {
-  id: number;
+  id: string;
   name: string;
   description?: string | null;
   level: number;
   abilities?: string[];
   created_at?: string;
   updated_at?: string;
-  tenant?: { id: number; name: string } | null;
-  tenant_id?: number | null;
+  tenant?: { id: string; name: string } | null;
+  tenant_id?: string | null;
   users_count: number;
 }
 
 const props = defineProps<{ rows: RoleRow[] }>();
 const emit = defineEmits<{
-  (e: 'edit', id: number): void;
-  (e: 'delete', id: number): void;
-  (e: 'assign', id: number): void;
-  (e: 'copy', id: number): void;
-  (e: 'delete-selected', ids: number[]): void;
-  (e: 'copy-selected', ids: number[]): void;
+  (e: 'edit', id: string): void;
+  (e: 'delete', id: string): void;
+  (e: 'assign', id: string): void;
+  (e: 'copy', id: string): void;
+  (e: 'delete-selected', ids: string[]): void;
+  (e: 'copy-selected', ids: string[]): void;
 }>();
 
 const { t } = useI18n();
@@ -215,7 +215,7 @@ const columns = computed(() => [
   { label: 'Actions', field: 'actions' },
 ]);
 
-const selectedIds = ref<number[]>([]);
+const selectedIds = ref<string[]>([]);
 
 const filteredRows = computed(() => {
   const rows = !searchTerm.value
@@ -227,7 +227,7 @@ const filteredRows = computed(() => {
 });
 
 function onSelectedRowsChange(params: any) {
-  selectedIds.value = params.selectedRows.map((r: any) => r.id);
+  selectedIds.value = params.selectedRows.map((r: any) => String(r.id));
 }
 
 function formatDate(d: string) {

--- a/frontend/src/components/statuses/TaskStatusesTable.vue
+++ b/frontend/src/components/statuses/TaskStatusesTable.vue
@@ -131,7 +131,7 @@ import { useI18n } from 'vue-i18n';
 import { useAuthStore, can } from '@/stores/auth';
 
 interface TaskStatus {
-  id: number;
+  id: string;
   name: string;
   slug: string;
   color: string;
@@ -139,17 +139,17 @@ interface TaskStatus {
   tasks_count: number;
   created_at: string;
   updated_at: string;
-  tenant?: { id: number; name: string } | null;
-  tenant_id?: number | null;
+  tenant?: { id: string; name: string } | null;
+  tenant_id?: string | null;
 }
 
 const props = defineProps<{ rows: TaskStatus[] }>();
 const emit = defineEmits<{
-  (e: 'edit', id: number): void;
-  (e: 'delete', id: number): void;
-  (e: 'copy', id: number): void;
-  (e: 'delete-selected', ids: number[]): void;
-  (e: 'copy-selected', ids: number[]): void;
+  (e: 'edit', id: string): void;
+  (e: 'delete', id: string): void;
+  (e: 'copy', id: string): void;
+  (e: 'delete-selected', ids: string[]): void;
+  (e: 'copy-selected', ids: string[]): void;
 }>();
 
 const { t } = useI18n();
@@ -186,7 +186,7 @@ const columns = [
   { label: 'Actions', field: 'actions' },
 ];
 
-const selectedIds = ref<number[]>([]);
+const selectedIds = ref<string[]>([]);
 
 const filteredRows = computed(() => {
   const rows = !searchTerm.value
@@ -198,7 +198,7 @@ const filteredRows = computed(() => {
 });
 
 function onSelectedRowsChange(params: any) {
-  selectedIds.value = params.selectedRows.map((r: any) => r.id);
+  selectedIds.value = params.selectedRows.map((r: any) => String(r.id));
 }
 
 function formatDate(d: string) {

--- a/frontend/src/components/tasks/AssigneePicker.vue
+++ b/frontend/src/components/tasks/AssigneePicker.vue
@@ -21,7 +21,7 @@ import { useLookupsStore } from '@/stores/lookups';
 import { useAuthStore } from '@/stores/auth';
 
 interface AssigneeValue {
-  id: number;
+  id: string;
 }
 
 const props = defineProps<{
@@ -43,14 +43,15 @@ onMounted(async () => {
   }
   if (props.modelValue) {
     const list = lookups.assignees.employees;
-    selected.value = list.find((a: any) => a.id === props.modelValue?.id) || null;
+    selected.value =
+      list.find((a: any) => String(a.id) === String(props.modelValue?.id)) || null;
   }
 });
 
 watch(
   selected,
   (val) => {
-    if (val) emit('update:modelValue', { id: val.id });
+    if (val) emit('update:modelValue', { id: String(val.id) });
     else emit('update:modelValue', null);
   },
   { deep: true },
@@ -64,7 +65,8 @@ watch(
       return;
     }
     const list = lookups.assignees.employees;
-    selected.value = list.find((a: any) => a.id === val.id) || null;
+    selected.value =
+      list.find((a: any) => String(a.id) === String(val.id)) || null;
   },
   { deep: true },
 );

--- a/frontend/src/components/tasks/PhotoField.vue
+++ b/frontend/src/components/tasks/PhotoField.vue
@@ -28,7 +28,7 @@ import { ref, watch } from 'vue';
 import { uploadFile } from '@/services/uploader';
 import { useI18n } from 'vue-i18n';
 
-const props = defineProps<{ photo: any; sectionKey: string; taskId: number; modelValue: any }>();
+const props = defineProps<{ photo: any; sectionKey: string; taskId: string; modelValue: any }>();
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>();
 const { t } = useI18n();
 

--- a/frontend/src/components/tasks/PhotoRepeater.vue
+++ b/frontend/src/components/tasks/PhotoRepeater.vue
@@ -30,7 +30,7 @@ import { ref, watch } from 'vue';
 import { uploadFile } from '@/services/uploader';
 import { useI18n } from 'vue-i18n';
 
-const props = defineProps<{ photo: any; sectionKey: string; taskId: number; modelValue: any[] }>();
+const props = defineProps<{ photo: any; sectionKey: string; taskId: string; modelValue: any[] }>();
 const emit = defineEmits<{ (e: 'update:modelValue', v: any[]): void }>();
 const { t } = useI18n();
 

--- a/frontend/src/components/tasks/SectionCard.vue
+++ b/frontend/src/components/tasks/SectionCard.vue
@@ -481,7 +481,16 @@ import { resolveI18n } from '@/utils/i18n';
 import UiTabs from '@/components/ui/Tabs/index.vue';
 import { Tab, TabPanel } from '@headlessui/vue';
 
-const props = defineProps<{ section: any; form: any; errors: Record<string, string>; taskId: number; readonly?: boolean; visible: Set<string>; required: Set<string>; showTargets: Set<string> }>();
+const props = defineProps<{
+  section: any;
+  form: any;
+  errors: Record<string, string>;
+  taskId: string;
+  readonly?: boolean;
+  visible: Set<string>;
+  required: Set<string>;
+  showTargets: Set<string>;
+}>();
 const emit = defineEmits<{ (e: 'update', payload: { key: string; value: any }): void; (e: 'error', payload: { key: string; msg: string }): void }>();
 
 const { t, locale } = useI18n();

--- a/frontend/src/components/tasks/SubtaskList.vue
+++ b/frontend/src/components/tasks/SubtaskList.vue
@@ -60,7 +60,7 @@ import { useI18n } from 'vue-i18n';
 import api from '@/services/api';
 import draggable from 'vuedraggable';
 
-const props = defineProps<{ taskId: number }>();
+const props = defineProps<{ taskId: string }>();
 const { t } = useI18n();
 const items = ref<any[]>([]);
 const newTitle = ref('');

--- a/frontend/src/components/teams/TeamsTable.vue
+++ b/frontend/src/components/teams/TeamsTable.vue
@@ -138,22 +138,26 @@ import { useI18n } from 'vue-i18n';
 import { can } from '@/stores/auth';
 
 interface TeamRow {
-  id: number;
+  id: string;
   name: string;
   description: string | null;
   members: { name: string; avatar?: string | null }[];
-  lead?: { id: number; name: string; avatar?: string | null } | null;
+  lead?: { id: string; name: string; avatar?: string | null } | null;
   created_at: string;
   updated_at: string;
-  tenant?: { id: number; name: string } | null;
-  tenant_id?: number | null;
+  tenant?: { id: string; name: string } | null;
+  tenant_id?: string | null;
 }
 
 const props = withDefaults(
   defineProps<{ rows: TeamRow[]; isSuperAdmin?: boolean }>(),
   { isSuperAdmin: false },
 );
-const emit = defineEmits<{ (e: 'edit', id: number): void; (e: 'delete', id: number): void; (e: 'delete-selected', ids: number[]): void; }>();
+const emit = defineEmits<{
+  (e: 'edit', id: string): void;
+  (e: 'delete', id: string): void;
+  (e: 'delete-selected', ids: string[]): void;
+}>();
 
 const { t } = useI18n();
 const searchTerm = ref('');
@@ -190,7 +194,7 @@ const columns = computed(() => {
   return cols;
 });
 
-const selectedIds = ref<number[]>([]);
+const selectedIds = ref<string[]>([]);
 
 const filteredRows = computed(() => {
   const rows = !searchTerm.value
@@ -202,7 +206,7 @@ const filteredRows = computed(() => {
 });
 
 function onSelectedRowsChange(params: any) {
-  selectedIds.value = params.selectedRows.map((r: any) => r.id);
+  selectedIds.value = params.selectedRows.map((r: any) => String(r.id));
 }
 
 function truncateDescription(desc: string) {

--- a/frontend/src/components/types/TaskTypesTable.vue
+++ b/frontend/src/components/types/TaskTypesTable.vue
@@ -125,9 +125,9 @@ import { useAuthStore } from '@/stores/auth';
 import { formatDisplay } from '@/utils/datetime';
 
 interface TaskType {
-  id: number;
+  id: string;
   name: string;
-  tenant?: { id: number; name: string } | null;
+  tenant?: { id: string; name: string } | null;
   statuses?: Record<string, string[]>;
   tasks_count?: number;
   updated_at?: string;
@@ -136,11 +136,11 @@ interface TaskType {
 
 const props = defineProps<{ rows: TaskType[] }>();
 const emit = defineEmits<{
-  (e: 'edit', id: number): void;
-  (e: 'delete', id: number): void;
-  (e: 'copy', id: number): void;
-  (e: 'delete-selected', ids: number[]): void;
-  (e: 'copy-selected', ids: number[]): void;
+  (e: 'edit', id: string): void;
+  (e: 'delete', id: string): void;
+  (e: 'copy', id: string): void;
+  (e: 'delete-selected', ids: string[]): void;
+  (e: 'copy-selected', ids: string[]): void;
 }>();
 
 const { t } = useI18n();
@@ -182,7 +182,7 @@ const columns = computed(() => {
   return base;
 });
 
-const selectedIds = ref<number[]>([]);
+const selectedIds = ref<string[]>([]);
 
 const filteredRows = computed(() => {
   const rows = !searchTerm.value
@@ -202,6 +202,6 @@ function onSelectedRowsChange(params: any) {
     selectedIds.value = [];
     return;
   }
-  selectedIds.value = params.selectedRows.map((r: any) => r.id);
+  selectedIds.value = params.selectedRows.map((r: any) => String(r.id));
 }
 </script>

--- a/frontend/src/components/types/TypeMetaBar.vue
+++ b/frontend/src/components/types/TypeMetaBar.vue
@@ -80,15 +80,15 @@ import Switch from '@/components/ui/Switch/index.vue';
 import { useTenantStore } from '@/stores/tenant';
 
 interface Option {
-  value: number | null;
+  value: string | null;
   label: string;
 }
 
 const props = withDefaults(
   defineProps<{
     name: string;
-    tenantId: number | '';
-    clientId?: number | '';
+    tenantId: string;
+    clientId?: string;
     showTenantSelect?: boolean;
     requireSubtasksComplete: boolean;
     clientOptions?: Option[];
@@ -98,6 +98,7 @@ const props = withDefaults(
   {
     showTenantSelect: true,
     requireSubtasksComplete: false,
+    tenantId: '',
     clientId: '',
     clientOptions: () => [],
     loadingClients: false,
@@ -106,8 +107,8 @@ const props = withDefaults(
 );
 const emit = defineEmits<{
   (e: 'update:name', value: string): void;
-  (e: 'update:tenantId', value: number | ''): void;
-  (e: 'update:clientId', value: number | ''): void;
+  (e: 'update:tenantId', value: string): void;
+  (e: 'update:clientId', value: string): void;
   (e: 'update:requireSubtasksComplete', value: boolean): void;
 }>();
 
@@ -119,7 +120,7 @@ watchEffect(() => {
   const tenants = tenantStore.tenants;
   tenantOptions.value = [
     { value: null, label: t('types.form.global') },
-    ...tenants.map((tenant: any) => ({ value: tenant.id, label: tenant.name })),
+    ...tenants.map((tenant: any) => ({ value: String(tenant.id), label: tenant.name })),
   ];
 });
 
@@ -130,12 +131,12 @@ const localName = computed({
 
 const localTenantId = computed<any>({
   get: () => (props.tenantId === '' ? null : props.tenantId),
-  set: (v: number | null) => emit('update:tenantId', v === null ? '' : Number(v)),
+  set: (v: string | null) => emit('update:tenantId', v === null ? '' : String(v)),
 });
 
 const localClientId = computed<any>({
   get: () => (props.clientId === '' ? null : props.clientId),
-  set: (v: number | null) => emit('update:clientId', v === null ? '' : Number(v)),
+  set: (v: string | null) => emit('update:clientId', v === null ? '' : String(v)),
 });
 
 const localRequireSubtasksComplete = computed({
@@ -150,7 +151,7 @@ const tenantDisplayName = computed(() => {
     return t('types.form.global');
   }
   const option = tenantOptions.value.find(
-    (item) => item.value !== null && Number(item.value) === Number(localTenantId.value),
+    (item) => item.value !== null && String(item.value) === String(localTenantId.value),
   );
   if (option) {
     return option.label;

--- a/frontend/src/services/featureGrants.ts
+++ b/frontend/src/services/featureGrants.ts
@@ -13,7 +13,7 @@ function abilityHash(abilities: string[]): string {
 }
 
 export async function ensureHiddenRole(
-  tenantId: string | number,
+  tenantId: string,
   feature: string,
   abilities: string[],
 ): Promise<components['schemas']['Role']> {
@@ -36,28 +36,28 @@ export async function ensureHiddenRole(
 }
 
 export async function assignHiddenRoleToUser(
-  userId: number,
+  userId: string,
   roleId: number,
 ): Promise<void> {
   await api.post(`/roles/${roleId}/assign`, { user_id: userId });
 }
 
 export async function removeHiddenRoleFromUser(
-  userId: number,
+  userId: string,
   roleId: number,
 ): Promise<void> {
   await api.delete(`/roles/${roleId}/assign`, { data: { user_id: userId } });
 }
 
 export async function assignHiddenRoleToTeam(
-  teamId: number,
+  teamId: string,
   roleId: number,
 ): Promise<void> {
   await api.post(`/roles/${roleId}/assign`, { team_id: teamId });
 }
 
 export async function removeHiddenRoleFromTeam(
-  teamId: number,
+  teamId: string,
   roleId: number,
 ): Promise<void> {
   await api.delete(`/roles/${roleId}/assign`, { data: { team_id: teamId } });

--- a/frontend/src/services/uploader.ts
+++ b/frontend/src/services/uploader.ts
@@ -5,7 +5,7 @@ export interface UploadOptions {
   onProgress?: (percent: number) => void;
   fieldKey?: string;
   sectionKey?: string;
-  taskId?: number;
+  taskId?: string;
 }
 
 export const DEFAULT_CHUNK_SIZE = 1024 * 1024; // 1MB default, backend allows up to 5MB
@@ -41,12 +41,16 @@ export async function uploadFile(file: File, options: UploadOptions = {}) {
     }
   }
 
-  const { data } = await api.post(`/uploads/${uploadId}/finalize`, {
+  const payload: Record<string, any> = {
     filename: file.name,
-    task_id: options.taskId,
     field_key: options.fieldKey,
     section_key: options.sectionKey,
-  });
+  };
+  if (options.taskId != null && options.taskId !== '') {
+    payload.task_id = options.taskId;
+  }
+
+  const { data } = await api.post(`/uploads/${uploadId}/finalize`, payload);
 
   return data;
 }

--- a/frontend/src/views/employees/EmployeeForm.vue
+++ b/frontend/src/views/employees/EmployeeForm.vue
@@ -100,7 +100,7 @@ const form = ref({
   roles: [] as string[],
 });
 
-const tenantId = ref<string | number | ''>('');
+const tenantId = ref<string>('');
 const featureGrants = ref<Record<string, string[]>>({});
 const hiddenRoles = ref<Record<string, any>>({});
 
@@ -159,10 +159,10 @@ async function submit() {
     address: form.value.address,
     roles: form.value.roles.filter((r) => r !== 'SuperAdmin'),
   };
-  let userId: number;
+  let userId: string;
   const selectedTenant = auth.isSuperAdmin
     ? String(tenantId.value)
-    : tenantStore.tenantId;
+    : String(tenantStore.tenantId ?? tenantId.value ?? '');
   const previousTenant = tenantStore.tenantId;
   if (auth.isSuperAdmin) {
     tenantStore.setTenant(selectedTenant);
@@ -170,10 +170,10 @@ async function submit() {
   try {
     if (isEdit.value) {
       await api.post(`/employees/${route.params.id}`, payload);
-      userId = Number(route.params.id);
+      userId = String(route.params.id);
     } else {
       const { data } = await api.post('/employees', payload);
-      userId = data.id;
+      userId = String(data.id);
     }
     await reconcileFeatureGrants(userId, selectedTenant);
     router.push({ name: 'employees.list' });
@@ -213,8 +213,8 @@ onMounted(async () => {
 });
 
 async function reconcileFeatureGrants(
-  userId: number,
-  selectedTenant: string | number,
+  userId: string,
+  selectedTenant: string,
 ) {
   for (const feature of availableFeatures.value) {
     const selected = featureGrants.value[feature] || [];

--- a/frontend/src/views/employees/EmployeesList.vue
+++ b/frontend/src/views/employees/EmployeesList.vue
@@ -53,7 +53,7 @@ import { useI18n } from 'vue-i18n';
 import { setTokens } from '@/services/authStorage';
 
 interface EmployeeRow {
-  id: number;
+  id: string;
   name: string;
   email: string;
   roles: string;
@@ -61,8 +61,8 @@ interface EmployeeRow {
   phone?: string | null;
   status?: string | null;
   last_login_at?: string | null;
-  tenant?: { id: number; name: string } | null;
-  tenant_id?: number | null;
+  tenant?: { id: string; name: string } | null;
+  tenant_id?: string | null;
   avatar?: string | null;
 }
 
@@ -74,11 +74,11 @@ const { t } = useI18n();
 
 const all = ref<EmployeeRow[]>([]);
 const loading = ref(true);
-const tenantFilter = ref<string | number | ''>('');
+const tenantFilter = ref<string>('');
 
 const tenantOptions = computed(() => [
   { value: '', label: t('allTenants') },
-  ...tenantStore.tenants.map((ten: any) => ({ value: ten.id, label: ten.name })),
+  ...tenantStore.tenants.map((ten: any) => ({ value: String(ten.id), label: ten.name })),
 ]);
 
 function formatRoles(roles: any[]) {
@@ -98,11 +98,11 @@ async function load() {
   const { data } = await api.get('/employees', { params });
   const employees = extractData(data);
   const tenantMap = tenantStore.tenants.reduce(
-    (acc: Record<number, any>, t: any) => ({ ...acc, [t.id]: t }),
+    (acc: Record<string, any>, t: any) => ({ ...acc, [String(t.id)]: t }),
     {},
   );
   all.value = employees.map((e: any) => ({
-    id: e.id,
+    id: String(e.public_id ?? e.id),
     name: e.name,
     email: e.email,
     roles: formatRoles(e.roles || []),
@@ -110,8 +110,8 @@ async function load() {
     phone: e.phone,
     status: e.status,
     last_login_at: e.last_login_at,
-    tenant: tenantMap[e.tenant_id] || null,
-    tenant_id: e.tenant_id,
+    tenant: tenantMap[String(e.tenant_id)] || null,
+    tenant_id: e.tenant_id != null ? String(e.tenant_id) : null,
     avatar: e.avatar,
   }));
   loading.value = false;
@@ -134,11 +134,11 @@ watch(
   },
 );
 
-function edit(id: number) {
+function edit(id: string) {
   router.push({ name: 'employees.edit', params: { id } });
 }
 
-async function remove(id: number) {
+async function remove(id: string) {
   if (auth.isSuperAdmin && !tenantFilter.value) {
     notify.error('Please select a tenant first');
     return;
@@ -163,7 +163,7 @@ async function remove(id: number) {
   }
 }
 
-async function removeMany(ids: number[]) {
+async function removeMany(ids: string[]) {
   if (auth.isSuperAdmin && !tenantFilter.value) {
     notify.error('Please select a tenant first');
     return;
@@ -191,7 +191,7 @@ async function removeMany(ids: number[]) {
   }
 }
 
-async function impersonate(id: number) {
+async function impersonate(id: string) {
   if (!can('employees.manage')) return;
   if (auth.isSuperAdmin && !tenantFilter.value) {
     notify.error('Please select a tenant first');
@@ -212,7 +212,7 @@ async function impersonate(id: number) {
   }
 }
 
-async function resendInvite(id: number) {
+async function resendInvite(id: string) {
   if (!can('employees.manage')) return;
   if (auth.isSuperAdmin && !tenantFilter.value) {
     notify.error('Please select a tenant first');
@@ -229,7 +229,7 @@ async function resendInvite(id: number) {
   }
 }
 
-async function resetEmail(id: number) {
+async function resetEmail(id: string) {
   if (!can('employees.manage')) return;
   if (auth.isSuperAdmin && !tenantFilter.value) {
     notify.error('Please select a tenant first');
@@ -271,7 +271,7 @@ async function resetEmail(id: number) {
   }
 }
 
-async function sendPasswordReset(id: number) {
+async function sendPasswordReset(id: string) {
   if (!can('employees.manage')) return;
   if (auth.isSuperAdmin && !tenantFilter.value) {
     notify.error('Please select a tenant first');

--- a/frontend/src/views/roles/RolesList.vue
+++ b/frontend/src/views/roles/RolesList.vue
@@ -78,12 +78,12 @@ const tenantStore = useTenantStore();
 
 const all = ref<RoleRow[]>([]);
 const loading = ref(true);
-const tenantFilter = ref<string | number | ''>('');
-const assignRoleId = ref<number | null>(null);
+const tenantFilter = ref<string>('');
+const assignRoleId = ref<string | null>(null);
 
 const tenantOptions = computed(() => [
   { value: '', label: t('allTenants') },
-  ...tenantStore.tenants.map((ten: any) => ({ value: ten.id, label: ten.name })),
+  ...tenantStore.tenants.map((ten: any) => ({ value: String(ten.id), label: ten.name })),
 ]);
 
 async function load() {
@@ -96,7 +96,7 @@ async function load() {
       ? 'tenant'
       : 'all'
     : 'tenant';
-  const tenantId: string | number | undefined = auth.isSuperAdmin
+  const tenantId: string | undefined = auth.isSuperAdmin
     ? isFilteringByTenant
       ? tenantFilter.value
       : undefined
@@ -105,17 +105,17 @@ async function load() {
   await rolesStore.fetch({ scope, tenant_id: tenantId });
   await tenantStore.loadTenants({ per_page: 100 });
   const tenantMap = tenantStore.tenants.reduce(
-    (acc: Record<number, any>, t) => ({ ...acc, [t.id]: t }),
+    (acc: Record<string, any>, t) => ({ ...acc, [String(t.id)]: t }),
     {},
   );
   all.value = rolesStore.roles.map((r: any) => ({
-    id: r.id,
+    id: String(r.public_id ?? r.id),
     name: r.name,
     description: r.description,
     level: r.level,
     abilities: r.abilities || [],
-    tenant: r.tenant || tenantMap[r.tenant_id] || null,
-    tenant_id: r.tenant_id,
+    tenant: r.tenant || tenantMap[String(r.tenant_id)] || null,
+    tenant_id: r.tenant_id != null ? String(r.tenant_id) : null,
     created_at: r.created_at,
     updated_at: r.updated_at,
     users_count: r.users_count,
@@ -140,11 +140,11 @@ watch(
   },
 );
 
-function edit(id: number) {
+function edit(id: string) {
   router.push({ name: 'roles.edit', params: { id } });
 }
 
-async function remove(id: number) {
+async function remove(id: string) {
   const res = await Swal.fire({
     title: 'Delete role?',
     icon: 'warning',
@@ -156,16 +156,16 @@ async function remove(id: number) {
   }
 }
 
-function openAssign(id: number) {
+function openAssign(id: string) {
   assignRoleId.value = id;
 }
 
-async function copy(id: number) {
-  let tenantId: string | number | undefined;
+async function copy(id: string) {
+  let tenantId: string | undefined;
   if (auth.isSuperAdmin) {
     await tenantStore.loadTenants();
     const inputOptions = tenantStore.tenants.reduce(
-      (acc: any, t: any) => ({ ...acc, [t.id]: t.name }),
+      (acc: any, t: any) => ({ ...acc, [String(t.id)]: t.name }),
       {},
     );
     const res = await Swal.fire({
@@ -181,7 +181,7 @@ async function copy(id: number) {
   reload();
 }
 
-async function removeMany(ids: number[]) {
+async function removeMany(ids: string[]) {
   const res = await Swal.fire({
     title: 'Delete selected roles?',
     icon: 'warning',
@@ -193,12 +193,12 @@ async function removeMany(ids: number[]) {
   }
 }
 
-async function copyMany(ids: number[]) {
-  let tenantId: string | number | undefined;
+async function copyMany(ids: string[]) {
+  let tenantId: string | undefined;
   if (auth.isSuperAdmin) {
     await tenantStore.loadTenants();
     const inputOptions = tenantStore.tenants.reduce(
-      (acc: any, t: any) => ({ ...acc, [t.id]: t.name }),
+      (acc: any, t: any) => ({ ...acc, [String(t.id)]: t.name }),
       {},
     );
     const res = await Swal.fire({

--- a/frontend/src/views/statuses/StatusForm.vue
+++ b/frontend/src/views/statuses/StatusForm.vue
@@ -155,7 +155,7 @@ const onSubmit = handleSubmit(async () => {
     position: position.value,
   };
   if (auth.isSuperAdmin) {
-    payload.tenant_id = tenantId.value === '' ? null : Number(tenantId.value);
+    payload.tenant_id = tenantId.value === '' ? null : tenantId.value;
   }
   try {
     if (isEdit.value) {

--- a/frontend/src/views/tasks/AttachmentPanel.vue
+++ b/frontend/src/views/tasks/AttachmentPanel.vue
@@ -23,7 +23,7 @@ import api from '@/services/api';
 import { uploadFile } from '@/services/uploader';
 import Card from '@/components/ui/Card/index.vue';
 
-const props = defineProps<{ taskId: number }>();
+const props = defineProps<{ taskId: string }>();
 const attachments = ref<any[]>([]);
 
 async function load() {

--- a/frontend/src/views/tasks/ReportsView.vue
+++ b/frontend/src/views/tasks/ReportsView.vue
@@ -70,7 +70,7 @@ interface Point {
 }
 
 const types = ref<any[]>([]);
-const typeId = ref<number | null>(null);
+const typeId = ref<string | null>(null);
 const range = ref('7');
 const throughput = ref<Point[]>([]);
 const cycle = ref<Point[]>([]);
@@ -85,10 +85,15 @@ onMounted(async () => {
   const { data } = await api.get('/task-types');
   types.value = data.data || data;
   const savedType = localStorage.getItem(TYPE_KEY);
-  if (savedType && types.value.find((t: any) => t.id === Number(savedType))) {
-    typeId.value = Number(savedType);
+  if (
+    savedType &&
+    types.value.find(
+      (t: any) => String(t.public_id ?? t.id) === savedType,
+    )
+  ) {
+    typeId.value = savedType;
   } else if (types.value.length) {
-    typeId.value = types.value[0].id;
+    typeId.value = String(types.value[0].public_id ?? types.value[0].id);
   }
   await fetchData();
 });

--- a/frontend/src/views/tasks/TaskCard.vue
+++ b/frontend/src/views/tasks/TaskCard.vue
@@ -248,7 +248,7 @@ const statusOptions = computed(() => {
 const canMoveLeft = computed(() => {
   const from = props.task.status_slug;
   const colIndex = props.columns.findIndex((c) =>
-    c.tasks.some((t) => t.id === props.task.id),
+    c.tasks.some((t) => cardTaskKey(t) === taskId.value),
   );
   const targetIndex = colIndex - 1;
   if (targetIndex < 0) return false;
@@ -260,7 +260,7 @@ const canMoveLeft = computed(() => {
 const canMoveRight = computed(() => {
   const from = props.task.status_slug;
   const colIndex = props.columns.findIndex((c) =>
-    c.tasks.some((t) => t.id === props.task.id),
+    c.tasks.some((t) => cardTaskKey(t) === taskId.value),
   );
   const targetIndex = colIndex + 1;
   if (targetIndex >= props.columns.length) return false;
@@ -306,9 +306,14 @@ function formatDate(d: string) {
   return new Date(d).toLocaleDateString();
 }
 
+const taskId = computed(() => String(props.task.public_id ?? props.task.id ?? ''));
+const cardTaskKey = (task: any) => String(task?.public_id ?? task?.id ?? '');
+
 async function assignMe() {
+  const id = taskId.value;
+  if (!id) return;
   try {
-    await api.patch(`/tasks/${props.task.id}/assign`, {
+    await api.patch(`/tasks/${id}/assign`, {
       assigned_user_id: auth.user.id,
     });
     emit('assigned', {
@@ -329,7 +334,7 @@ function changeStatus(slug: string) {
 function move(dir: number) {
   if (!canMoveTasks.value) return;
   const colIndex = props.columns.findIndex((c) =>
-    c.tasks.some((t) => t.id === props.task.id),
+    c.tasks.some((t) => cardTaskKey(t) === taskId.value),
   );
   const targetIndex = colIndex + dir;
   if (targetIndex < 0 || targetIndex >= props.columns.length) return;
@@ -344,7 +349,9 @@ function move(dir: number) {
 }
 
 function editTask() {
-  router.push({ name: 'tasks.edit', params: { id: props.task.id } });
+  const id = taskId.value;
+  if (!id) return;
+  router.push({ name: 'tasks.edit', params: { id } });
 }
 
 function menuClass(active: boolean) {

--- a/frontend/src/views/tasks/TaskDetails.vue
+++ b/frontend/src/views/tasks/TaskDetails.vue
@@ -179,9 +179,13 @@ async function load() {
   const { data } = await api.get(`/tasks/${route.params.id}`, {
     params: { include: 'client' },
   });
-  task.value = data;
+  const taskData = data.data ?? data;
+  task.value = { ...taskData, id: String(taskData.public_id ?? taskData.id) };
   const res = await statusesStore.fetch('all');
-  statuses.value = res.data;
+  const list = res.data ?? res;
+  statuses.value = Array.isArray(list)
+    ? list.map((s: any) => ({ ...s, id: String(s.public_id ?? s.id) }))
+    : [];
 }
 
 onMounted(load);
@@ -193,11 +197,11 @@ function onCommentAdded(c: any) {
 const currentStatusId = computed(() => {
   const current = task.value?.status;
   const found = statuses.value.find((s: any) => s.name === current);
-  return found?.id;
+  return found ? String(found.id) : null;
 });
 
-function onStatusChanged(id: number) {
-  const found = statuses.value.find((s: any) => s.id === id);
+function onStatusChanged(id: string) {
+  const found = statuses.value.find((s: any) => String(s.id) === id);
   if (found && task.value) {
     task.value.status = found.name;
   }

--- a/frontend/src/views/tenants/TenantDetails.vue
+++ b/frontend/src/views/tenants/TenantDetails.vue
@@ -11,7 +11,7 @@
         {{ t('tenants.table.loading') }}
       </div>
       <div v-else-if="tenant" class="grid gap-2">
-        <div><strong>{{ t('tenants.details.id') }}:</strong> {{ tenant.id }}</div>
+        <div><strong>{{ t('tenants.details.id') }}:</strong> {{ tenant.public_id || tenant.id }}</div>
         <div><strong>{{ t('tenants.details.name') }}:</strong> {{ tenant.name }}</div>
         <div><strong>{{ t('tenants.details.phone') }}:</strong> {{ tenant.phone || '—' }}</div>
         <div><strong>{{ t('tenants.details.address') }}:</strong> {{ tenant.address || '—' }}</div>
@@ -20,7 +20,7 @@
             v-if="canEditTenant"
             btnClass="btn-primary btn-sm"
             :text="t('actions.edit')"
-            :to="{ name: 'tenants.edit', params: { id: tenant.id } }"
+            :to="tenantEditParams(tenant)"
           />
           <Button
             btnClass="btn-secondary btn-sm"
@@ -45,7 +45,7 @@
         {{ t('tenants.table.loading') }}
       </div>
       <div v-else-if="tenant" class="grid gap-2">
-        <div><strong>{{ t('tenants.details.id') }}:</strong> {{ tenant.id }}</div>
+        <div><strong>{{ t('tenants.details.id') }}:</strong> {{ tenant.public_id || tenant.id }}</div>
         <div><strong>{{ t('tenants.details.name') }}:</strong> {{ tenant.name }}</div>
         <div><strong>{{ t('tenants.details.phone') }}:</strong> {{ tenant.phone || '—' }}</div>
         <div><strong>{{ t('tenants.details.address') }}:</strong> {{ tenant.address || '—' }}</div>
@@ -54,7 +54,7 @@
             v-if="canEditTenant"
             btnClass="btn-primary btn-sm"
             :text="t('actions.edit')"
-            :to="{ name: 'tenants.edit', params: { id: tenant.id } }"
+            :to="tenantEditParams(tenant)"
           />
           <Button
             btnClass="btn-secondary btn-sm"
@@ -166,5 +166,10 @@ function handleClose() {
   } else {
     router.push({ name: 'tenants.list' });
   }
+}
+
+function tenantEditParams(target: Record<string, any> | null) {
+  const id = target ? String(target.public_id ?? target.id ?? '') : '';
+  return { name: 'tenants.edit', params: { id } };
 }
 </script>


### PR DESCRIPTION
## Summary
- treat entity identifiers as strings/public IDs throughout task, type, role, team, and tenant flows
- update tables, selectors, and payload builders to avoid numeric coercion and preserve hashed IDs
- ensure feature grant helpers and router links pass through string IDs for navigation and API calls

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cec0974ffc8323a0aad653c7664618