### PR TITLE
Use string identifiers for task report type options

### DIFF
--- a/frontend/src/views/tasks/ReportsView.vue
+++ b/frontend/src/views/tasks/ReportsView.vue
@@ -8,7 +8,13 @@
           class="w-40"
           aria-label="Type"
         >
-          <option v-for="t in types" :key="t.id" :value="t.id">{{ t.name }}</option>
+          <option
+            v-for="t in types"
+            :key="String(t.public_id ?? t.id)"
+            :value="String(t.public_id ?? t.id)"
+          >
+            {{ t.name }}
+          </option>
         </Select>
         <Select
           v-model="range"


### PR DESCRIPTION
## Summary
- update the task reports type dropdown so each option uses the string form of the public or numeric id for both key and value

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceddbe42e88323a90bfd08427cf354