### PR TITLE
Handle tenant modal close routing

### DIFF
--- a/frontend/src/views/tenants/TenantsIndex.vue
+++ b/frontend/src/views/tenants/TenantsIndex.vue
@@ -2,12 +2,27 @@
   <div class="relative">
     <TenantsList />
     <RouterView #default="{ Component, route }">
-      <component :is="Component" v-if="Component && route?.meta?.modal" />
+      <component
+        :is="Component"
+        v-if="Component && route?.meta?.modal"
+        @close="handleModalClose(route)"
+      />
     </RouterView>
   </div>
 </template>
 
 <script setup lang="ts">
-import { RouterView } from 'vue-router';
+import { RouterView, useRouter, type RouteLocationNormalizedLoaded } from 'vue-router';
 import TenantsList from './TenantsList.vue';
+
+const router = useRouter();
+
+function handleModalClose(route: RouteLocationNormalizedLoaded) {
+  const fallbackRouteName = 'tenants.list';
+  const targetRouteName = typeof route.meta?.groupParent === 'string'
+    ? route.meta.groupParent
+    : fallbackRouteName;
+
+  router.push({ name: targetRouteName });
+}
 </script>


### PR DESCRIPTION
## Summary
- forward tenant modal close events from TenantsIndex to the list route so router-driven modals dismiss themselves

## Testing
- pnpm --dir frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68ced01f4be48323af9fee613841e248