### PR TITLE
Ensure string IDs persist through task and client flows

### DIFF
--- a/frontend/src/components/Board/BoardFilters.vue
+++ b/frontend/src/components/Board/BoardFilters.vue
@@ -226,12 +226,17 @@ const local = ref<Filters>(createEmptyFilters());
 const normalizeFilters = (value?: Partial<Filters> | null): Filters => {
   const source = value ?? {};
   return {
-    assigneeId: source.assigneeId ?? null,
+    assigneeId:
+      source.assigneeId === null || source.assigneeId === undefined || source.assigneeId === ''
+        ? null
+        : String(source.assigneeId),
     priority: source.priority ?? null,
     sla: source.sla ?? null,
     q: source.q ?? null,
     hasPhotos: source.hasPhotos ?? null,
-    typeIds: Array.isArray(source.typeIds) ? [...source.typeIds] : [],
+    typeIds: Array.isArray(source.typeIds)
+      ? source.typeIds.map((id) => String(id))
+      : [],
     mine: !!source.mine,
     dueToday: !!source.dueToday,
     breachedOnly: !!source.breachedOnly,

--- a/frontend/src/components/fields/ReviewerPicker.vue
+++ b/frontend/src/components/fields/ReviewerPicker.vue
@@ -20,7 +20,7 @@ import { useAuthStore } from '@/stores/auth';
 
 interface ReviewerValue {
   kind: 'team' | 'employee';
-  id: number;
+  id: string;
 }
 
 const props = defineProps<{
@@ -49,14 +49,15 @@ onMounted(async () => {
   if (props.modelValue) {
     tab.value = props.modelValue.kind === 'team' ? 'teams' : 'employees';
     const list = lookups.assignees[tab.value];
-    selected.value = list.find((a: any) => a.id === props.modelValue?.id) || null;
+    selected.value =
+      list.find((a: any) => String(a.id) === String(props.modelValue?.id)) || null;
   }
 });
 
 watch(
   selected,
   (val) => {
-    if (val) emit('update:modelValue', { kind: val.kind, id: val.id });
+    if (val) emit('update:modelValue', { kind: val.kind, id: String(val.id) });
     else emit('update:modelValue', null);
   },
   { deep: true },
@@ -71,7 +72,8 @@ watch(
     }
     tab.value = val.kind === 'team' ? 'teams' : 'employees';
     const list = lookups.assignees[tab.value];
-    selected.value = list.find((a: any) => a.id === val.id) || null;
+    selected.value =
+      list.find((a: any) => String(a.id) === String(val.id)) || null;
   },
   { deep: true },
 );

--- a/frontend/src/services/listPrefs.ts
+++ b/frontend/src/services/listPrefs.ts
@@ -3,7 +3,7 @@ export type ListPrefs = {
   filters: {
     status: string;
     type: string;
-    assignee: { id: number } | null;
+    assignee: { id: string } | null;
     priority: string;
     dueStart: string;
     dueEnd: string;

--- a/frontend/src/stores/lookups.ts
+++ b/frontend/src/stores/lookups.ts
@@ -14,6 +14,25 @@ export const useLookupsStore = defineStore('lookups', {
     },
   }),
   actions: {
+    normalizeAssignee(record: any) {
+      if (!record || typeof record !== 'object') {
+        return record;
+      }
+      const normalized: any = { ...record };
+      if (normalized.id !== undefined && normalized.id !== null) {
+        normalized.id = String(normalized.id);
+      }
+      if (normalized.team_id !== undefined && normalized.team_id !== null) {
+        normalized.team_id = String(normalized.team_id);
+      }
+      if (normalized.user_id !== undefined && normalized.user_id !== null) {
+        normalized.user_id = String(normalized.user_id);
+      }
+      if (normalized.employee_id !== undefined && normalized.employee_id !== null) {
+        normalized.employee_id = String(normalized.employee_id);
+      }
+      return normalized;
+    },
     async fetchAssignees(
       type: 'all' | 'teams' | 'employees' = 'all',
       force = false,
@@ -35,19 +54,22 @@ export const useLookupsStore = defineStore('lookups', {
 
       const params = withListParams({ type, ...extraParams });
       const { data } = await api.get('/lookups/assignees', { params });
+      const normalized = Array.isArray(data)
+        ? data.map((record: any) => this.normalizeAssignee(record))
+        : [];
 
       if (type === 'all') {
-        this.assignees.teams = data.filter((a: any) => a.kind === 'team');
-        this.assignees.employees = data.filter((a: any) => a.kind === 'employee');
+        this.assignees.teams = normalized.filter((a: any) => a.kind === 'team');
+        this.assignees.employees = normalized.filter((a: any) => a.kind === 'employee');
         this.assigneeFetchedAt.teams = now;
         this.assigneeFetchedAt.employees = now;
       } else {
         // @ts-ignore
-        this.assignees[type] = data;
+        this.assignees[type] = normalized;
         this.assigneeFetchedAt[type] = now;
       }
 
-      return data;
+      return normalized;
     },
   },
 });

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -8,26 +8,48 @@ export const useTasksStore = defineStore('tasks', {
   }),
   actions: {
     normalize(payload: any) {
+      const data: any = {
+        ...payload,
+      };
+
+      if (data.id !== undefined && data.id !== null) {
+        data.id = String(data.id);
+      }
+      if (data.public_id !== undefined && data.public_id !== null) {
+        data.public_id = String(data.public_id);
+      }
+
       if (payload.assignee) {
-        payload.assignee = {
-          id: payload.assignee.id,
-          name: payload.assignee.name,
-        };
+        const assigneeId = payload.assignee.public_id ?? payload.assignee.id;
+        if (assigneeId !== undefined && assigneeId !== null) {
+          data.assignee = {
+            id: String(assigneeId),
+            name: payload.assignee.name,
+          };
+        }
       }
       if (payload.client) {
-        payload.client = {
-          id: payload.client.id,
-          name: payload.client.name,
-        };
+        const clientId = payload.client.public_id ?? payload.client.id;
+        if (clientId !== undefined && clientId !== null) {
+          data.client = {
+            id: String(clientId),
+            name: payload.client.name,
+          };
+        }
       }
-      return payload;
+      return data;
     },
     toPayload(payload: any) {
       const data = { ...payload };
       if (payload.assignee) {
-        data.assignee = {
-          id: payload.assignee.id,
-        };
+        const assigneeId = payload.assignee.public_id ?? payload.assignee.id;
+        if (assigneeId !== undefined && assigneeId !== null) {
+          data.assignee = {
+            id: String(assigneeId),
+          };
+        } else {
+          delete data.assignee;
+        }
       }
       return data;
     },

--- a/frontend/src/views/tasks/TaskCard.vue
+++ b/frontend/src/views/tasks/TaskCard.vue
@@ -182,12 +182,12 @@ import { MenuItem } from '@headlessui/vue';
 import { computeAllowedTransitions } from './allowedTransitions';
 
 interface Task {
-  id: number;
+  id: string;
   title: string;
   description?: string | null;
   due_at?: string | null;
-  assignee?: { id: number; name: string } | null;
-  client?: { id: number; name?: string | null } | null;
+  assignee?: { id: string; name: string } | null;
+  client?: { id: string; name?: string | null } | null;
   priority?: string | null;
   sla_chip?: 'ok' | 'dueSoon' | 'breached' | null;
   status_slug: string;
@@ -314,11 +314,11 @@ async function assignMe() {
   if (!id) return;
   try {
     await api.patch(`/tasks/${id}/assign`, {
-      assigned_user_id: auth.user.id,
+      assigned_user_id: String(auth.user.id),
     });
     emit('assigned', {
       ...props.task,
-      assignee: { id: auth.user.id, name: auth.user.name },
+      assignee: { id: String(auth.user.id), name: auth.user.name },
     });
   } catch {
     notify.error(t('tasks.messages.error'));

--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -202,7 +202,7 @@ const showFilters = ref(false);
 const statusFilter = ref('');
 const typeFilter = ref('');
 const clientFilter = ref('');
-const assigneeFilter = ref<{ id: number } | null>(null);
+const assigneeFilter = ref<{ id: string } | null>(null);
 const priorityFilter = ref('');
 const dueStart = ref('');
 const dueEnd = ref('');
@@ -330,7 +330,9 @@ onMounted(async () => {
   if (prefs.value.filters) {
     statusFilter.value = prefs.value.filters.status || '';
     typeFilter.value = prefs.value.filters.type || '';
-    assigneeFilter.value = prefs.value.filters.assignee || null;
+    assigneeFilter.value = prefs.value.filters.assignee
+      ? { id: String(prefs.value.filters.assignee.id) }
+      : null;
     priorityFilter.value = prefs.value.filters.priority || '';
     dueStart.value = prefs.value.filters.dueStart || '';
     dueEnd.value = prefs.value.filters.dueEnd || '';
@@ -350,7 +352,9 @@ function saveView() {
     filters: {
       status: statusFilter.value,
       type: typeFilter.value,
-      assignee: assigneeFilter.value,
+      assignee: assigneeFilter.value
+        ? { id: String(assigneeFilter.value.id) }
+        : null,
       priority: priorityFilter.value,
       dueStart: dueStart.value,
       dueEnd: dueEnd.value,
@@ -415,8 +419,9 @@ async function fetchTasks({ page, perPage, sort, search }: any) {
     );
   }
   if (assigneeFilter.value) {
+    const targetId = assigneeFilter.value.id;
     rows = rows.filter(
-      (r) => r.assignee && r.assignee.id === assigneeFilter.value.id,
+      (r) => String(r.assignee?.id ?? '') === targetId,
     );
   }
   if (priorityFilter.value) {
@@ -434,7 +439,10 @@ async function fetchTasks({ page, perPage, sort, search }: any) {
     rows = rows.filter((r) => r.photos && r.photos.length);
   }
   if (mine.value && auth.user) {
-    rows = rows.filter((r) => r.assignee && r.assignee.id === auth.user.id);
+    const currentUserId = String(auth.user.id ?? '');
+    rows = rows.filter(
+      (r) => String(r.assignee?.id ?? '') === currentUserId,
+    );
   }
   if (search) {
     const q = String(search).toLowerCase();

--- a/frontend/tests/unit/stores/clients.spec.ts
+++ b/frontend/tests/unit/stores/clients.spec.ts
@@ -4,6 +4,19 @@ import { setActivePinia, createPinia } from 'pinia';
 
 const useAuthStoreMock = vi.fn();
 const useTenantStoreMock = vi.fn();
+const clientsApiMock = {
+  list: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+  restore: vi.fn(),
+  archive: vi.fn(),
+  unarchive: vi.fn(),
+  bulkArchive: vi.fn(),
+  bulkDelete: vi.fn(),
+  toggleStatus: vi.fn(),
+};
 
 vi.mock('@/stores/auth', () => ({
   useAuthStore: useAuthStoreMock,
@@ -14,20 +27,30 @@ vi.mock('@/stores/tenant', () => ({
   useTenantStore: useTenantStoreMock,
 }));
 
-describe('clients store tenant filter behaviour', () => {
-  let authState: { isSuperAdmin: boolean };
+vi.mock('@/services/api/clients', () => ({
+  __esModule: true,
+  default: clientsApiMock,
+}));
 
+let authState: { isSuperAdmin: boolean };
+
+beforeEach(() => {
+  vi.resetModules();
+  setActivePinia(createPinia());
+  authState = { isSuperAdmin: false };
+  useAuthStoreMock.mockReset();
+  useTenantStoreMock.mockReset();
+  Object.values(clientsApiMock).forEach((mock) => mock.mockReset());
+  useAuthStoreMock.mockImplementation(() => authState);
+  useTenantStoreMock.mockReturnValue({
+    currentTenantId: null,
+    tenants: [],
+  });
+});
+
+describe('clients store tenant filter behaviour', () => {
   beforeEach(() => {
-    vi.resetModules();
-    setActivePinia(createPinia());
-    authState = { isSuperAdmin: false };
-    useAuthStoreMock.mockReset();
-    useTenantStoreMock.mockReset();
-    useAuthStoreMock.mockImplementation(() => authState);
-    useTenantStoreMock.mockReturnValue({
-      currentTenantId: null,
-      tenants: [],
-    });
+    clientsApiMock.list.mockResolvedValue({ data: { data: [], meta: {} } });
   });
 
   it('ignores tenant filter overrides for non super admins', async () => {
@@ -48,5 +71,53 @@ describe('clients store tenant filter behaviour', () => {
     store.setTenantFilter('456');
 
     expect(store.filters.tenantId).toBe('456');
+  });
+});
+
+describe('clients store id normalization', () => {
+  it('normalizes ids on create responses', async () => {
+    const { useClientsStore } = await import('@/stores/clients');
+    const store = useClientsStore();
+    clientsApiMock.create.mockResolvedValue({
+      data: { id: 101, tenant_id: 202, name: 'Client', status: 'active' },
+    });
+
+    const created = await store.create({ name: 'Client' });
+
+    expect(clientsApiMock.create).toHaveBeenCalledWith({ name: 'Client' });
+    expect(created.id).toBe('101');
+    expect(created.tenant_id).toBe('202');
+    expect(store.clients[0].id).toBe('101');
+  });
+
+  it('normalizes ids on update and merges into state', async () => {
+    const { useClientsStore } = await import('@/stores/clients');
+    const store = useClientsStore();
+    store.clients = [{ id: '300', name: 'Existing', tenant_id: 'tenant-1' } as any];
+    clientsApiMock.update.mockResolvedValue({
+      data: { id: 300, tenant_id: 404, name: 'Updated', status: 'active' },
+    });
+
+    const updated = await store.update('300', { name: 'Updated' });
+
+    expect(clientsApiMock.update).toHaveBeenCalledWith('300', { name: 'Updated' });
+    expect(updated.id).toBe('300');
+    expect(updated.tenant_id).toBe('404');
+    expect(store.clients[0].id).toBe('300');
+    expect(store.clients[0].name).toBe('Updated');
+  });
+
+  it('normalizes ids returned from bulk archive', async () => {
+    const { useClientsStore } = await import('@/stores/clients');
+    const store = useClientsStore();
+    clientsApiMock.bulkArchive.mockResolvedValue({
+      data: { data: [{ id: 555, name: 'Archived', status: 'inactive' }] },
+    });
+
+    const archived = await store.archiveMany([555, '666']);
+
+    expect(clientsApiMock.bulkArchive).toHaveBeenCalledWith(['555', '666']);
+    expect(archived[0].id).toBe('555');
+    expect(store.clients.some((client) => client.id === '555')).toBe(true);
   });
 });

--- a/frontend/tests/unit/stores/tasks.spec.ts
+++ b/frontend/tests/unit/stores/tasks.spec.ts
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const postMock = vi.fn();
+const patchMock = vi.fn();
+const getMock = vi.fn();
+
+vi.mock('@/services/api', () => ({
+  __esModule: true,
+  default: {
+    get: getMock,
+    post: postMock,
+    patch: patchMock,
+  },
+}));
+
+describe('tasks store id normalization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setActivePinia(createPinia());
+    postMock.mockReset();
+    patchMock.mockReset();
+    getMock.mockReset();
+  });
+
+  it('normalizes ids and nested relationships to strings', async () => {
+    const { useTasksStore } = await import('@/stores/tasks');
+    const store = useTasksStore();
+    const normalized = store.normalize({
+      id: 42,
+      public_id: 'tsk_hash',
+      assignee: { id: 9, public_id: 'user_hash', name: 'Assignee' },
+      client: { id: 7, public_id: 'client_hash', name: 'Client' },
+    });
+
+    expect(normalized.id).toBe('42');
+    expect(normalized.public_id).toBe('tsk_hash');
+    expect(normalized.assignee).toEqual({ id: 'user_hash', name: 'Assignee' });
+    expect(normalized.client).toEqual({ id: 'client_hash', name: 'Client' });
+  });
+
+  it('builds payloads with string ids', async () => {
+    const { useTasksStore } = await import('@/stores/tasks');
+    const store = useTasksStore();
+
+    const hashed = store.toPayload({ assignee: { id: 'user_hash' } });
+    const numeric = store.toPayload({ assignee: { id: 15 } as any });
+
+    expect(hashed.assignee?.id).toBe('user_hash');
+    expect(numeric.assignee?.id).toBe('15');
+  });
+
+  it('creates tasks with normalized ids', async () => {
+    const { useTasksStore } = await import('@/stores/tasks');
+    const store = useTasksStore();
+    postMock.mockResolvedValue({
+      data: {
+        id: 1001,
+        assignee: { id: 22, name: 'Assigned' },
+        client: { id: 'client_77', name: 'Client' },
+      },
+    });
+
+    const payload = { title: 'Test', assignee: { id: 'user_hash' } };
+    const created = await store.create(payload);
+
+    expect(postMock).toHaveBeenCalledWith('/tasks', {
+      title: 'Test',
+      assignee: { id: 'user_hash' },
+    });
+    expect(created.id).toBe('1001');
+    expect(created.assignee?.id).toBe('22');
+    expect(store.tasks[0].client?.id).toBe('client_77');
+  });
+
+  it('updates tasks while preserving string ids', async () => {
+    const { useTasksStore } = await import('@/stores/tasks');
+    const store = useTasksStore();
+    store.tasks = [
+      store.normalize({
+        id: 2002,
+        assignee: { id: 11, name: 'Old' },
+        client: { id: 33, name: 'Client' },
+      }),
+    ];
+    patchMock.mockResolvedValue({
+      data: {
+        id: 2002,
+        assignee: { id: 'user_next', name: 'Next' },
+        client: { id: 77, name: 'Client' },
+      },
+    });
+
+    const updated = await store.update(2002, { title: 'Updated', assignee: { id: 'user_next' } });
+
+    expect(patchMock).toHaveBeenCalledWith('/tasks/2002', {
+      title: 'Updated',
+      assignee: { id: 'user_next' },
+    });
+    expect(updated.id).toBe('2002');
+    expect(updated.assignee?.id).toBe('user_next');
+    expect(store.tasks[0].assignee?.id).toBe('user_next');
+    expect(store.tasks[0].client?.id).toBe('77');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize task payload builders and in-memory caches so IDs remain in string form
- update client, team, lookup, and board logic to preserve hashed identifiers in filters and bulk actions
- add unit coverage for task and client stores to guard the new ID handling

## Testing
- pnpm exec vitest run tests/unit/stores/tasks.spec.ts tests/unit/stores/clients.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cec7b0a10c832393c7c39b70171746