### PR TITLE
Normalize assignee filter ID comparison

### DIFF
--- a/frontend/src/views/tasks/TasksList.vue
+++ b/frontend/src/views/tasks/TasksList.vue
@@ -419,9 +419,10 @@ async function fetchTasks({ page, perPage, sort, search }: any) {
     );
   }
   if (assigneeFilter.value) {
-    const targetId = assigneeFilter.value.id;
+    const targetId = String(assigneeFilter.value.id);
     rows = rows.filter(
-      (r) => String(r.assignee?.id ?? '') === targetId,
+      (r) =>
+        String(r.assignee?.public_id ?? r.assignee?.id ?? '') === targetId,
     );
   }
   if (priorityFilter.value) {


### PR DESCRIPTION
## Summary
- normalize the selected assignee id to a string before filtering
- compare against the assignee's public or internal id to support hashed identifiers

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cedee4d02483238df5f70711d8c8f8