### PR TITLE
Validate numeric identifiers before returning from resolver

### DIFF
--- a/backend/app/Support/PublicIdResolver.php
+++ b/backend/app/Support/PublicIdResolver.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -24,32 +25,70 @@ class PublicIdResolver
         }
 
         if (is_int($identifier)) {
-            return $identifier;
+            return $this->resolveNumericIdentifier($modelClass, $identifier);
         }
 
         if (is_string($identifier) && ctype_digit($identifier)) {
-            return (int) $identifier;
+            return $this->resolveNumericIdentifier($modelClass, (int) $identifier);
         }
 
         if (! is_string($identifier)) {
             return null;
         }
 
+        return $this->resolvePublicIdentifier($modelClass, $identifier);
+    }
+
+    /**
+     * Resolve a numeric identifier by looking up the model in the database.
+     */
+    protected function resolveNumericIdentifier(string $modelClass, int $identifier): ?int
+    {
+        $cacheKey = $modelClass.'|#|'.$identifier;
+
+        if (array_key_exists($cacheKey, $this->cache)) {
+            return $this->cache[$cacheKey];
+        }
+
+        $query = $this->newQueryForModel($modelClass);
+
+        return $this->cache[$cacheKey] = $query
+            ->whereKey($identifier)
+            ->value('id');
+    }
+
+    /**
+     * Resolve a hashed public identifier by looking up the model in the database.
+     */
+    protected function resolvePublicIdentifier(string $modelClass, string $identifier): ?int
+    {
         $cacheKey = $modelClass.'|'.$identifier;
 
         if (array_key_exists($cacheKey, $this->cache)) {
             return $this->cache[$cacheKey];
         }
 
-        /** @var class-string<Model> $modelClass */
+        $query = $this->newQueryForModel($modelClass);
+
+        return $this->cache[$cacheKey] = $query
+            ->where('public_id', $identifier)
+            ->value('id');
+    }
+
+    /**
+     * Build a new query instance for the given model.
+     *
+     * @param class-string<Model> $modelClass
+     * @return Builder<Model>
+     */
+    protected function newQueryForModel(string $modelClass): Builder
+    {
         $query = $modelClass::query();
 
         if (in_array(SoftDeletes::class, class_uses_recursive($modelClass), true)) {
             $query->withTrashed();
         }
 
-        return $this->cache[$cacheKey] = $query
-            ->where('public_id', $identifier)
-            ->value('id');
+        return $query;
     }
 }


### PR DESCRIPTION
## Summary
- resolve numeric identifiers by querying the model before returning so invalid IDs now yield null
- reuse shared query-building logic that honours soft deletes for both numeric and public identifiers

## Testing
- composer test *(fails: requires seeded database/test fixtures and .env configuration; numerous feature tests expect full app setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ced67b812c8323be2e05e95e3f5855