### PR TITLE
Update frontend tests to use hashed public identifiers

### DIFF
--- a/frontend/tests/e2e/permissions-matrix.spec.ts
+++ b/frontend/tests/e2e/permissions-matrix.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const selectedTenantId = fakeTenantId('permissions-selected');
 
 // Placeholder: ensure permissions matrix renders switches per role.
 test('permissions matrix displays role switches (placeholder)', async () => {
@@ -12,7 +15,7 @@ test('permissions matrix hidden when tenant not selected', async () => {
 });
 
 test('permissions matrix visible once tenant selected', async () => {
-  const tenantId = 1;
+  const tenantId = selectedTenantId;
   const showMatrix = tenantId !== '';
   expect(showMatrix).toBe(true);
 });

--- a/frontend/tests/e2e/roles-abilities.spec.ts
+++ b/frontend/tests/e2e/roles-abilities.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const rolesTenantEditId = fakeTenantId('roles-tenant-edit');
 
 // No running server in the environment; this test documents the expected flow.
 test.skip('shows abilities only after selecting a tenant', async ({ page }) => {
@@ -17,7 +20,7 @@ test.skip('deselecting a feature hides its abilities immediately', async ({ page
   await page.getByRole('option').first().click();
   await page.getByLabel('Abilities').click();
   await expect(page.getByRole('option', { name: 'tasks.view' })).toBeVisible();
-  await page.goto('/users/tenants/1/edit');
+  await page.goto(`/users/tenants/${rolesTenantEditId}/edit`);
   await page.getByLabel('Features').click();
   await page.getByRole('option', { name: /Tasks/ }).click();
   await page.goto('/roles');

--- a/frontend/tests/e2e/status-flow-editor.spec.ts
+++ b/frontend/tests/e2e/status-flow-editor.spec.ts
@@ -1,10 +1,14 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const firstTenantId = fakeTenantId('status-alpha');
+const secondTenantId = fakeTenantId('status-beta');
 
 test('selecting a tenant loads statuses and leaves transitions empty', async ({ page }) => {
   await page.route(/\/task-statuses\?.*/, (route) => {
     const url = new URL(route.request().url());
     const tenantId = url.searchParams.get('tenant_id');
-    const data = tenantId === '2'
+    const data = tenantId === secondTenantId
       ? [{ slug: 'custom' }]
       : [{ slug: 'open' }, { slug: 'closed' }];
     route.fulfill({ json: { data } });
@@ -13,8 +17,8 @@ test('selecting a tenant loads statuses and leaves transitions empty', async ({ 
   await page.setContent(`
     <select id="tenant">
       <option value="">Select tenant</option>
-      <option value="1">Tenant 1</option>
-      <option value="2">Tenant 2</option>
+      <option value="${firstTenantId}">Tenant 1</option>
+      <option value="${secondTenantId}">Tenant 2</option>
     </select>
     <ul id="statuses"></ul>
     <ul id="transitions"></ul>
@@ -32,11 +36,11 @@ test('selecting a tenant loads statuses and leaves transitions empty', async ({ 
     </script>
   `);
 
-  await page.selectOption('#tenant', '1');
+  await page.selectOption('#tenant', firstTenantId);
   await expect(page.locator('#statuses li')).toHaveCount(2);
   await expect(page.locator('#transitions li')).toHaveCount(0);
 
-  await page.selectOption('#tenant', '2');
+  await page.selectOption('#tenant', secondTenantId);
   await expect(page.locator('#statuses li')).toHaveCount(1);
   await expect(page.locator('#transitions li')).toHaveCount(0);
 

--- a/frontend/tests/e2e/task-type-create-ui.spec.ts
+++ b/frontend/tests/e2e/task-type-create-ui.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { fakeTaskId } from '../utils/publicIds';
+
+const createdTaskTypeId = fakeTaskId('type-create');
 
 test.describe('task type create UI', () => {
   test('can add field then access preview and inspector', async ({ page }) => {
@@ -110,10 +113,10 @@ test.describe('task type create UI', () => {
       await route.fulfill({
         status: 201,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: 7 }),
+        body: JSON.stringify({ id: '${createdTaskTypeId}' }),
       });
     });
-    await page.route('**/api/task-types/7/automations', async (route) => {
+    await page.route(`**/api/task-types/${createdTaskTypeId}/automations`, async (route) => {
       const data = JSON.parse(route.request().postData() || '{}');
       expect(data.enabled).toBe(false);
       await route.fulfill({ status: 201, body: '{}' });
@@ -139,6 +142,6 @@ test.describe('task type create UI', () => {
     `);
     await page.getByRole('button', { name: 'Save Automation' }).click();
     await page.getByRole('button', { name: 'Save Type' }).click();
-    await page.waitForRequest('**/api/task-types/7/automations');
+    await page.waitForRequest(`**/api/task-types/${createdTaskTypeId}/automations`);
   });
 });

--- a/frontend/tests/e2e/tasks-list.spec.ts
+++ b/frontend/tests/e2e/tasks-list.spec.ts
@@ -1,10 +1,13 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const tasksListTenantId = fakeTenantId('tasks-list');
 
 test('tasks list filters persist after reload', async ({ page }) => {
   await page.goto('/tasks');
   await page.evaluate(() => {
     localStorage.setItem(
-      'asbuild:tasksList:v1:1',
+      'asbuild:tasksList:v1:' + tasksListTenantId,
       JSON.stringify({
         filters: { status: 'completed', type: '', assignee: null, priority: '', dueStart: '', dueEnd: '', hasPhotos: false, mine: false },
         sort: null,
@@ -13,6 +16,10 @@ test('tasks list filters persist after reload', async ({ page }) => {
     );
   });
   await page.reload();
-  const prefs = await page.evaluate(() => JSON.parse(localStorage.getItem('asbuild:tasksList:v1:1') || '{}'));
+  const prefs = await page.evaluate(
+    (tenantId) =>
+      JSON.parse(localStorage.getItem('asbuild:tasksList:v1:' + tenantId) || '{}'),
+    tasksListTenantId,
+  );
   expect(prefs.filters.status).toBe('completed');
 });

--- a/frontend/tests/e2e/tenant-management.spec.ts
+++ b/frontend/tests/e2e/tenant-management.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const tenantAlphaId = fakeTenantId('alpha');
+const tenantBetaId = fakeTenantId('beta');
+const tenantGammaId = fakeTenantId('gamma');
 
 const tenantManagementMarkup = `
   <div id="tenant-app">
@@ -25,9 +30,9 @@ const tenantManagementMarkup = `
   <script>
     (() => {
       const tenants = [
-        { id: 1, name: 'Alpha Manufacturing' },
-        { id: 2, name: 'Beta Logistics' },
-        { id: 3, name: 'Gamma Research' }
+        { id: '${tenantAlphaId}', name: 'Alpha Manufacturing' },
+        { id: '${tenantBetaId}', name: 'Beta Logistics' },
+        { id: '${tenantGammaId}', name: 'Gamma Research' }
       ];
       const abilities = new Set(['tenants.view']);
       const tbody = document.getElementById('tenant-rows');
@@ -117,7 +122,7 @@ const tenantManagementMarkup = `
               const input = row.querySelector('input[type="checkbox"]');
               if (input instanceof HTMLInputElement && input.checked) {
                 input.checked = false;
-                selected.delete(Number(input.value));
+                selected.delete(input.value);
               }
             }
           });
@@ -204,7 +209,9 @@ test.describe('tenant management behaviours', () => {
     await expect(bulkDelete).toBeEnabled();
     await bulkDelete.click();
 
-    await expect(page.locator('#toast')).toHaveText('Deleted Tenant #1, Tenant #2');
+    await expect(page.locator('#toast')).toHaveText(
+      `Deleted Tenant #${tenantAlphaId}, Tenant #${tenantBetaId}`,
+    );
     await expect(page.locator('tbody tr')).toHaveCount(1);
     await expect(bulkDelete).toBeDisabled();
   });

--- a/frontend/tests/e2e/tenant-role-switch.spec.ts
+++ b/frontend/tests/e2e/tenant-role-switch.spec.ts
@@ -1,12 +1,16 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const tenantAId = fakeTenantId('builder-tenant-a');
+const tenantBId = fakeTenantId('builder-tenant-b');
 
 // Simulates the task-type builder flow when switching tenants.
 test('full happy path for builder with tenant switching', async ({ page }) => {
   await page.setContent(`
     <select id="tenant">
       <option value="">Select tenant</option>
-      <option value="a">Tenant A</option>
-      <option value="b">Tenant B</option>
+      <option value="${tenantAId}">Tenant A</option>
+      <option value="${tenantBId}">Tenant B</option>
     </select>
     <div id="gating" role="status">Select tenant to configure permissions</div>
     <div id="roles" hidden></div>
@@ -17,7 +21,7 @@ test('full happy path for builder with tenant switching', async ({ page }) => {
     <div id="transitions"></div>
     <button id="publish">Publish</button>
     <script>
-      const tenants = { a: ['roleA1', 'roleA2'], b: ['roleB1'] };
+      const tenants = { ${JSON.stringify(tenantAId)}: ['roleA1', 'roleA2'], ${JSON.stringify(tenantBId)}: ['roleB1'] };
       window.permissions = {};
       window.fieldRoles = { view: [], edit: [] };
       const statuses = [];
@@ -111,7 +115,7 @@ test('full happy path for builder with tenant switching', async ({ page }) => {
   await expect(page.locator('#roles')).toBeHidden();
 
   // pick tenant A
-  await page.selectOption('#tenant', 'a');
+  await page.selectOption('#tenant', tenantAId);
   await expect(page.locator('#gating')).toBeHidden();
   await expect(page.locator('#roles label')).toHaveCount(2);
   await expect(page.locator('#inspector')).toBeVisible();
@@ -123,7 +127,7 @@ test('full happy path for builder with tenant switching', async ({ page }) => {
   await page.click('#save');
 
   // change tenant to B and ensure roles are sanitized
-  await page.selectOption('#tenant', 'b');
+  await page.selectOption('#tenant', tenantBId);
   await expect(page.locator('#roles label')).toHaveCount(1);
   await expect(page.locator('#roles input')).not.toBeChecked();
   expect(await page.evaluate(() => window.fieldRoles.view.length)).toBe(0);

--- a/frontend/tests/e2e/tenants.spec.ts
+++ b/frontend/tests/e2e/tenants.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const editTenantId = fakeTenantId('tenants-edit');
+const impersonationTenantId = fakeTenantId('tenants-impersonate');
 
 // No running server in the environment; this test documents the expected flow.
 test.skip('tenant deletion requires confirmation', async ({ page }) => {
@@ -19,7 +23,7 @@ test.skip('super admin can create a tenant', async ({ page }) => {
 });
 
 test.skip('super admin can edit a tenant', async ({ page }) => {
-  await page.goto('/users/tenants/1/edit');
+  await page.goto(`/users/tenants/${editTenantId}/edit`);
   await page.getByLabel('Name').fill('Updated Tenant');
   await page.getByRole('button', { name: 'Save' }).click();
 });
@@ -48,6 +52,6 @@ test.skip('impersonation is forbidden without tenants.manage', async ({ page }) 
   await expect(page.getByRole('menuitem', { name: 'Impersonate' })).toHaveCount(0);
 
   // Even if the API is called manually, the backend should respond with 403.
-  const response = await page.request.post('/api/tenants/1/impersonate');
+  const response = await page.request.post(`/api/tenants/${impersonationTenantId}/impersonate`);
   expect(response.status()).toBe(403);
 });

--- a/frontend/tests/e2e/tenants.users.spec.ts
+++ b/frontend/tests/e2e/tenants.users.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { fakeTenantId } from '../utils/publicIds';
+
+const targetTenantId = fakeTenantId('users-target');
 
 // No running server in the environment; these tests document the expected
 // authorization behaviour for tenant management under the Users menu.
@@ -10,7 +13,7 @@ test.skip('tenants actions are gated by abilities', async ({ page }) => {
   page.route('**/api/tenants', route =>
     route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
   );
-  page.route('**/api/tenants/1/impersonate', route =>
+  page.route(`**/api/tenants/${targetTenantId}/impersonate`, route =>
     route.fulfill({ status: 403, body: '{"message":"forbidden"}' })
   );
 
@@ -22,21 +25,24 @@ test.skip('tenants actions are gated by abilities', async ({ page }) => {
   ]);
   await Promise.all([
     page.waitForResponse(resp =>
-      resp.url().includes('/api/tenants/1/impersonate') && resp.status() === 403
+      resp.url().includes(`/api/tenants/${targetTenantId}/impersonate`) && resp.status() === 403
     ),
-    page.evaluate(() => fetch('/api/tenants/1/impersonate', { method: 'POST' })),
+    page.evaluate(
+      (id) => fetch(`/api/tenants/${id}/impersonate`, { method: 'POST' }),
+      targetTenantId,
+    ),
   ]);
 });
 
 test.skip('tenants impersonation action succeeds', async ({ page }) => {
   await page.goto('/users/tenants');
 
-  page.route('**/api/tenants/1/impersonate', route =>
+  page.route(`**/api/tenants/${targetTenantId}/impersonate`, route =>
     route.fulfill({ status: 200, body: '{"access_token":"t"}' })
   );
   await Promise.all([
     page.waitForResponse(resp =>
-      resp.url().includes('/api/tenants/1/impersonate') && resp.status() === 200
+      resp.url().includes(`/api/tenants/${targetTenantId}/impersonate`) && resp.status() === 200
     ),
     page.getByRole('button', { name: 'Impersonate' }).first().click(),
   ]);

--- a/frontend/tests/unit/CanvasSection.addTab.test.ts
+++ b/frontend/tests/unit/CanvasSection.addTab.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { createApp } from 'vue';
 import { createI18n } from 'vue-i18n';
 import CanvasSection from '@/components/types/CanvasSection.vue';
+import { fakePublicId } from '../utils/publicIds';
 
 vi.mock('vuedraggable', () => ({
   default: { name: 'draggable', template: '<div><slot /></div>' },
@@ -39,7 +40,7 @@ describe('CanvasSection addTab', () => {
     const section = {
       label: { en: 'Section', el: 'Section' },
       cols: 1,
-      fields: [{ id: 1, key: 'a', label: { en: 'A', el: 'A' } }],
+      fields: [{ id: fakePublicId('canvas-field'), key: 'a', label: { en: 'A', el: 'A' } }],
       tabs: [],
     } as any;
     const i18n = createI18n({ locale: 'en', messages: { en: {}, el: {} } });

--- a/frontend/tests/unit/TenantsTable.interactions.test.ts
+++ b/frontend/tests/unit/TenantsTable.interactions.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { h, defineComponent, nextTick } from 'vue';
 import TenantsTable from '@/components/tenants/TenantsTable.vue';
+import { fakeTenantId } from '../utils/publicIds';
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
@@ -54,6 +55,9 @@ vi.mock('vue-good-table-next', () => {
   return { VueGoodTable: component };
 });
 
+const tenantAlphaId = fakeTenantId('table-alpha');
+const tenantBetaId = fakeTenantId('table-beta');
+
 describe('TenantsTable remote interactions', () => {
   function mountComponent() {
     const InputGroupStub = defineComponent({
@@ -104,14 +108,14 @@ describe('TenantsTable remote interactions', () => {
       props: {
         rows: [
           {
-            id: 1,
+            id: tenantAlphaId,
             name: 'Alpha',
             feature_count: 3,
             archived_at: null,
             deleted_at: null,
           },
           {
-            id: 2,
+            id: tenantBetaId,
             name: 'Beta',
             archived_at: '2024-01-01',
             deleted_at: null,
@@ -177,14 +181,14 @@ describe('TenantsTable remote interactions', () => {
     expect(wrapper.emitted('update:sort')?.[0]).toEqual([{ sort: 'name', direction: 'desc' }]);
 
     table.vm.$emit('selected-rows-change', {
-      selectedRows: [{ id: 1 }, { id: 2 }],
+      selectedRows: [{ id: tenantAlphaId }, { id: tenantBetaId }],
     });
     await nextTick();
-    expect(wrapper.emitted('selection-change')?.[0]).toEqual([[1, 2]]);
+    expect(wrapper.emitted('selection-change')?.[0]).toEqual([[tenantAlphaId, tenantBetaId]]);
     expect(slotSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        selectedIds: [1, 2],
-        archivableIds: [1],
+        selectedIds: [tenantAlphaId, tenantBetaId],
+        archivableIds: [tenantAlphaId],
       }),
     );
 

--- a/frontend/tests/unit/TypeMetaBar.tenant-client.test.ts
+++ b/frontend/tests/unit/TypeMetaBar.tenant-client.test.ts
@@ -5,6 +5,7 @@ import { createI18n } from 'vue-i18n';
 import { createPinia, setActivePinia } from 'pinia';
 import TypeMetaBar from '@/components/types/TypeMetaBar.vue';
 import { useTenantStore } from '@/stores/tenant';
+import { fakeClientId, fakeTenantId } from '../utils/publicIds';
 
 vi.mock('@/components/ui/Card/index.vue', () => ({
   default: { name: 'Card', template: '<div><slot /></div>' },
@@ -71,6 +72,10 @@ describe('TypeMetaBar tenant and client selectors', () => {
     setActivePinia(createPinia());
   });
 
+  const defaultTenantId = fakeTenantId('meta-default');
+  const defaultClientId = fakeClientId('meta-default');
+  const lockedTenantId = fakeTenantId('meta-locked');
+
   function mountComponent(props: Record<string, unknown> = {}) {
     const i18n = createI18n({
       legacy: false,
@@ -92,9 +97,9 @@ describe('TypeMetaBar tenant and client selectors', () => {
 
     const app = createApp(TypeMetaBar, {
       name: 'Example',
-      tenantId: 1,
+      tenantId: defaultTenantId,
       clientId: '',
-      clientOptions: [{ value: 10, label: 'Client 1' }],
+      clientOptions: [{ value: defaultClientId, label: 'Client 1' }],
       requireSubtasksComplete: false,
       showTenantSelect: true,
       ...props,
@@ -107,7 +112,7 @@ describe('TypeMetaBar tenant and client selectors', () => {
 
   it('renders tenant and client dropdowns for super admins', () => {
     const tenantStore = useTenantStore();
-    tenantStore.tenants = [{ id: 1, name: 'Alpha Corp' }] as any;
+    tenantStore.tenants = [{ id: defaultTenantId, name: 'Alpha Corp' }] as any;
     const { el } = mountComponent();
 
     expect(el.querySelector('[data-testid="tenant-select"]')).not.toBeNull();
@@ -119,7 +124,7 @@ describe('TypeMetaBar tenant and client selectors', () => {
     tenantStore.tenants = [];
     const { el } = mountComponent({
       showTenantSelect: false,
-      tenantId: 42,
+      tenantId: lockedTenantId,
       tenantName: 'Beta LLC',
     });
 

--- a/frontend/tests/unit/employees.actions.test.ts
+++ b/frontend/tests/unit/employees.actions.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
+import { fakeUserId } from '../utils/publicIds';
 
 const { notifySuccess, notifyError, swalFire, swalShowValidationMessage } = vi.hoisted(() => ({
   notifySuccess: vi.fn(),
@@ -39,6 +40,9 @@ function createSetup() {
   return (EmployeesList as any).setup?.(undefined, ctx) as any;
 }
 
+const firstEmployeeId = fakeUserId('employees-first');
+const secondEmployeeId = fakeUserId('employees-second');
+
 describe('EmployeesList user actions', () => {
   let getSpy: ReturnType<typeof vi.spyOn>;
   let postSpy: ReturnType<typeof vi.spyOn>;
@@ -73,13 +77,13 @@ describe('EmployeesList user actions', () => {
     swalFire.mockResolvedValue({ isConfirmed: true, value: 'new@example.com' });
 
     const setup = createSetup();
-    setup.all.value = [{ id: 7, email: 'old@example.com' }];
+    setup.all.value = [{ id: firstEmployeeId, email: 'old@example.com' }];
 
-    await setup.resetEmail(7);
+    await setup.resetEmail(firstEmployeeId);
 
     expect(swalFire).toHaveBeenCalled();
     expect(postSpy).toHaveBeenCalledWith(
-      '/employees/7/email-reset',
+      `/employees/${firstEmployeeId}/email-reset`,
       { email: 'new@example.com' },
       { params: {} },
     );
@@ -89,10 +93,10 @@ describe('EmployeesList user actions', () => {
   it('sends password reset request', async () => {
     const setup = createSetup();
 
-    await setup.sendPasswordReset(5);
+    await setup.sendPasswordReset(secondEmployeeId);
 
     expect(postSpy).toHaveBeenCalledWith(
-      '/employees/5/password-reset',
+      `/employees/${secondEmployeeId}/password-reset`,
       {},
       { params: {} },
     );

--- a/frontend/tests/unit/stores/roles.spec.ts
+++ b/frontend/tests/unit/stores/roles.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useRolesStore } from '@/stores/roles';
+import { fakeRoleId, fakeTenantId, fakeUserId } from '../../utils/publicIds';
 
 vi.mock('@/services/api', () => ({
   default: {
@@ -19,13 +20,15 @@ describe('roles store', () => {
   });
 
   it('fetches roles with params', async () => {
-    (api.get as any).mockResolvedValue({ data: { data: [{ id: 1, description: 'desc' }] } });
+    const tenantScopeId = fakeTenantId('roles-scope');
+    const scopedRoleId = fakeRoleId('roles-desc');
+    (api.get as any).mockResolvedValue({ data: { data: [{ id: scopedRoleId, description: 'desc' }] } });
     const store = useRolesStore();
-    await store.fetch({ scope: 'tenant', tenant_id: '1' });
+    await store.fetch({ scope: 'tenant', tenant_id: tenantScopeId });
     expect(api.get).toHaveBeenCalledWith('/roles', {
       params: {
         scope: 'tenant',
-        tenant_id: '1',
+        tenant_id: tenantScopeId,
         page: 1,
         per_page: 20,
         search: '',
@@ -33,13 +36,13 @@ describe('roles store', () => {
         dir: 'asc',
       },
     });
-    expect(store.roles).toEqual([{ id: 1, description: 'desc' }]);
+    expect(store.roles).toEqual([{ id: scopedRoleId, description: 'desc' }]);
   });
 
   it('omits tenant_id when scope is all', async () => {
     (api.get as any).mockResolvedValue({ data: { data: [] } });
     const store = useRolesStore();
-    await store.fetch({ scope: 'all', tenant_id: '1' });
+    await store.fetch({ scope: 'all', tenant_id: fakeTenantId('roles-all') });
     expect(api.get).toHaveBeenCalledWith('/roles', {
       params: {
         scope: 'all',
@@ -55,15 +58,22 @@ describe('roles store', () => {
   it('assigns role to user', async () => {
     (api.post as any).mockResolvedValue({});
     const store = useRolesStore();
-    await store.assignUser(2, { user_id: 3, tenant_id: '4' });
-    expect(api.post).toHaveBeenCalledWith('/roles/2/assign', {
-      user_id: 3,
-      tenant_id: '4',
+    const assignmentRoleId = fakeRoleId('assign');
+    const assignmentUserId = fakeUserId('assigned');
+    const assignmentTenantId = fakeTenantId('assigned');
+    await store.assignUser(assignmentRoleId, {
+      user_id: assignmentUserId,
+      tenant_id: assignmentTenantId,
+    });
+    expect(api.post).toHaveBeenCalledWith(`/roles/${assignmentRoleId}/assign`, {
+      user_id: assignmentUserId,
+      tenant_id: assignmentTenantId,
     });
   });
 
   it('creates role with description', async () => {
-    (api.post as any).mockResolvedValue({ data: { id: 1 } });
+    const createdRoleId = fakeRoleId('created');
+    (api.post as any).mockResolvedValue({ data: { id: createdRoleId } });
     const store = useRolesStore();
     await store.create({ name: 'Tester', description: 'desc' } as any);
     expect(api.post).toHaveBeenCalledWith('/roles', {

--- a/frontend/tests/utils/publicIds.ts
+++ b/frontend/tests/utils/publicIds.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+
+const CROCKFORD_BASE32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const ULID_LENGTH = 26;
+const ULID_PREFIX = '01';
+
+/**
+ * Generates a deterministic ULID-like identifier for tests based on a label.
+ * The prefix ensures the string resembles Laravel's ULID output while
+ * subsequent characters are derived from the label hash for stability.
+ */
+export function fakePublicId(label: string): string {
+  const hash = createHash('sha256').update(label).digest();
+  let identifier = ULID_PREFIX;
+  let index = 0;
+
+  while (identifier.length < ULID_LENGTH) {
+    const byte = hash[index % hash.length];
+    identifier += CROCKFORD_BASE32[byte % CROCKFORD_BASE32.length];
+    index += 1;
+  }
+
+  return identifier;
+}
+
+export function fakeTenantId(label: string): string {
+  return fakePublicId(`tenant:${label}`);
+}
+
+export function fakeUserId(label: string): string {
+  return fakePublicId(`user:${label}`);
+}
+
+export function fakeRoleId(label: string): string {
+  return fakePublicId(`role:${label}`);
+}
+
+export function fakeTaskId(label: string): string {
+  return fakePublicId(`task:${label}`);
+}
+
+export function fakeClientId(label: string): string {
+  return fakePublicId(`client:${label}`);
+}
+
+export function fakeStatusId(label: string): string {
+  return fakePublicId(`status:${label}`);
+}


### PR DESCRIPTION
## Summary
- add a fakePublicId helper that returns deterministic ULID-style strings for tests
- update auth, tenant switching, and other unit/e2e fixtures to supply hashed identifiers instead of numeric IDs
- adjust local storage and API expectations in the frontend test suite to work with hashed IDs end-to-end

## Testing
- pnpm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cecbf5328c8323b573466be9f9f8a4