### PR TITLE
Handle soft deleted tenant in seeder

### DIFF
--- a/backend/database/seeders/InitialSystemSeeder.php
+++ b/backend/database/seeders/InitialSystemSeeder.php
@@ -15,7 +15,7 @@ class InitialSystemSeeder extends Seeder
     {
         $features = config('features', []);
 
-        $tenant = Tenant::query()->updateOrCreate(
+        $tenant = Tenant::query()->withTrashed()->updateOrCreate(
             ['id' => 1],
             [
                 'name' => 'Super Admin Tenant',
@@ -24,9 +24,12 @@ class InitialSystemSeeder extends Seeder
                 'phone' => '123-456-7890',
                 'address' => '123 Main St',
                 'archived_at' => null,
-                'deleted_at' => null,
             ]
         );
+
+        if ($tenant->trashed()) {
+            $tenant->restore();
+        }
 
         $selectedAbilities = $tenant->selectedFeatureAbilities();
         $tenant->forceFill(['feature_abilities' => $selectedAbilities])->save();


### PR DESCRIPTION
## Summary
- allow `InitialSystemSeeder` to update soft-deleted tenants by querying with trashed records and restoring them when needed

## Testing
- php artisan test *(fails: numerous existing test failures and missing `.env` configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ceccd899fc83238046ec7ffa565bd9