### PR TITLE
Fix SuperAdmin bypass tenant assignment fixture

### DIFF
--- a/backend/tests/Feature/SuperAdminBypassTest.php
+++ b/backend/tests/Feature/SuperAdminBypassTest.php
@@ -35,7 +35,7 @@ class SuperAdminBypassTest extends TestCase
             'name' => 'Root',
             'email' => 'root@example.com',
             'password' => Hash::make('secret'),
-            'tenant_id' => $this->publicIdFor($tenant),
+            'tenant_id' => $tenant->id,
             'phone' => '123456',
             'address' => 'Street 1',
         ]);
@@ -47,7 +47,7 @@ class SuperAdminBypassTest extends TestCase
             'name' => 'Types Manager',
             'slug' => 'task_types.manager',
             'abilities' => ['task_types.manage'],
-            'tenant_id' => $tenant->id,
+            'tenant_id' => $this->publicIdFor($tenant),
             'level' => 1,
         ];
 


### PR DESCRIPTION
## Summary
- ensure the SuperAdmin bypass fixture persists the numeric tenant id to maintain relationships
- send the tenant public identifier through the HTTP payload to exercise hashed id handling

## Testing
- php artisan test --filter=SuperAdminBypassTest

------
https://chatgpt.com/codex/tasks/task_e_68cedaee1e2c83239d9433a46b37d92f